### PR TITLE
`fit()` in `rescaled()` decorator should return `self`

### DIFF
--- a/skll/learner.py
+++ b/skll/learner.py
@@ -321,6 +321,8 @@ def rescaled(cls):
             self.y_mean = np.mean(y)
             self.y_sd = np.std(y)
 
+        return self
+
     @wraps(cls.predict)
     def predict(self, X):
         """
@@ -1409,7 +1411,7 @@ class Learner(object):
                  if save_cv_folds is True, otherwise None.
         :rtype: (list of 4-tuples, list of float, dict)
         """
-        
+
         # Seed the random number generator so that randomized algorithms are
         # replicable.
         random_state = np.random.RandomState(123456789)
@@ -1444,7 +1446,7 @@ class Learner(object):
             stratified = (stratified and
                           self.model_type._estimator_type == 'classifier')
             if stratified:
-                kfold = StratifiedKFold(examples.labels, n_folds=cv_folds)   
+                kfold = StratifiedKFold(examples.labels, n_folds=cv_folds)
             else:
                 kfold = KFold(len(examples.labels),
                               n_folds=cv_folds,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -83,7 +83,7 @@ def tearDown():
 
 
 # a utility function to check rescaling for linear models
-def check_rescaling(name):
+def check_rescaling(name, grid_search=False):
 
     train_fs, test_fs, _ = make_regression_data(num_examples=2000,
                                                 sd_noise=4,
@@ -94,8 +94,13 @@ def check_rescaling(name):
     rescaled_learner = Learner('Rescaled' + name)
 
     # train both the regular regressor and the rescaled regressor
-    learner.train(train_fs, grid_objective='pearson')
-    rescaled_learner.train(train_fs, grid_objective='pearson')
+    # with and without using grid search
+    if grid_search:
+        learner.train(train_fs, grid_objective='pearson')
+        rescaled_learner.train(train_fs, grid_objective='pearson')
+    else:
+        learner.train(train_fs, grid_search=False)
+        rescaled_learner.train(train_fs, grid_search=False)
 
     # now generate both sets of predictions on the test feature set
     predictions = learner.predict(test_fs)
@@ -132,10 +137,11 @@ def check_rescaling(name):
 def test_rescaling():
     for regressor_name in ['ElasticNet', 'Lasso', 'LinearRegression', 'Ridge',
                            'LinearSVR', 'SVR', 'SGDRegressor']:
-        yield check_rescaling, regressor_name
+        for do_grid_search in [True, False]:
+            yield check_rescaling, regressor_name, do_grid_search
 
 
-# the utility function to run the linear regression tests
+# the utility function to run the linear regession tests
 def check_linear_models(name,
                         use_feature_hashing=False,
                         use_rescaling=False):


### PR DESCRIPTION
Currently the `fit()` method in the `rescaled()` decorator does not return `self` which is generally what `fit()` methods in `scikit-learn` should do. 

I fixed that and also modified the `test_rescaling()` regression test to also test rescaled learners without using grid search. So, we have new tests to check for this functionality which we didn't have before which is probably why this bug slipped through,