### PR TITLE
Get coveralls.io working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda2/bin:$PATH
-  - conda config --add channels https://conda.binstar.org/dan_blanchard
+  - conda config --add channels dan_blanchard
+  - conda config --add channels desilinguist
   - conda update --yes conda
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy beautiful-soup six scikit-learn==0.17.0 joblib prettytable python-coveralls pyyaml


### PR DESCRIPTION
Currently, the `coveralls.io` build is broken because the `python-coveralls` in @dan-blanchard's channel is too old. I made a new package and put it in my `conda` channel and modified `.travis.yml` to use both @dan-blanchard's channel as well as my channel. This resurrects the `coveralls.io` builds as can be seen [here](https://coveralls.io/builds/5109277).