### PR TITLE
Several minor bugfixes

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -145,7 +145,7 @@ possible settings for each section is provided below, but to summarize:
 .. _evaluate:
 
 *   If you want to **train a model and evaluate it** on some data, specify a
-    training location, a test location, and a directory to store results, 
+    training location, a test location, and a directory to store results,
     and set :ref:`task` to ``evaluate``.
 
 .. _predict:
@@ -212,7 +212,7 @@ below.  Custom learners can also be specified. See
 
 Classifiers:
 
-    *   **AdaBoostClassifier**: `AdaBoost Classifier <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostClassifier.html#sklearn.ensemble.AdaBoostClassifier>`__
+    *   **AdaBoostClassifier**: `AdaBoost Classifier <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostClassifier.html#sklearn.ensemble.AdaBoostClassifier>`__.  Note that the default base estimator is a ``DecisionTreeClassifier``. A different base estimator can be used by specifying a ``base_estimator`` fixed parameter in the :ref:`fixed_parameters <fixed_parameters>` list. The following additional base estimators are supported: ``MultinomialNB``, ``SGDClassifier``, and ``SVC``. Note that the last two base require setting an additional ``algorithm`` fixed parameter with the value ``'SAMME'``.
     *   **DecisionTreeClassifier**: `Decision Tree Classifier <http://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html#sklearn.tree.DecisionTreeClassifier>`__
     *   **GradientBoostingClassifier**: `Gradient Boosting Classifier <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingClassifier.html#sklearn.ensemble.GradientBoostingClassifier>`__
     *   **KNeighborsClassifier**: `K-Nearest Neighbors Classifier <http://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html#sklearn.neighbors.KNeighborsClassifier>`__
@@ -227,7 +227,7 @@ Classifiers:
 
 Regressors:
 
-    *   **AdaBoostRegressor**: `AdaBoost Regressor <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostRegressor.html#sklearn.ensemble.AdaBoostRegressor>`__
+    *   **AdaBoostRegressor**: `AdaBoost Regressor <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostRegressor.html#sklearn.ensemble.AdaBoostRegressor>`__. Note that the default base estimator is a ``DecisionTreeRegressor``. A different base estimator can be used by specifying a ``base_estimator`` fixed parameter in the :ref:`fixed_parameters <fixed_parameters>` list. The following additional base estimators are supported: ``SGDRegressor``, and ``SVR``.
     *   **DecisionTreeRegressor**: `Decision Tree Regressor <http://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html#sklearn.tree.DecisionTreeRegressor>`__
     *   **ElasticNet**: `ElasticNet Regression <http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html#sklearn.linear_model.ElasticNet>`__
     *   **GradientBoostingRegressor**: `Gradient Boosting Regressor <http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingRegressor.html#sklearn.ensemble.GradientBoostingRegressor>`__

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -309,7 +309,7 @@ def _parse_config_file(config_path):
     # produce warnings if hasher_features is set but feature_hasher
     # is missing or set to False.
     if config.has_option("Input", "hasher_features"):
-        if not config.has_option("Input", "hasher_features"):
+        if not config.has_option("Input", "feature_hasher"):
             logger.warning("Ignoring hasher_features since feature_hasher" +
                            " is missing from the config file.")
         else:

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -579,7 +579,8 @@ class Learner(object):
                        DecisionTreeClassifier, GradientBoostingClassifier,
                        GradientBoostingRegressor, DecisionTreeRegressor,
                        RandomForestRegressor, SGDClassifier, SGDRegressor,
-                       AdaBoostRegressor, AdaBoostClassifier)):
+                       AdaBoostRegressor, AdaBoostClassifier, LinearSVR,
+                       Lasso, ElasticNet)):
             self._model_kwargs['random_state'] = 123456789
 
         if sampler_kwargs:
@@ -898,10 +899,6 @@ class Learner(object):
                  not doing grid search.
         :rtype: float
         """
-        # seed the random number generator so that randomized algorithms are
-        # replicable
-        rand_seed = 123456789
-        np.random.seed(rand_seed)
         logger = logging.getLogger(__name__)
 
         # if we are asked to do grid search, check that the grid objective
@@ -962,7 +959,7 @@ class Learner(object):
                                'different results compared to scikit-learn.')
             ids, labels, features = sk_shuffle(examples.ids, examples.labels,
                                                examples.features,
-                                               random_state=rand_seed)
+                                               random_state=123456789)
             examples = FeatureSet(examples.name, ids, labels=labels,
                                   features=features,
                                   vectorizer=examples.vectorizer)
@@ -1386,8 +1383,6 @@ class Learner(object):
         """
         # seed the random number generator so that randomized algorithms are
         # replicable
-        rand_seed = 123456789
-        np.random.seed(rand_seed)
         logger = logging.getLogger(__name__)
 
         # Shuffle so that the folds are random for the inner grid search CV.
@@ -1401,7 +1396,7 @@ class Learner(object):
                                'different results compared to scikit-learn.')
             ids, labels, features = sk_shuffle(examples.ids, examples.labels,
                                                examples.features,
-                                               random_state=rand_seed)
+                                               random_state=123456789)
             examples = FeatureSet(examples.name, ids, labels=labels,
                                   features=features,
                                   vectorizer=examples.vectorizer)

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -144,12 +144,7 @@ _INT_CLASS_OBJ_FUNCS = frozenset(['unweighted_kappa',
                                   'lwk_off_by_one',
                                   'qwk_off_by_one'])
 
-_REQUIRES_DENSE = (AdaBoostClassifier, AdaBoostRegressor,
-                   DecisionTreeClassifier, DecisionTreeRegressor,
-                   GradientBoostingClassifier, GradientBoostingRegressor,
-                   KNeighborsClassifier, KNeighborsRegressor,
-                   MultinomialNB, RandomForestClassifier,
-                   RandomForestRegressor)
+_REQUIRES_DENSE = (GradientBoostingClassifier, GradientBoostingRegressor)
 
 MAX_CONCURRENT_PROCESSES = int(os.getenv('SKLL_MAX_CONCURRENT_PROCESSES', '5'))
 
@@ -604,7 +599,7 @@ class Learner(object):
             if issubclass(self._model_type,
                           (AdaBoostRegressor, AdaBoostClassifier)) and ('base_estimator' in model_kwargs):
                 base_estimator_name = model_kwargs['base_estimator']
-                base_estimator_kwargs = {} if base_estimator_name == 'MultinomialNB' else {'random_state': 123456789}
+                base_estimator_kwargs = {} if base_estimator_name in ['MultinomialNB', 'SVR'] else {'random_state': 123456789}
                 base_estimator = globals()[base_estimator_name](**base_estimator_kwargs)
                 model_kwargs['base_estimator'] = base_estimator
             self._model_kwargs.update(model_kwargs)

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -597,11 +597,15 @@ class Learner(object):
         if model_kwargs:
             # if the model is an AdaBoost classifier or regressor, then we
             # need to convert any specified `base_estimator` (a string)
-            # into an object before passing it in to the learner constructor
+            # into an object before passing it in to the learner constructor.
+            # we also need to make sure that if the base estimator is
+            # anything other than MultinomialNB, we set the random state
+            # to a fixed seed such that results are replicable
             if issubclass(self._model_type,
                           (AdaBoostRegressor, AdaBoostClassifier)) and ('base_estimator' in model_kwargs):
                 base_estimator_name = model_kwargs['base_estimator']
-                base_estimator = globals()[base_estimator_name]()
+                base_estimator_kwargs = {} if base_estimator_name == 'MultinomialNB' else {'random_state': 123456789}
+                base_estimator = globals()[base_estimator_name](**base_estimator_kwargs)
                 model_kwargs['base_estimator'] = base_estimator
             self._model_kwargs.update(model_kwargs)
 

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -588,6 +588,14 @@ class Learner(object):
             self.sampler = None
 
         if model_kwargs:
+            # if the model is an AdaBoost classifier or regressor, then we
+            # need to convert any specified `base_estimator` (a string)
+            # into an object before passing it in to the learner constructor
+            if issubclass(self._model_type,
+                          (AdaBoostRegressor, AdaBoostClassifier)) and ('base_estimator' in model_kwargs):
+                base_estimator_name = model_kwargs['base_estimator']
+                base_estimator = globals()[base_estimator_name]()
+                model_kwargs['base_estimator'] = base_estimator
             self._model_kwargs.update(model_kwargs)
 
     @classmethod

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -580,7 +580,7 @@ class Learner(object):
                        GradientBoostingRegressor, DecisionTreeRegressor,
                        RandomForestRegressor, SGDClassifier, SGDRegressor,
                        AdaBoostRegressor, AdaBoostClassifier, LinearSVR,
-                       Lasso, ElasticNet)):
+                       Lasso, ElasticNet, SVC)):
             self._model_kwargs['random_state'] = 123456789
 
         if sampler_kwargs:

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -424,5 +424,5 @@ def test_adaboost_predict():
                                                                'SVC'],
                                                                ['SAMME.R', 'SAMME.R',
                                                                 'SAMME', 'SAMME'],
-                                                               [0.45, 0.5, 0.44, 0.43]):
+                                                               [0.45, 0.5, 0.45, 0.43]):
         yield check_adaboost_predict, base_estimator_name, algorithm, expected_score

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -424,5 +424,5 @@ def test_adaboost_predict():
                                                                'SVC'],
                                                                ['SAMME.R', 'SAMME.R',
                                                                 'SAMME', 'SAMME'],
-                                                               [0.45, 0.5, 0.45, 0.43]):
+                                                               [0.45, 0.5, 0.44, 0.43]):
         yield check_adaboost_predict, base_estimator_name, algorithm, expected_score

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -274,8 +274,7 @@ def make_sparse_data(use_feature_hashing=False):
 
 
 def check_sparse_predict(use_feature_hashing=False):
-    train_fs, test_fs = make_sparse_data(
-        use_feature_hashing=use_feature_hashing)
+    train_fs, test_fs = make_sparse_data(use_feature_hashing=use_feature_hashing)
 
     # train a linear SVM on the training data and evalute on the testing data
     learner = Learner('LogisticRegression')
@@ -405,3 +404,24 @@ def test_test_file_and_test_directory():
                                                             'jsonlines'),
                                                        test_directory='foo')
     _parse_config_file(config_path)
+
+def check_adaboost_predict(base_estimator, algorithm, expected_score):
+    train_fs, test_fs = make_sparse_data()
+
+    # train an AdaBoostClassifier on the training data and evalute on the testing data
+    learner = Learner('AdaBoostClassifier', model_kwargs={'base_estimator': base_estimator,
+                                                          'algorithm': algorithm})
+    learner.train(train_fs, grid_search=False)
+    test_score = learner.evaluate(test_fs)[1]
+    assert_almost_equal(test_score, expected_score)
+
+
+def test_adaboost_predict():
+    for base_estimator_name, algorithm, expected_score in zip(['MultinomialNB',
+                                                               'DecisionTreeClassifier',
+                                                               'SGDClassifier',
+                                                               'SVC'],
+                                                               ['SAMME.R', 'SAMME.R',
+                                                                'SAMME', 'SAMME'],
+                                                               [0.45, 0.5, 0.45, 0.43]):
+        yield check_adaboost_predict, base_estimator_name, algorithm, expected_score

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -23,8 +23,6 @@ from os.path import abspath, dirname, exists, join
 import numpy as np
 from nose.tools import eq_, assert_almost_equal, raises
 from sklearn.base import RegressorMixin
-from sklearn.feature_extraction import FeatureHasher
-from sklearn.datasets.samples_generator import make_classification
 
 from skll.data import FeatureSet
 from skll.data.writers import NDJWriter
@@ -33,7 +31,7 @@ from skll.experiments import (_parse_config_file, _setup_config_parser,
 from skll.learner import Learner
 from skll.learner import _DEFAULT_PARAM_GRIDS
 
-from utils import make_classification_data, make_regression_data
+from utils import make_classification_data, make_regression_data, make_sparse_data
 
 
 _ALL_MODELS = list(_DEFAULT_PARAM_GRIDS.keys())
@@ -213,81 +211,30 @@ def test_rare_class():
         eq_(len(pred), 15)
 
 
-def make_sparse_data(use_feature_hashing=False):
-    """
-    Function to create sparse data with two features always zero
-    in the training set and a different one always zero in the
-    test set
-    """
-    # Create training data
-    X, y = make_classification(n_samples=500, n_features=3,
-                               n_informative=3, n_redundant=0,
-                               n_classes=2, random_state=1234567890)
-
-    # we need features to be non-negative since we will be
-    # using naive bayes laster
-    X = np.abs(X)
-
-    # make sure that none of the features are zero
-    X[np.where(X == 0)] += 1
-
-    # since we want to use SKLL's FeatureSet class, we need to
-    # create a list of IDs
-    ids = ['EXAMPLE_{}'.format(n) for n in range(1, 501)]
-
-    # create a list of dictionaries as the features
-    # with f1 and f5 always 0
-    feature_names = ['f{}'.format(n) for n in range(1, 6)]
-    features = []
-    for row in X:
-        row = [0] + row.tolist() + [0]
-        features.append(dict(zip(feature_names, row)))
-
-    # use a FeatureHasher if we are asked to do feature hashing
-    vectorizer = FeatureHasher(n_features=4) if use_feature_hashing else None
-    train_fs = FeatureSet('train_sparse', ids,
-                          features=features, labels=y,
-                          vectorizer=vectorizer)
-
-    # now create the test set with f4 always 0 but nothing else
-    X, y = make_classification(n_samples=100, n_features=4,
-                               n_informative=4, n_redundant=0,
-                               n_classes=2, random_state=1234567890)
-    X = np.abs(X)
-    X[np.where(X == 0)] += 1
-    ids = ['EXAMPLE_{}'.format(n) for n in range(1, 101)]
-
-    # create a list of dictionaries as the features
-    # with f4 always 0
-    feature_names = ['f{}'.format(n) for n in range(1, 6)]
-    features = []
-    for row in X:
-        row = row.tolist()
-        row = row[:3] + [0] + row[3:]
-        features.append(dict(zip(feature_names, row)))
-
-    test_fs = FeatureSet('test_sparse', ids,
-                         features=features, labels=y,
-                         vectorizer=vectorizer)
-
-    return train_fs, test_fs
-
-
-def check_sparse_predict(use_feature_hashing=False):
+def check_sparse_predict(learner_name, expected_score, use_feature_hashing=False):
     train_fs, test_fs = make_sparse_data(use_feature_hashing=use_feature_hashing)
 
     # train a logistic regression classifier on the training
     # data and evalute on the testing data
-    learner = Learner('LogisticRegression')
+    learner = Learner(learner_name)
     learner.train(train_fs, grid_search=False)
     test_score = learner.evaluate(test_fs)[1]
-    expected_score = 0.51 if use_feature_hashing else 0.45
     assert_almost_equal(test_score, expected_score)
 
 
 def test_sparse_predict():
-    yield check_sparse_predict, False
-    yield check_sparse_predict, True
+    for learner_name, expected_scores in zip(['LogisticRegression',
+                                              'DecisionTreeClassifier',
+                                              'RandomForestClassifier',
+                                              'AdaBoostClassifier',
+                                              'MultinomialNB',
+                                              'KNeighborsClassifier'],
+                                             [(0.45, 0.51), (0.5, 0.51),
+                                              (0.46, 0.46), (0.5, 0.5),
+                                              (0.44, 0), (0.51, 0.43)]):
+        yield check_sparse_predict, learner_name, expected_scores[0], False
+        if learner_name != 'MultinomialNB':
+            yield check_sparse_predict, learner_name, expected_scores[1], True
 
 
 def check_sparse_predict_sampler(use_feature_hashing=False):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -283,24 +283,24 @@ def check_tree_models(name,
 
     # make sure that the feature importances are as expected.
     if name.endswith('DecisionTreeRegressor'):
-        expected_feature_importances = ([0.37331461,
-                                         0.08572699,
-                                         0.2543484,
-                                         0.1841172,
-                                         0.1024928] if use_feature_hashing else
-                                        [0.08931994,
-                                         0.15545093,
-                                         0.75522913])
+        expected_feature_importances = ([0.37483895,
+                                         0.08816508,
+                                         0.25379838,
+                                         0.18337128,
+                                         0.09982631] if use_feature_hashing else
+                                        [0.08926899,
+                                         0.15585068,
+                                         0.75488033])
         expected_cor_range = [0.5, 0.6] if use_feature_hashing else [0.9, 1.0]
     else:
-        if use_feature_hashing:
-            expected_feature_importances = [0.40195655,
-                                            0.06702161,
-                                            0.25814858,
-                                            0.18183947,
-                                            0.09103379]
-        else:
-            expected_feature_importances = [0.07975691, 0.16122862, 0.75901447]
+        expected_feature_importances = ([0.40195798,
+                                         0.06702903,
+                                         0.25816559,
+                                         0.18185518,
+                                         0.09099222] if use_feature_hashing else
+                                        [0.07974267,
+                                         0.16121895,
+                                         0.75903838])
         expected_cor_range = [0.7, 0.8] if use_feature_hashing else [0.9, 1.0]
 
     feature_importances = learner.model.feature_importances_
@@ -360,11 +360,11 @@ def check_ensemble_models(name,
     # make sure that the feature importances are as expected.
     if name.endswith('AdaBoostRegressor'):
         if use_feature_hashing:
-            expected_feature_importances = [0.33260501,
-                                            0.07685393,
-                                            0.25858443,
-                                            0.19214259,
-                                            0.13981404]
+            expected_feature_importances = [0.33718443,
+                                            0.07810721,
+                                            0.25621769,
+                                            0.19489766,
+                                            0.13359301]
         else:
             expected_feature_importances = [0.10266744, 0.18681777, 0.71051479]
     else:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -77,6 +77,10 @@ def tearDown():
     if exists(config_file):
         os.unlink(config_file)
 
+    config_file = join(config_dir, 'test_int_labels_cv.cfg')
+    if exists(config_file):
+        os.unlink(config_file)
+
 
 # a utility function to check rescaling for linear models
 def check_rescaling(name):
@@ -468,3 +472,26 @@ def test_fancy_output():
         assert_almost_equal(pred_stats_from_file[stat_type],
                             pred_stats_from_api[stat_type],
                             places=4)
+
+def check_adaboost_regression(base_estimator):
+    train_fs, test_fs, _ = make_regression_data(num_examples=2000,
+                                                sd_noise=4,
+                                                num_features=3)
+
+    # train an AdaBoostClassifier on the training data and evalute on the testing data
+    learner = Learner('AdaBoostRegressor', model_kwargs={'base_estimator': base_estimator})
+    learner.train(train_fs, grid_search=False)
+
+    # now generate the predictions on the test set
+    predictions = learner.predict(test_fs)
+
+    # now make sure that the predictions are close to
+    # the actual test FeatureSet labels that we generated
+    # using make_regression_data. To do this, we just
+    # make sure that they are correlated
+    cor, _ = pearsonr(predictions, test_fs.labels)
+    assert_greater(cor, 0.95)
+
+def test_adaboost_regression():
+    for base_estimator_name in ['DecisionTreeRegressor', 'SGDRegressor', 'SVR']:
+        yield check_adaboost_regression, base_estimator_name

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -305,7 +305,7 @@ def check_tree_models(name,
 
     feature_importances = learner.model.feature_importances_
     assert_allclose(feature_importances, expected_feature_importances,
-                    rtol=1e-2)
+                    atol=1e-2, rtol=0)
 
     # now generate the predictions on the test FeatureSet
     predictions = learner.predict(test_fs)
@@ -379,7 +379,7 @@ def check_ensemble_models(name,
 
     feature_importances = learner.model.feature_importances_
     assert_allclose(feature_importances, expected_feature_importances,
-                    rtol=1e-2)
+                    atol=1e-2, rtol=0)
 
     # now generate the predictions on the test FeatureSet
     predictions = learner.predict(test_fs)


### PR DESCRIPTION
- Allow non-default base estimators for AdaBoost (#238)
  - Correctly interpret the `base_estimator` fixed parameter for AdaBoostClassifiers and AdaBoostRegressors as objects instead of strings.
  - Make sure that the base estimator for Adaboost has a fixed seed so that results are replicable.
  - Add corresponding unit tests for both classification and regression and update documentation.
- Fix `hasher_features` typo in `experiments.py` (#234).
- Remove unnecessary setting of numpy global random seeds (#220)
  - We are already passing in `random_state` seeds in `model_kwargs` for all classifiers/regressors so we don't need to set the `numpy` global random seed.
  - Include `Lasso`, `ElasticNet`, `LinearSVR`, and `SVC` when setting the above seeds in `model_kwargs`.
- Remove requirements for several learners to have dense input (#207)
  - In the new version of scikit-learn, only `GradientBoostingClassifier` and `GradientBoostingRegressor` require dense input.
  - Move `make_sparse_data()` to `utils.py`
  - Update `test_sparse_predict()` to include all sparse-friendly classifiers.
- Update expected values in certain tests to account for all of the above changes.