### PR TITLE
fix so results contain model parameters for the evaluate task

### DIFF
--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -364,7 +364,7 @@ def _classify_featureset(args):
         learner_result_dict_base = {'experiment_name': experiment_name,
                                     'train_set_name': train_set_name,
                                     'test_set_name': test_set_name,
-                                    'featureset': featureset,
+                                    'featureset': json.dumps(featureset),
                                     'given_learner': given_learner,
                                     'task': task,
                                     'timestamp': timestamp,
@@ -477,12 +477,18 @@ def _create_learner_result_dicts(task_results, grid_scores,
         learner_result_dict = {}
         learner_result_dict.update(learner_result_dict_base)
 
-        if num_folds == 1:
-            learner_result_dict['fold'] = ""
-        else:
+        # initialize some variables to blanks so that the
+        # set of columns is fixed.
+        learner_result_dict['result_table'] = ''
+        learner_result_dict['accuracy'] = ''
+        learner_result_dict['score'] = ''
+        learner_result_dict['fold'] = ''
+
+        if learner_result_dict_base['task'] == 'cross_validate':
             learner_result_dict['fold'] = k
-            learner_result_dict['model_params'] = model_params
-            learner_result_dict['grid_score'] = grid_score
+
+        learner_result_dict['model_params'] = json.dumps(model_params)
+        learner_result_dict['grid_score'] = grid_score
 
         if conf_matrix:
             classes = sorted(iterkeys(task_results[0][2]))

--- a/tests/test_skll.py
+++ b/tests/test_skll.py
@@ -361,6 +361,14 @@ def test_summary():
         reader = csv.DictReader(f, dialect='excel-tab')
 
         for row in reader:
+            # the learner results dictionaries should have 16 rows,
+            # and all of these except results_table
+            # should be printed (though some columns will be blank).
+            eq_(len(row), 15)
+            assert row['model_params']
+            assert row['grid_score']
+            assert row['score']
+
             if row['given_learner'] == 'LogisticRegression':
                 logistic_summary_score = float(row['score'])
             elif row['given_learner'] == 'MultinomialNB':


### PR DESCRIPTION
fix so that the results and summary files contain model parameters for the evaluate task.  also cleaned up printing of the featuresets in those files (in python 2).
