### PR TITLE
Compatibility with scikit-learn v0.16.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - conda config --add channels https://conda.binstar.org/dan_blanchard
   - conda update --yes conda
 install:
-  - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy beautiful-soup six scikit-learn joblib prettytable python-coveralls pyyaml
+  - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy beautiful-soup six scikit-learn==0.16.1 joblib prettytable python-coveralls pyyaml
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes configparser logutils mock; fi
   - if [ $GRIDMAP == "true" ]; then conda install --yes drmaa gridmap; fi
   # Have to use pip for nose-cov because its entry points are not supported by conda yet

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -145,7 +145,7 @@ possible settings for each section is provided below, but to summarize:
 .. _evaluate:
 
 *   If you want to **train a model and evaluate it** on some data, specify a
-    training location, a test location, and a directory to store results, 
+    training location, a test location, and a directory to store results,
     and set :ref:`task` to ``evaluate``.
 
 .. _predict:
@@ -234,13 +234,11 @@ Regressors:
     *   **KNeighborsRegressor**: `K-Nearest Neighbors Regressor <http://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsRegressor.html#sklearn.neighbors.KNeighborsRegressor>`__
     *   **Lasso**: `Lasso Regression <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html#sklearn.linear_model.Lasso>`__
     *   **LinearRegression**: `Linear Regression <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html#sklearn.linear_model.LinearRegression>`__
+    *   **LinearSVR**: `Support Vector Regression using LibLinear <http://scikit-learn.org/stable/modules/generated/sklearn.svm.LinearSVR.html#sklearn.svm.LinearSVR>`__
     *   **RandomForestRegressor**: `Random Forest Regressor <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html#sklearn.ensemble.RandomForestRegressor>`__
     *   **Ridge**: `Ridge Regression <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html#sklearn.linear_model.Ridge>`__
     *   **SGDRegressor**: `Stochastic Gradient Descent Regressor <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDRegressor.html>`__
-    *   **SVR**: `Support Vector Regression <http://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR>`__
-        with a linear kernel. Can use other kernels by specifying a ``kernel``
-        fixed parameter in the
-        :ref:`fixed_parameters <fixed_parameters>` list.
+    *   **SVR**: `Support Vector Regression using LibSVM <http://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR>`__
 
     For all regressors you can also prepend ``Rescaled`` to the
     beginning of the full name (e.g., ``RescaledSVR``) to get a version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.15.2
+scikit-learn==0.16.1
 six
 PrettyTable
 beautifulsoup4

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,7 +1,7 @@
 configparser
 logutils
 mock
-scikit-learn>=0.14
+scikit-learn==0.16.1
 six
 PrettyTable
 beautifulsoup4

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -754,9 +754,6 @@ class Learner(object):
             raise ValueError("%s is not a valid learner type." %
                              (self._model_type,))
 
-        # Ensure that the kernel argument has right type for Python version.
-        if issubclass(self._model_type, SVR) and sys.version_info < (3, 0):
-            self.model_kwargs['kernel'] = self.model_kwargs['kernel'].encode()
         estimator = self._model_type(**self._model_kwargs)
 
         return estimator, default_param_grid

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -277,7 +277,8 @@ def check_sparse_predict(use_feature_hashing=False):
     train_fs, test_fs = make_sparse_data(
         use_feature_hashing=use_feature_hashing)
 
-    # train a linear SVM on the training data and evalute on the testing data
+    # train a logistic regression classifier on the training
+    # data and evalute on the testing data
     learner = Learner('LogisticRegression')
     learner.train(train_fs, grid_search=False)
     test_score = learner.evaluate(test_fs)[1]
@@ -309,7 +310,7 @@ def check_sparse_predict_sampler(use_feature_hashing=False):
     learner.train(train_fs, grid_search=False)
     test_score = learner.evaluate(test_fs)[1]
 
-    expected_score = 0.4 if use_feature_hashing else 0.48999999999999999
+    expected_score = 0.44 if use_feature_hashing else 0.48999999999999999
     assert_almost_equal(test_score, expected_score)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -138,7 +138,7 @@ def test_invalid_grid_obj_func():
                   'ElasticNet', 'GradientBoostingRegressor',
                   'KNeighborsRegressor', 'Lasso',
                   'LinearRegression', 'RandomForestRegressor',
-                  'Ridge', 'SVR', 'SGDRegressor']:
+                  'Ridge', 'LinearSVR', 'SVR', 'SGDRegressor']:
         for metric in ['accuracy',
                        'precision',
                        'recall',

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -240,8 +240,7 @@ def make_scaling_data(use_feature_hashing=False):
 
 
 def check_scaling_features(use_feature_hashing=False, use_scaling=False):
-    train_fs, test_fs = make_scaling_data(
-        use_feature_hashing=use_feature_hashing)
+    train_fs, test_fs = make_scaling_data(use_feature_hashing=use_feature_hashing)
 
     # create a Linear SVM with the value of scaling as specified
     feature_scaling = 'both' if use_scaling else 'none'
@@ -256,13 +255,13 @@ def check_scaling_features(use_feature_hashing=False, use_scaling=False):
 
     # these are the expected values of the f-measures, sorted
     if not use_feature_hashing:
-        expected_fmeasures = ([0.7979797979797979, 0.80198019801980192] if
+        expected_fmeasures = ([0.77319587628865982, 0.78640776699029125] if
                               not use_scaling else
-                              [0.94883720930232551, 0.94054054054054048])
+                              [0.94930875576036866, 0.93989071038251359])
     else:
-        expected_fmeasures = ([0.83962264150943389, 0.81914893617021278] if
+        expected_fmeasures = ([0.42774566473988435, 0.5638766519823788] if
                               not use_scaling else
-                              [0.88038277511961716, 0.86910994764397898])
+                              [0.87323943661971837, 0.85561497326203206])
 
     assert_almost_equal(expected_fmeasures, fmeasures)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -127,7 +127,7 @@ def check_rescaling(name):
 
 def test_rescaling():
     for regressor_name in ['ElasticNet', 'Lasso', 'LinearRegression', 'Ridge',
-                           'SVR', 'SGDRegressor']:
+                           'LinearSVR', 'SVR', 'SGDRegressor']:
         yield check_rescaling, regressor_name
 
 
@@ -190,13 +190,68 @@ def test_linear_models():
     for (regressor_name,
          use_feature_hashing,
          use_rescaling) in product(['ElasticNet', 'Lasso', 'LinearRegression',
-                                    'Ridge', 'SVR', 'SGDRegressor'],
+                                    'Ridge', 'LinearSVR', 'SGDRegressor'],
                                    [False, True],
                                    [False, True]):
 
         yield (check_linear_models, regressor_name, use_feature_hashing,
                use_rescaling)
 
+
+# the utility function to run the non-linear tests
+def check_non_linear_models(name,
+                            use_feature_hashing=False,
+                            use_rescaling=False):
+
+    # create a FeatureSet object with the data we want to use
+    if use_feature_hashing:
+        train_fs, test_fs, weightdict = make_regression_data(num_examples=5000,
+                                                             num_features=10,
+                                                             use_feature_hashing=True,
+                                                             feature_bins=5)
+    else:
+        train_fs, test_fs, weightdict = make_regression_data(num_examples=2000,
+                                                             num_features=3)
+
+    # create the learner
+    if use_rescaling:
+        name = 'Rescaled' + name
+    learner = Learner(name)
+
+    # train it with the training feature set we created
+    # make sure to set the grid objective to pearson
+    learner.train(train_fs, grid_objective='pearson')
+
+    # Note that we cannot check the feature weights here
+    # since `model_params()` is not defined for non-linear
+    # kernels.
+
+    # now generate the predictions on the test FeatureSet
+    predictions = learner.predict(test_fs)
+
+    # now make sure that the predictions are close to
+    # the actual test FeatureSet labels that we generated
+    # using make_regression_data. To do this, we just
+    # make sure that they are correlated with pearson > 0.95
+    cor, _ = pearsonr(predictions, test_fs.labels)
+    expected_cor_range = [0.7, 0.8] if use_feature_hashing else [0.9, 1.0]
+    assert_greater(cor, expected_cor_range[0])
+    assert_less(cor, expected_cor_range[1])
+
+
+# the runner function for linear regression models
+def test_non_linear_models():
+
+    for (regressor_name,
+         use_feature_hashing,
+         use_rescaling) in product(['SVR'],
+                                   [False, True],
+                                   [False, True]):
+
+        yield (check_non_linear_models,
+               regressor_name,
+               use_feature_hashing,
+               use_rescaling)
 
 # the utility function to run the tree-based regression tests
 def check_tree_models(name,


### PR DESCRIPTION
- Update `scikit-learn` to version 0.16.1 in `.travis.yml`, `requirements.txt`, and `requirements_rtd.txt`.
- Remove SVR coefficient correction now that the original bug has been fixed in scikit-learn (#111).
- Remove dependency on `BaseLibLinear` in `model_params()` since it is no longer exposed in scikit-learn (#233, #235).
- Expose `LinearSVR` from scikit-learn and so change `SVR` to *not* have a 'linear' kernel by default.
- Include `RescaledLinearSVR` among the rescaled regressors.
- Remove `SVR` from `test_linear_models()` in `test_regression.py` and create a new `test_non_linear_models()`.
- Update one of the expected values in `test_sparse_predict_sampler()` likely due to the following item in the scikit-learn 0.16 release notes: *"RBFSampler with gamma=g formerly approximated rbf_kernel with gamma=g/2.; the definition of gamma is now consistent, which may substantially change your results if you use a fixed value."*
- Update expected values in `test_scaling()` likely due to this item in the scikit-learn v0.16 release notes: *"Fix numerical stability issues in linear_model.SGDClassifier and linear_model.SGDRegressor by  clipping large gradients and ensuring that weight decay rescaling is always positive."*