### PR TITLE
only print out a warning about hasher_features when feature_hasher is not set

### DIFF
--- a/skll/config.py
+++ b/skll/config.py
@@ -276,7 +276,7 @@ def _parse_config_file(config_path):
 
     # produce warnings if hasher_features is set but feature_hasher
     # is not set correctly
-    if not feature_hasher and hasher_features > 0:
+    elif hasher_features > 0:
         logger.warning("Ignoring hasher_features since feature_hasher is either"
                        " missing or set to False.")
 

--- a/skll/config.py
+++ b/skll/config.py
@@ -276,7 +276,7 @@ def _parse_config_file(config_path):
 
     # produce warnings if hasher_features is set but feature_hasher
     # is not set correctly
-    if hasher_features > 0:
+    if not feature_hasher and hasher_features > 0:
         logger.warning("Ignoring hasher_features since feature_hasher is either"
                        " missing or set to False.")
 


### PR DESCRIPTION
Otherwise the user might think that their feature hasher is being ignored. 

This fixes #265.