### PR TITLE
Release 0.28.0

### DIFF
--- a/skll/version.py
+++ b/skll/version.py
@@ -7,5 +7,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :organization: ETS
 '''
 
-__version__ = '0.27.0'
+__version__ = '0.28.0'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
This release has some big behind-the-scenes changes.  First, we split the `data.py` module up into a sub-package (#147).  There is also a new `FeatureSet` class that replaces the old `namedtuple`-based  `ExamplesTuple` (#81), so `ExamplesTuple` is now deprecated and will be removed in SKLL 1.0.0.  

Speaking of which, we're having an all-day SKLL sprint on the October 17th where we hope to resolve all the remaining issues preventing the 1.0 release.

Other changes include:
-  Fixed a bunch of minor problems with loading/writing LibSVM files
-  Added file reading/writing progress indicators
-  Fixed crash with `generate_predictions` when the model was not trained with `probability` set to True (#144).
-  Deprecated `write_feature_file` function in favor of using a `FeatureSetWriter` object.
-  Deprecated `load_examples` function in favor of using a `Reader` object.
-  Temporarily added replacement version of scikit-learn `DictVectorizer` class until scikit-learn/scikit-learn#3683 version is included in a release.  This allows us to make file loading substantially more memory efficient.
