### PR TITLE
modified the scorers dictionary so that average F1 scores can be compute...

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -364,8 +364,11 @@ Tuning
             *   *accuracy*: Overall `accuracy <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html>`_
             *   *precision*: `Precision <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html>`_
             *   *recall*: `Recall <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html>`_
+            *   *f1*: The default scikit-learn `F1 score <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html>`_
+                (F1 of the positive class for binary classification, or the weighted average F1 for multiclass classification)
             *   *f1_score_micro*: Micro-averaged `F1 score <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html>`_
             *   *f1_score_macro*: Macro-averaged `F1 score <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html>`_
+            *   *f1_score_weighted*: Weighted average `F1 score <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html>`_
             *   *f1_score_least_frequent*: F1 score of the least frequent class. The
                 least frequent class may vary from fold to fold for certain data
                 distributions.

--- a/skll/__init__.py
+++ b/skll/__init__.py
@@ -27,8 +27,9 @@ __all__ = ['Learner', 'load_examples', 'kappa', 'kendall_tau', 'spearman',
 
 # Add our scorers to the sklearn dictionary here so that they will always be
 # available if you import anything from skll
-_scorers = {'f1_score_micro': make_scorer(f1_score, average='micro'),
-            'f1_score_macro': make_scorer(f1_score, average='macro'),
+_scorers = {'f1_score_micro': make_scorer(f1_score, average='micro', pos_label=None),
+            'f1_score_macro': make_scorer(f1_score, average='macro', pos_label=None),
+            'f1_score_weighted': make_scorer(f1_score, average='weighted', pos_label=None),
             'f1_score_least_frequent': make_scorer(f1_score_least_frequent),
             'pearson': make_scorer(pearson),
             'spearman': make_scorer(spearman),


### PR DESCRIPTION
...d for binary classification rather than just having f1 for the positive class, which is the default (I believe support for this was added in scikit-learn some time in 2013)
