### PR TITLE
Remove `GRIDMAP=true` from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.7
   - 3.4
 env:
-  - GRIDMAP=true
   - GRIDMAP=false
 notifications:
   email: false


### PR DESCRIPTION
Since we cannot successfully get SGE to install on Travis CI and switching to another CI platform is too much work right now, we are going to disable 2/4 builds on Travis that use `gridmap`. 