### PR TITLE
Release 1.0.1

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -1,6 +1,6 @@
 package:
   name: skll
-  version: {{ environ['GIT_DESCRIBE_TAG'].replace('v', '') }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('v', '') }}
 
 source:
   git_url: ./

--- a/skll/version.py
+++ b/skll/version.py
@@ -7,5 +7,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :organization: ETS
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
This is a fairly minor bugfix release.  Changes include:

-  Update links in README.
-  Fix crash when trying to run experiments with integer labels (Issue #225, PR #219)
-  Update documentation about ablation to note that there will always be a run with all features (Issue #224, PR #226)
-  Update documentation about format of `cv_folds_file` (Issue #225, PR #228)
-  Remove duplicate words in documentation (PR #218)
-  Fixed `KeyError` when trying to build conda recipe.
-  Update outdated parameter grids in `run_experiment` documentation (commit 80d78e4)