### PR TITLE
Raise error when config file on command line is an empty string.

### DIFF
--- a/skll/config.py
+++ b/skll/config.py
@@ -236,6 +236,10 @@ def _parse_config_file(config_path):
     # Initialize logger
     logger = logging.getLogger(__name__)
 
+    # check that config_path is not empty
+    if config_path == "":
+        raise ValueError("The name of the configuration file is empty")
+
     # compute the absolute path for the config file
     config_path = realpath(config_path)
     config_dir = dirname(config_path)

--- a/skll/config.py
+++ b/skll/config.py
@@ -238,7 +238,7 @@ def _parse_config_file(config_path):
 
     # check that config_path is not empty
     if config_path == "":
-        raise ValueError("The name of the configuration file is empty")
+        raise IOError("The name of the configuration file is empty")
 
     # compute the absolute path for the config file
     config_path = realpath(config_path)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -133,6 +133,14 @@ def check_config_parsing_file_not_found_error(config_path):
     """
     _parse_config_file(config_path)
 
+
+@raises(ValueError)
+def test_empty_config_name_raises_file_not_found_error():
+   """ 
+   Assert that calling _parse_config_file on an empty string raises FileNotFoundError
+   """
+   _parse_config_file("")
+
 def test_config_parsing_no_name():
     """
     Test to ensure config file parsing raises an error missing experiment name

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -137,7 +137,7 @@ def check_config_parsing_file_not_found_error(config_path):
 @raises(ValueError)
 def test_empty_config_name_raises_file_not_found_error():
    """ 
-   Assert that calling _parse_config_file on an empty string raises FileNotFoundError
+   Assert that calling _parse_config_file on an empty string raises ValueError
    """
    _parse_config_file("")
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -134,10 +134,10 @@ def check_config_parsing_file_not_found_error(config_path):
     _parse_config_file(config_path)
 
 
-@raises(ValueError)
+@raises(IOError)
 def test_empty_config_name_raises_file_not_found_error():
    """ 
-   Assert that calling _parse_config_file on an empty string raises ValueError
+   Assert that calling _parse_config_file on an empty string raises IOError
    """
    _parse_config_file("")
 


### PR DESCRIPTION
Added an extra check for empty config file name. This can generally only happen via the API.