### PR TITLE
Added support for use case in which user submits single training and tes...

### DIFF
--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -296,8 +296,8 @@ def _parse_config_file(config_path):
                             '1.0.  Please use the full name, {}, '
                             'instead.').format(learner, _SHORT_NAMES[learner]))
             learners[i] = _SHORT_NAMES[learner]
-    if config.has_option("Input", "featuresets"):
-        featuresets = yaml.load(_fix_json(config.get("Input", "featuresets")))
+
+    featuresets = yaml.load(_fix_json(config.get("Input", "featuresets")))
 
     # ensure that featuresets is a list of lists
     if not isinstance(featuresets, list) or not all([isinstance(fs, list) for fs


### PR DESCRIPTION
...ting files via train_file and test_file in the configuration file.

This pull request addresses the following issue:

"Train/test requires feature files to have the same name but in different directories". #12

Let me know what you think about this solution--it's both hacky and elegant at the same time.  It's elegant in the sense that it is able to reuse all of the run_configuration() code as-is, with no modifications to the general architecture.  It's hacky in the sense that some of the pre-existing variables are being reused with new meanings for this new use case (e.g., train_path and test_path specify the full file paths of the input files instead of the directory paths).  The code passes nosetests and works for the use cases I envisioned, but new unit tests and documentation need to be added.  Please point me in the right direction for this if you'd like me to do it.
