### PR TITLE
Feature/save cv folds

### DIFF
--- a/skll/config.py
+++ b/skll/config.py
@@ -70,6 +70,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                     'results': '',
                     'sampler': '',
                     'sampler_parameters': '[]',
+                    'save_cv_folds': 'False',
                     'shuffle': 'False',
                     'suffix': '',
                     'test_directory': '',
@@ -105,6 +106,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                                    'results': 'Output',
                                    'sampler': 'Input',
                                    'sampler_parameters': 'Input',
+                                   'save_cv_folds': 'Input',
                                    'shuffle': 'Input',
                                    'suffix': 'Input',
                                    'test_directory': 'Input',
@@ -363,6 +365,9 @@ def _parse_config_file(config_path):
             # default number of cross-validation folds
             cv_folds = 10
 
+    # whether or not to save the cv fold ids
+    save_cv_folds = config.get("Input", "save_cv_folds")
+
     # whether or not to do stratified cross validation
     random_folds = config.getboolean("Input", "random_folds")
     if random_folds:
@@ -523,10 +528,10 @@ def _parse_config_file(config_path):
             test_set_name, suffix, featuresets, do_shuffle, model_path,
             do_grid_search, grid_objective, probability, results_path,
             pos_label_str, feature_scaling, min_feature_count,
-            grid_search_jobs, grid_search_folds, cv_folds, do_stratified_folds,
-            fixed_parameter_list, param_grid_list, featureset_names, learners,
-            prediction_dir, log_path, train_path, test_path, ids_to_floats,
-            class_map, custom_learner_path)
+            grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
+            do_stratified_folds, fixed_parameter_list, param_grid_list,
+            featureset_names, learners, prediction_dir, log_path, train_path,
+            test_path, ids_to_floats, class_map, custom_learner_path)
 
 
 def _munge_featureset_name(featureset):

--- a/skll/config.py
+++ b/skll/config.py
@@ -106,7 +106,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                                    'results': 'Output',
                                    'sampler': 'Input',
                                    'sampler_parameters': 'Input',
-                                   'save_cv_folds': 'Input',
+                                   'save_cv_folds': 'Output',
                                    'shuffle': 'Input',
                                    'suffix': 'Input',
                                    'test_directory': 'Input',
@@ -366,7 +366,7 @@ def _parse_config_file(config_path):
             cv_folds = 10
 
     # whether or not to save the cv fold ids
-    save_cv_folds = config.get("Input", "save_cv_folds")
+    save_cv_folds = config.get("Output", "save_cv_folds")
 
     # whether or not to do stratified cross validation
     random_folds = config.getboolean("Input", "random_folds")

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -1441,7 +1441,7 @@ class Learner(object):
             skll_fold_ids = {}
             for fold_num, (_, test_indices) in enumerate(kfold):
                 for index in test_indices:
-                    skll_fold_ids[examples.ids[index]] = fold_num
+                    skll_fold_ids[examples.ids[index]] = str(fold_num)
 
         # handle each fold separately and accumulate the predictions and the
         # numbers

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -1339,7 +1339,7 @@ class Learner(object):
     def cross_validate(self, examples, stratified=True, cv_folds=10,
                        grid_search=False, grid_search_folds=3, grid_jobs=None,
                        grid_objective='f1_score_micro', prediction_prefix=None,
-                       param_grid=None, shuffle=False):
+                       param_grid=None, shuffle=False, save_cv_folds=False):
         """
         Cross-validates a given model on the training examples.
 
@@ -1376,11 +1376,15 @@ class Learner(object):
         :type prediction_prefix: str
         :param shuffle: Shuffle examples before splitting into folds for CV.
         :type shuffle: bool
+        :param save_cv_folds: Whether to save the cv fold ids or not
+        :type save_cv_folds: bool
 
         :return: The confusion matrix, overall accuracy, per-label PRFs, and
                  model parameters for each fold in one list, and another list
-                 with the grid search scores for each fold.
-        :rtype: (list of 4-tuples, list of float)
+                 with the grid search scores for each fold. Also return a
+                 dictionary containing the test-fold number for each id
+                 if save_cv_folds is True, otherwise None.
+        :rtype: (list of 4-tuples, list of float, dict)
         """
         # seed the random number generator so that randomized algorithms are
         # replicable
@@ -1430,6 +1434,15 @@ class Learner(object):
             kfold = FilteredLeaveOneLabelOut(fold_labels, cv_folds, examples)
             grid_search_folds = cv_folds
 
+        # Save the cross-validation fold information, if required
+        # The format is that the test-fold that each id appears in is stored
+        skll_fold_ids = None
+        if save_cv_folds:
+            skll_fold_ids = {}
+            for fold_num, (_, test_indices) in enumerate(kfold):
+                for index in test_indices:
+                    skll_fold_ids[examples.ids[index]] = fold_num
+
         # handle each fold separately and accumulate the predictions and the
         # numbers
         results = []
@@ -1470,4 +1483,4 @@ class Learner(object):
             append_predictions = True
 
         # return list of results for all folds
-        return results, grid_search_scores
+        return results, grid_search_scores, skll_fold_ids

--- a/tests/configs/test_save_cv_folds.template.cfg
+++ b/tests/configs/test_save_cv_folds.template.cfg
@@ -6,10 +6,10 @@ task=cross_validate
 featuresets=[["test_save_cv_folds"]]
 learners=["LogisticRegression"]
 suffix=.jsonlines
-save_cv_folds=True
 
 [Tuning]
 grid_search=False
 
 [Output]
+save_cv_folds=True
 results=output

--- a/tests/configs/test_save_cv_folds.template.cfg
+++ b/tests/configs/test_save_cv_folds.template.cfg
@@ -1,0 +1,15 @@
+[General]
+experiment_name=test_save_cv_folds
+task=cross_validate
+
+[Input]
+featuresets=[["test_save_cv_folds"]]
+learners=["LogisticRegression"]
+suffix=.jsonlines
+save_cv_folds=True
+
+[Tuning]
+grid_search=False
+
+[Output]
+results=output

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -23,6 +23,7 @@ from glob import glob
 import numpy as np
 from nose.tools import eq_, raises
 from six import PY2
+import random
 
 from sklearn.feature_extraction import FeatureHasher
 from sklearn.datasets.samples_generator import make_classification
@@ -221,14 +222,21 @@ def test_retrieve_cv_folds():
     num_folds = 5
     cv_fs, custom_cv_folds = make_cv_folds_data(num_examples_per_fold=2, num_folds=num_folds)
 
-    expected_fold_ids = {'EXAMPLE_0': 0, 'EXAMPLE_1': 4, 'EXAMPLE_2': 3, 'EXAMPLE_3': 1,
-                         'EXAMPLE_4': 2, 'EXAMPLE_5': 2, 'EXAMPLE_6': 1, 'EXAMPLE_7': 0,
-                         'EXAMPLE_8': 4, 'EXAMPLE_9': 3}
+    # First test where learner.cross_validate makes the folds itself
+    expected_fold_ids = {'EXAMPLE_0': '0', 'EXAMPLE_1': '4', 'EXAMPLE_2': '3', 'EXAMPLE_3': '1',
+                         'EXAMPLE_4': '2', 'EXAMPLE_5': '2', 'EXAMPLE_6': '1', 'EXAMPLE_7': '0',
+                         'EXAMPLE_8': '4', 'EXAMPLE_9': '3'}
 
     _, _, skll_fold_ids = learner.cross_validate(cv_fs, cv_folds=num_folds, save_cv_folds=True,
                                                  grid_search=True)
 
     assert_equal(skll_fold_ids, expected_fold_ids)
+
+    # Now test that if we pass in custom fold ids, those are also preserved
+    _, _, skll_fold_ids = learner.cross_validate(cv_fs, cv_folds=custom_cv_folds, save_cv_folds=True,
+                                                 grid_search=True)
+
+    assert_equal(skll_fold_ids, custom_cv_folds)
 
 
 def test_cross_validate_task():

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -17,6 +17,8 @@ import itertools
 from io import open
 import os
 from os.path import abspath, dirname, join, exists
+import json
+from glob import glob
 
 import numpy as np
 from nose.tools import eq_, raises
@@ -24,15 +26,33 @@ from six import PY2
 
 from sklearn.feature_extraction import FeatureHasher
 from sklearn.datasets.samples_generator import make_classification
-from sklearn.utils.testing import assert_greater, assert_less
+from sklearn.utils.testing import assert_greater, assert_less, assert_equal, \
+                                    assert_almost_equal
 from skll.config import _load_cv_folds
 from skll.data import FeatureSet
 from skll.learner import Learner
 from skll.learner import _DEFAULT_PARAM_GRIDS
-
+from skll.experiments import _load_featureset
+from sklearn.cross_validation import StratifiedKFold
+from utils import fill_in_config_paths_for_single_file
+from skll.experiments import run_configuration
 
 _ALL_MODELS = list(_DEFAULT_PARAM_GRIDS.keys())
 _my_dir = abspath(dirname(__file__))
+
+
+
+
+def setup():
+    """
+    Create necessary directories for testing.
+    """
+    train_dir = join(_my_dir, 'train')
+    if not exists(train_dir):
+        os.makedirs(train_dir)
+    output_dir = join(_my_dir, 'output')
+    if not exists(output_dir):
+        os.makedirs(output_dir)
 
 
 def tearDown():
@@ -42,6 +62,20 @@ def tearDown():
     fold_file_path = join(_my_dir, 'other', 'custom_folds.csv')
     if exists(fold_file_path):
         os.unlink(fold_file_path)
+
+    train_dir = join(_my_dir, 'train')
+    output_dir = join(_my_dir, 'output')
+    config_dir = join(_my_dir, 'configs')
+
+    cfg_file = join(config_dir, 'test_save_cv_folds.cfg')
+    os.unlink(cfg_file)
+
+    for output_file in (glob(join(output_dir,
+                                  'test_save_cv_folds_*')) +
+                        glob(join(output_dir,
+                                  'test_int_labels_cv_*'))):
+        os.unlink(output_file)
+
 
 
 def make_cv_folds_data(num_examples_per_fold=100,
@@ -177,3 +211,67 @@ def test_load_cv_folds_non_float_ids():
 
     # now read the CSV file using _load_cv_folds, which should raise ValueError
     _load_cv_folds(fold_file_path, ids_to_floats=True)
+
+def test_retrieve_cv_folds():
+    """
+    Test to make sure that the fold ids get returned correctly after cross-validation
+    """
+
+    learner = Learner('LogisticRegression')
+    num_folds = 5
+    cv_fs, custom_cv_folds = make_cv_folds_data(num_examples_per_fold=2, num_folds=num_folds)
+
+    expected_fold_ids = {'EXAMPLE_0': 0, 'EXAMPLE_1': 4, 'EXAMPLE_2': 3, 'EXAMPLE_3': 1,
+                         'EXAMPLE_4': 2, 'EXAMPLE_5': 2, 'EXAMPLE_6': 1, 'EXAMPLE_7': 0,
+                         'EXAMPLE_8': 4, 'EXAMPLE_9': 3}
+
+    _, _, skll_fold_ids = learner.cross_validate(cv_fs, cv_folds=num_folds, save_cv_folds=True,
+                                                 grid_search=True)
+
+    assert_equal(skll_fold_ids, expected_fold_ids)
+
+
+def test_cross_validate_task():
+    """
+    Test that 10-fold cross_validate experiments work.
+    Test that fold ids get correctly saved.
+    """
+
+    # Run experiment
+    suffix = '.jsonlines'
+    train_path = join(_my_dir, 'train', 'f0{}'.format(suffix))
+
+    config_path = fill_in_config_paths_for_single_file(join(_my_dir, "configs",
+                                                            "test_save_cv_folds"
+                                                            ".template.cfg"),
+                                                       train_path,
+                                                       None)
+    run_configuration(config_path, quiet=True)
+
+    # Check final average results
+    with open(join(_my_dir, 'output', 'test_save_cv_folds_train_f0.' +
+                                      'jsonlines_LogisticRegression.results.json')) as f:
+        result_dict = json.load(f)[10]
+
+    assert_almost_equal(result_dict['score'], 0.517)
+
+    # Check that the fold ids were saved correctly
+    expected_skll_ids = {}
+    examples = _load_featureset(train_path, '', suffix, quiet=True)
+    kfold = StratifiedKFold(examples.labels, n_folds=10)
+    for fold_num, (_, test_indices) in enumerate(kfold):
+        for index in test_indices:
+            expected_skll_ids[examples.ids[index]] = fold_num
+
+    skll_fold_ids = {}
+    with open(join(_my_dir, 'output', 'test_save_cv_folds_skll_fold_ids.csv')) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            skll_fold_ids[row['id']] = row['cv_test_fold']
+
+    # convert the dictionary to strings (sorted by key) for quick comparison
+    skll_fold_ids_str = ''.join('{}{}'.format(key, val) for key, val in sorted(skll_fold_ids.items()))
+    expected_skll_ids_str = ''.join('{}{}'.format(key, val) for key, val in sorted(expected_skll_ids.items()))
+
+    assert_equal(skll_fold_ids_str, expected_skll_ids_str)
+

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -782,7 +782,7 @@ def test_config_parsing_relative_input_path():
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objective, probability, results_path,
      pos_label_str, feature_scaling, min_feature_count,
-     grid_search_jobs, grid_search_folds, cv_folds, do_stratified_folds,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
      class_map, custom_learner_path) = _parse_config_file(config_path)
@@ -815,7 +815,7 @@ def test_default_number_of_cv_folds():
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objective, probability, results_path,
      pos_label_str, feature_scaling, min_feature_count,
-     grid_search_jobs, grid_search_folds, cv_folds, do_stratified_folds,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
      class_map, custom_learner_path) = _parse_config_file(config_path)
@@ -850,7 +850,7 @@ def test_setting_number_of_cv_folds():
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objective, probability, results_path,
      pos_label_str, feature_scaling, min_feature_count,
-     grid_search_jobs, grid_search_folds, cv_folds, do_stratified_folds,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
      class_map, custom_learner_path) = _parse_config_file(config_path)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -129,10 +129,10 @@ def check_summary_score(use_feature_hashing=False):
         reader = csv.DictReader(f, dialect='excel-tab')
 
         for row in reader:
-            # the learner results dictionaries should have 28 rows,
+            # the learner results dictionaries should have 29 rows,
             # and all of these except results_table
             # should be printed (though some columns will be blank).
-            eq_(len(row), 28)
+            eq_(len(row), 29)
             assert row['model_params']
             assert row['grid_score']
             assert row['score']


### PR DESCRIPTION
Add a new config option that saves information about which example was in which test fold during cross validation experiments. The name of the file is fixed for each experiment. 