### PR TITLE
Upgrade scikit-learn to 0.17.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - conda config --add channels desilinguist
   - conda update --yes conda
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy beautiful-soup six scikit-learn==0.17.0 joblib prettytable python-coveralls pyyaml
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy beautiful-soup six scikit-learn==0.17.1 joblib prettytable python-coveralls pyyaml
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes configparser logutils mock; fi
   # Have to use pip for nose-cov because its entry points are not supported by conda yet
   - pip install nose-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.17.0
+scikit-learn==0.17.1
 six
 PrettyTable
 beautifulsoup4

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,7 +1,7 @@
 configparser==3.5.0b2
 logutils
 mock
-scikit-learn==0.17.0
+scikit-learn==0.17.1
 six
 PrettyTable
 beautifulsoup4


### PR DESCRIPTION
While we were working on version 1.2 of SKLL, the `scikit-learn` folks released a [minor upgrade](http://scikit-learn.org/stable/whats_new.html) from 0.17.0 to 0.17.1. It most likely will not impact any of our tests but has some important bug fixes so we want to include it.