### PR TITLE
Update scikit-learn to 0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - conda config --add channels https://conda.binstar.org/dan_blanchard
   - conda update --yes conda
 install:
-  - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy beautiful-soup six scikit-learn==0.16.1 joblib prettytable python-coveralls pyyaml
+  - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy beautiful-soup six scikit-learn==0.17.0 joblib prettytable python-coveralls pyyaml
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes configparser logutils mock; fi
   # Have to use pip for nose-cov because its entry points are not supported by conda yet
   - pip install nose-cov

--- a/conda.yaml
+++ b/conda.yaml
@@ -41,7 +41,7 @@ requirements:
     - python
     - joblib
     - setuptools
-    - scikit-learn 0.16.1
+    - scikit-learn 0.17.0
     - six
     - prettytable
     - beautiful-soup
@@ -56,7 +56,7 @@ requirements:
   run:
     - python
     - joblib
-    - scikit-learn 0.16.1
+    - scikit-learn 0.17.0
     - six
     - prettytable
     - beautiful-soup

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -558,7 +558,7 @@ SVR
 
     .. code-block:: python
 
-       {'class_weight': 'auto'}
+       {'class_weight': 'balanced'}
 
     The second option allows you to assign an specific weight per each
     class. The default weight per class is 1. For example:

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -415,12 +415,14 @@ custom_learner_path *(Optional)*
 
 Path to a ``.py`` file that defines a custom learner.  This file will be
 imported dynamically.  This is only required if a custom learner in specified
-in the list of :ref:`learners`.  Custom learners must implement the ``fit`` and
-``predict`` methods and inherit from
-`sklearn.base.BaseEstimator <http://scikit-learn.org/stable/modules/generated/sklearn.base.BaseEstimator.html>`__.
-Custom regressors must also inherit from
-`sklearn.base.RegressorMixin <http://scikit-learn.org/stable/modules/generated/sklearn.base.RegressorMixin.html>`__.
-Models that require dense matrices should implement a method ``requires_dense``
+in the list of :ref:`learners`.
+
+All Custom learners must implement the ``fit`` and
+``predict`` methods. Custom classifiers must either (a) inherit from an existing scikit-learn classifier, or (b) inherit from both `sklearn.base.BaseEstimator <http://scikit-learn.org/stable/modules/generated/sklearn.base.BaseEstimator.html>`__. *and* from `sklearn.base.ClassifierMixin <http://scikit-learn.org/stable/modules/generated/sklearn.base.ClassifierMixin.html>`__.
+
+Similarly, Custom regressors must either (a) inherit from an existing scikit-learn regressor, or (b) inherit from both `sklearn.base.BaseEstimator <http://scikit-learn.org/stable/modules/generated/sklearn.base.BaseEstimator.html>`__. *and* from `sklearn.base.RegressorMixin <http://scikit-learn.org/stable/modules/generated/sklearn.base.RegressorMixin.html>`__.
+
+Learners that require dense matrices should implement a method ``requires_dense``
 that returns ``True``.
 
 .. _sampler:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.16.1
+scikit-learn==0.17.0
 six
 PrettyTable
 beautifulsoup4

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,7 +1,7 @@
 configparser==3.5.0b2
 logutils
 mock
-scikit-learn==0.16.1
+scikit-learn==0.17.0
 six
 PrettyTable
 beautifulsoup4

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -785,7 +785,7 @@ class Learner(object):
         check that the examples are properly formatted.
         """
         # Make sure the labels for a regression task are not strings.
-        if self.model._estimator_type == 'regressor':
+        if self.model_type._estimator_type == 'regressor':
             for label in examples.labels:
                 if isinstance(label, string_types):
                     raise TypeError("You are doing regression with string "
@@ -819,7 +819,7 @@ class Learner(object):
         :type examples: FeatureSet
         """
         # We don't need to do this for regression models, so return.
-        if self.model._estimator_type == 'regressor':
+        if self.model_type._estimator_type == 'regressor':
             return
 
         # extract list of unique labels if we are doing classification
@@ -917,7 +917,7 @@ class Learner(object):
         # if we are asked to do grid search, check that the grid objective
         # function is valid for the selected learner
         if grid_search:
-            if self.model._estimator_type == 'regressor':
+            if self.model_type._estimator_type == 'regressor':
                 # types 2-4 are valid for all regression models
                 if grid_objective in _CLASSIFICATION_ONLY_OBJ_FUNCS:
                     raise ValueError("{} is not a valid grid objective "
@@ -1028,7 +1028,7 @@ class Learner(object):
 
         # use label dict transformed version of examples.labels if doing
         # classification
-        if self.model._estimator_type == 'classifier':
+        if self.model_type._estimator_type == 'classifier':
             labels = np.array([self.label_dict[label] for label in
                                examples.labels])
         else:
@@ -1069,7 +1069,7 @@ class Learner(object):
             # If we're using a correlation metric for doing binary
             # classification, override the estimator's predict function
             if (grid_objective in _CORRELATION_METRICS and
-                    self.model._estimator_type == 'classifier'):
+                    self.model_type._estimator_type == 'classifier'):
                 estimator.predict_normal = estimator.predict
                 estimator.predict = _predict_binary
 
@@ -1124,7 +1124,7 @@ class Learner(object):
                             append=append)
 
         # extract actual labels (transformed for classification tasks)
-        if self.model._estimator_type == 'classifier':
+        if self.model_type._estimator_type == 'classifier':
             ytest = np.array([self.label_dict[label] for label in
                               examples.labels])
         else:
@@ -1152,7 +1152,7 @@ class Learner(object):
             except ValueError:
                 grid_score = float('NaN')
 
-        if self.model._estimator_type == 'regressor':
+        if self.model_type._estimator_type == 'regressor':
             result_dict = {'descriptive': defaultdict(dict)}
             for table_label, y in zip(['actual', 'predicted'], [ytest, yhat]):
                 result_dict['descriptive'][table_label]['min'] = min(y)
@@ -1309,7 +1309,7 @@ class Learner(object):
                                         [str(x) for x in class_probs]),
                               file=predictionfh)
                 else:
-                    if self.model._estimator_type == 'regressor':
+                    if self.model_type._estimator_type == 'regressor':
                         for example_id, pred in zip(example_ids, yhat):
                             print('{0}\t{1}'.format(example_id, pred),
                                   file=predictionfh)
@@ -1320,7 +1320,7 @@ class Learner(object):
                                   file=predictionfh)
 
         if (class_labels and
-                self.model._estimator_type == 'classifier'):
+                self.model_type._estimator_type == 'classifier'):
             yhat = np.array([self.label_list[int(pred)] for pred in yhat])
 
         return yhat
@@ -1333,7 +1333,7 @@ class Learner(object):
         assert isinstance(cv_folds, int)
 
         # For regression models, we can just return the current cv_folds
-        if self.model._estimator_type == 'regressor':
+        if self.model_type._estimator_type == 'regressor':
             return cv_folds
 
         min_examples_per_label = min(Counter(labels).values())
@@ -1428,7 +1428,7 @@ class Learner(object):
                 cv_folds, examples.labels)
 
             stratified = (stratified and
-                          self.model._estimator_type == 'classifier')
+                          self.model_type._estimator_type == 'classifier')
             kfold = (StratifiedKFold(examples.labels, n_folds=cv_folds) if
                      stratified else KFold(len(examples.labels),
                                            n_folds=cv_folds))

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -29,7 +29,6 @@ from six import iteritems, itervalues
 from six import string_types
 from six.moves import xrange as range
 from six.moves import zip
-from sklearn.base import RegressorMixin
 from sklearn.cross_validation import KFold, LeaveOneLabelOut, StratifiedKFold
 from sklearn.ensemble import (AdaBoostClassifier, AdaBoostRegressor,
                               GradientBoostingClassifier,
@@ -294,7 +293,7 @@ def rescaled(cls):
     orig_fit = cls.fit
     orig_predict = cls.predict
 
-    if not issubclass(cls, RegressorMixin):
+    if cls._estimator_type == 'classifier':
         raise ValueError('Classifiers cannot be rescaled. ' +
                          'Only regressors can.')
 
@@ -786,7 +785,7 @@ class Learner(object):
         check that the examples are properly formatted.
         """
         # Make sure the labels for a regression task are not strings.
-        if issubclass(self._model_type, RegressorMixin):
+        if self.model._estimator_type == 'regressor':
             for label in examples.labels:
                 if isinstance(label, string_types):
                     raise TypeError("You are doing regression with string "
@@ -820,7 +819,7 @@ class Learner(object):
         :type examples: FeatureSet
         """
         # We don't need to do this for regression models, so return.
-        if issubclass(self._model_type, RegressorMixin):
+        if self.model._estimator_type == 'regressor':
             return
 
         # extract list of unique labels if we are doing classification
@@ -918,7 +917,7 @@ class Learner(object):
         # if we are asked to do grid search, check that the grid objective
         # function is valid for the selected learner
         if grid_search:
-            if issubclass(self.model_type, RegressorMixin):
+            if self.model._estimator_type == 'regressor':
                 # types 2-4 are valid for all regression models
                 if grid_objective in _CLASSIFICATION_ONLY_OBJ_FUNCS:
                     raise ValueError("{} is not a valid grid objective "
@@ -1029,7 +1028,7 @@ class Learner(object):
 
         # use label dict transformed version of examples.labels if doing
         # classification
-        if not issubclass(self._model_type, RegressorMixin):
+        if self.model._estimator_type == 'classifier':
             labels = np.array([self.label_dict[label] for label in
                                examples.labels])
         else:
@@ -1070,7 +1069,7 @@ class Learner(object):
             # If we're using a correlation metric for doing binary
             # classification, override the estimator's predict function
             if (grid_objective in _CORRELATION_METRICS and
-                    not issubclass(self._model_type, RegressorMixin)):
+                    self.model._estimator_type == 'classifier'):
                 estimator.predict_normal = estimator.predict
                 estimator.predict = _predict_binary
 
@@ -1125,7 +1124,7 @@ class Learner(object):
                             append=append)
 
         # extract actual labels (transformed for classification tasks)
-        if not issubclass(self._model_type, RegressorMixin):
+        if self.model._estimator_type == 'classifier':
             ytest = np.array([self.label_dict[label] for label in
                               examples.labels])
         else:
@@ -1153,7 +1152,7 @@ class Learner(object):
             except ValueError:
                 grid_score = float('NaN')
 
-        if issubclass(self._model_type, RegressorMixin):
+        if self.model._estimator_type == 'regressor':
             result_dict = {'descriptive': defaultdict(dict)}
             for table_label, y in zip(['actual', 'predicted'], [ytest, yhat]):
                 result_dict['descriptive'][table_label]['min'] = min(y)
@@ -1310,7 +1309,7 @@ class Learner(object):
                                         [str(x) for x in class_probs]),
                               file=predictionfh)
                 else:
-                    if issubclass(self._model_type, RegressorMixin):
+                    if self.model._estimator_type == 'regressor':
                         for example_id, pred in zip(example_ids, yhat):
                             print('{0}\t{1}'.format(example_id, pred),
                                   file=predictionfh)
@@ -1320,8 +1319,8 @@ class Learner(object):
                                               self.label_list[int(pred)]),
                                   file=predictionfh)
 
-        if (class_labels and not
-                issubclass(self._model_type, RegressorMixin)):
+        if (class_labels and
+                self.model._estimator_type == 'classifier'):
             yhat = np.array([self.label_list[int(pred)] for pred in yhat])
 
         return yhat
@@ -1334,7 +1333,7 @@ class Learner(object):
         assert isinstance(cv_folds, int)
 
         # For regression models, we can just return the current cv_folds
-        if issubclass(self._model_type, RegressorMixin):
+        if self.model._estimator_type == 'regressor':
             return cv_folds
 
         min_examples_per_label = min(Counter(labels).values())
@@ -1429,7 +1428,7 @@ class Learner(object):
                 cv_folds, examples.labels)
 
             stratified = (stratified and
-                          not issubclass(self._model_type, RegressorMixin))
+                          self.model._estimator_type == 'classifier')
             kfold = (StratifiedKFold(examples.labels, n_folds=cv_folds) if
                      stratified else KFold(len(examples.labels),
                                            n_folds=cv_folds))

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -576,7 +576,7 @@ class Learner(object):
                        GradientBoostingRegressor, DecisionTreeRegressor,
                        RandomForestRegressor, SGDClassifier, SGDRegressor,
                        AdaBoostRegressor, AdaBoostClassifier, LinearSVR,
-                       Lasso, ElasticNet, SVC)):
+                       Lasso, Ridge, ElasticNet, SVC)):
             self._model_kwargs['random_state'] = 123456789
 
         if sampler_kwargs:

--- a/skll/utilities/generate_predictions.py
+++ b/skll/utilities/generate_predictions.py
@@ -15,8 +15,6 @@ import argparse
 import logging
 import os
 
-from sklearn.base import RegressorMixin
-
 from skll.data.readers import EXT_TO_READER
 from skll.learner import Learner
 from skll.version import __version__
@@ -69,7 +67,7 @@ class Predictor(object):
             else:
                 return [int(pred[self._pos_index] >= self.threshold)
                         for pred in preds]
-        elif issubclass(self._learner.model_type, RegressorMixin):
+        elif self._learner.model._estimator_type == 'regressor':
             return preds
         else:
             return [self._learner.label_list[pred if isinstance(pred, int) else

--- a/tests/other/majority_class_learner.py
+++ b/tests/other/majority_class_learner.py
@@ -8,10 +8,10 @@ A simple majority class classifier, an example of a custom classifier.
 from collections import Counter
 
 import numpy as np
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, ClassifierMixin
 
 
-class MajorityClassLearner(BaseEstimator):
+class MajorityClassLearner(BaseEstimator, ClassifierMixin):
     def __init__(self):
         self.majority_class = None
 
@@ -25,3 +25,4 @@ class MajorityClassLearner(BaseEstimator):
 
     def predict(self, X):
         return np.array([self.majority_class for x in range(X.shape[0])])
+

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -21,7 +21,6 @@ from os.path import abspath, dirname, exists, join
 
 import numpy as np
 from nose.tools import eq_, assert_almost_equal, raises
-from sklearn.base import RegressorMixin
 
 from skll.data import FeatureSet
 from skll.data.writers import NDJWriter
@@ -82,7 +81,7 @@ def check_predict(model, use_feature_hashing=False):
     """
 
     # create the random data for the given model
-    if issubclass(model, RegressorMixin):
+    if model._estimator_type == 'regressor':
         train_fs, test_fs, _ = \
             make_regression_data(use_feature_hashing=use_feature_hashing,
                                  feature_bins=5)


### PR DESCRIPTION
The only change that was required was to patch up learner objects from older versions of SKLL (and scikit-learn) that we might load using the `from_file()` class method. 