### PR TITLE
Fix errors when using reusing relative paths in output section

### DIFF
--- a/examples/boston/cross_val.cfg
+++ b/examples/boston/cross_val.cfg
@@ -4,7 +4,7 @@ task = cross_validate
 
 [Input]
 # this could also be an absolute path instead (and must be if you're not running things in local mode)
-train_directory = boston/train
+train_directory = train
 featuresets = [["example_boston_features"]]
 # there is only set of features to try with one feature file in it here.
 featureset_names = ["example_boston"]

--- a/examples/boston/evaluate.cfg
+++ b/examples/boston/evaluate.cfg
@@ -4,8 +4,8 @@ task = evaluate
 
 [Input]
 # this could also be an absolute path instead (and must be if you're not running things in local mode)
-train_directory = boston/train
-test_directory = boston/test
+train_directory = train
+test_directory = test
 featuresets = [["example_boston_features"]]
 # there is only set of features to try with one feature file in it here.
 featureset_names = ["example_boston"]

--- a/skll/config.py
+++ b/skll/config.py
@@ -300,7 +300,8 @@ def _parse_config_file(config_path):
                          ' times, which is not currently supported.  Please use'
                          ' param_grids with tuning to find the optimal settings'
                          ' for the learner.')
-    custom_learner_path = config.get("Input", "custom_learner_path")
+    custom_learner_path = _locate_file(config.get("Input", "custom_learner_path"),
+                                       config_dir)
 
     # get the featuresets
     featuresets_string = config.get("Input", "featuresets")
@@ -350,10 +351,10 @@ def _parse_config_file(config_path):
     ids_to_floats = config.getboolean("Input", "ids_to_floats")
 
     # get the cv folds file and make a dictionary from it, if it exists
-    cv_folds_file = config.get("Input", "cv_folds_file")
+    cv_folds_file = _locate_file(config.get("Input", "cv_folds_file"),
+                                 config_dir)
     num_cv_folds = config.getint("Input", "num_cv_folds")
     if cv_folds_file:
-        cv_folds_file = _locate_file(cv_folds_file, config_path)
         cv_folds = _load_cv_folds(cv_folds_file,
                                   ids_to_floats=ids_to_floats)
     else:
@@ -442,28 +443,28 @@ def _parse_config_file(config_path):
     probability = config.getboolean("Output", "probability")
 
     # do we want to keep the predictions?
-    prediction_dir = config.get("Output", "predictions")
+    prediction_dir = _locate_file(config.get("Output", "predictions"),
+                                  config_dir)
     if prediction_dir:
-        prediction_dir = join(config_dir, prediction_dir)
         if not exists(prediction_dir):
             os.makedirs(prediction_dir)
 
     # make sure log path exists
-    log_path = config.get("Output", "log")
+    log_path = _locate_file(config.get("Output", "log"), config_dir)
     if log_path:
         log_path = join(config_dir, log_path)
         if not exists(log_path):
             os.makedirs(log_path)
 
     # make sure model path exists
-    model_path = config.get("Output", "models")
+    model_path = _locate_file(config.get("Output", "models"), config_dir)
     if model_path:
         model_path = join(config_dir, model_path)
         if not exists(model_path):
             os.makedirs(model_path)
 
     # make sure results path exists
-    results_path = config.get("Output", "results")
+    results_path = _locate_file(config.get("Output", "results"), config_dir)
     if results_path:
         results_path = join(config_dir, results_path)
         if not exists(results_path):

--- a/tests/configs/test_relative_paths.template.cfg
+++ b/tests/configs/test_relative_paths.template.cfg
@@ -1,0 +1,15 @@
+[General]
+experiment_name=test_relative_paths
+task=evaluate
+
+[Input]
+learners=["MajorityClassLearner"]
+suffix=.jsonlines
+custom_learner_path=../other/majority_class_learner.py
+
+[Tuning]
+grid_search=true
+objective=accuracy
+
+[Output]
+probability=false

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -870,13 +870,6 @@ def test_config_parsing_relative_input_paths():
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
      class_map, custom_learner_path) = _parse_config_file(config_path)
 
-    #for _path, _name in [(train_file, train_path),
-    #                     (test_file, test_path),
-    #                     (output_dir, 'output'),
-    #                     (custom_learner_path_input, 'other'),
-    #                     ()]:
-    #    eq_(normpath(_path), (join(_my_dir, _name)))
-
 def test_default_number_of_cv_folds():
 
     train_dir = join(_my_dir, 'train')

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -874,7 +874,7 @@ def test_default_number_of_cv_folds():
 
     train_dir = join(_my_dir, 'train')
     output_dir = join(_my_dir, 'output')
-    cv_folds_file = join(_my_dir)
+    
     # make a simple config file that does not set cv_folds
 
     values_to_fill_dict = {'experiment_name': 'config_parsing',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -71,11 +71,11 @@ def test_locate_file_valid_paths1():
     Test that `config.locate_file` works with absolute paths.
     """
 
-    config_abs_path = join(_my_dir, 'test', 'test_config.cfg')
+    config_abs_path = join(_my_dir, 'configs',
+                           'test_config_parsing_relative_path1.cfg')
     open(config_abs_path, 'w').close()
     eq_(_locate_file(config_abs_path, _my_dir),
-        join(_my_dir, 'test', 'test_config.cfg'))
-    os.unlink(config_abs_path)
+        join(_my_dir, 'configs', 'test_config_parsing_relative_path1.cfg'))
 
 
 def test_locate_file_valid_paths2():
@@ -83,11 +83,11 @@ def test_locate_file_valid_paths2():
     Test that `config.locate_file` works with relative paths.
     """
 
-    config_abs_path = join(_my_dir, 'test', 'test_config.cfg')
-    config_rel_path = 'test/test_config.cfg'
+    config_abs_path = join(_my_dir, 'configs',
+                           'test_config_parsing_relative_path2.cfg')
+    config_rel_path = 'configs/test_config_parsing_relative_path2.cfg'
     open(config_abs_path, 'w').close()
     eq_(_locate_file(config_rel_path, _my_dir), config_abs_path)
-    os.unlink(config_abs_path)
 
 
 def test_locate_file_valid_paths3():
@@ -95,12 +95,12 @@ def test_locate_file_valid_paths3():
     Test that `config.locate_file` works with relative/absolute paths.
     """
 
-    config_abs_path = join(_my_dir, 'test', 'test_config.cfg')
-    config_rel_path = 'test/test_config.cfg'
+    config_abs_path = join(_my_dir, 'configs',
+                           'test_config_parsing_relative_path3.cfg')
+    config_rel_path = 'configs/test_config_parsing_relative_path3.cfg'
     open(config_abs_path, 'w').close()
     eq_(_locate_file(config_abs_path, _my_dir),
         _locate_file(config_rel_path, _my_dir))
-    os.unlink(config_abs_path)
 
 
 @raises(IOError)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -15,11 +15,11 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import tempfile
 from glob import glob
-from os.path import abspath, dirname, exists, join, normpath
+from os.path import abspath, dirname, exists, join, normpath, realpath
 
 from nose.tools import eq_, raises
 
-from skll.config import _parse_config_file
+from skll.config import _parse_config_file, _locate_file
 from skll.data.readers import safe_float
 from skll.experiments import _load_featureset
 
@@ -64,6 +64,53 @@ def test_safe_float_conversion():
     for input_val, expected_val in zip(['1.234', 1.234, '3.0', '3', 3, 'foo'],
                                        [1.234, 1.234, 3.0, 3, 3, 'foo']):
         yield check_safe_float_conversion, safe_float(input_val), expected_val
+
+
+def test_locate_file_valid_paths1():
+    """
+    Test that `config.locate_file` works with absolute paths.
+    """
+
+    config_abs_path = join(_my_dir, 'test', 'test_config.cfg')
+    open(config_abs_path, 'w').close()
+    eq_(_locate_file(config_abs_path, _my_dir),
+        join(_my_dir, 'test', 'test_config.cfg'))
+    os.unlink(config_abs_path)
+
+
+def test_locate_file_valid_paths2():
+    """
+    Test that `config.locate_file` works with relative paths.
+    """
+
+    config_abs_path = join(_my_dir, 'test', 'test_config.cfg')
+    config_rel_path = 'test/test_config.cfg'
+    open(config_abs_path, 'w').close()
+    eq_(_locate_file(config_rel_path, _my_dir), config_abs_path)
+    os.unlink(config_abs_path)
+
+
+def test_locate_file_valid_paths3():
+    """
+    Test that `config.locate_file` works with relative/absolute paths.
+    """
+
+    config_abs_path = join(_my_dir, 'test', 'test_config.cfg')
+    config_rel_path = 'test/test_config.cfg'
+    open(config_abs_path, 'w').close()
+    eq_(_locate_file(config_abs_path, _my_dir),
+        _locate_file(config_rel_path, _my_dir))
+    os.unlink(config_abs_path)
+
+
+@raises(IOError)
+def test_locate_file_invalid_path():
+    """
+    Test that `config.locate_file` raises an error for paths that do not
+    exist.
+    """
+
+    _locate_file('test/does_not_exist.cfg', _my_dir)
 
 
 @raises(ValueError)
@@ -774,8 +821,8 @@ def test_config_parsing_relative_input_path():
                                 'test_config_parsing.template.cfg')
 
     config_path = fill_in_config_options(config_template_path,
-                                                   values_to_fill_dict,
-                                                   'mislocated_input_file')
+                                         values_to_fill_dict,
+                                         'mislocated_input_file')
 
     (experiment_name, task, sampler, fixed_sampler_parameters,
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
@@ -789,10 +836,52 @@ def test_config_parsing_relative_input_path():
 
     eq_(normpath(train_path), (join(_my_dir, 'train')))
 
+def test_config_parsing_relative_input_paths():
+
+    train_dir = '../train'
+    train_file = join(train_dir, 'f0.jsonlines')
+    test_file = join(train_dir, 'f1.jsonlines')
+    output_dir = '../output'
+    custom_learner_path_input = join('other', 'majority_class_learner.py')
+
+    # make a simple config file that has relative paths
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'evaluate',
+                           'train_file': train_file,
+                           'test_file': test_file,
+                           'learners': "['LogisticRegression']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'objective': 'f1_score_macro'}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_relative_paths.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'relative_paths')
+
+    (experiment_name, task, sampler, fixed_sampler_parameters,
+     feature_hasher, hasher_features, id_col, label_col, train_set_name,
+     test_set_name, suffix, featuresets, do_shuffle, model_path,
+     do_grid_search, grid_objective, probability, results_path,
+     pos_label_str, feature_scaling, min_feature_count,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds, do_stratified_folds,
+     fixed_parameter_list, param_grid_list, featureset_names, learners,
+     prediction_dir, log_path, train_path, test_path, ids_to_floats,
+     class_map, custom_learner_path) = _parse_config_file(config_path)
+
+    #for _path, _name in [(train_file, train_path),
+    #                     (test_file, test_path),
+    #                     (output_dir, 'output'),
+    #                     (custom_learner_path_input, 'other'),
+    #                     ()]:
+    #    eq_(normpath(_path), (join(_my_dir, _name)))
+
 def test_default_number_of_cv_folds():
 
     train_dir = join(_my_dir, 'train')
     output_dir = join(_my_dir, 'output')
+    cv_folds_file = join(_my_dir)
     # make a simple config file that does not set cv_folds
 
     values_to_fill_dict = {'experiment_name': 'config_parsing',


### PR DESCRIPTION
Added in support of relative paths in config files for more than just the training/test set files (e.g. model directory, custom learner, etc.) + some unit tests.