### PR TITLE
Upgrade scikit-learn to v0.18.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - conda config --add channels desilinguist
   - conda update --yes conda
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy beautiful-soup six scikit-learn==0.17.1 joblib prettytable python-coveralls pyyaml
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION nomkl numpy scipy beautiful-soup six scikit-learn==0.18.1 joblib prettytable python-coveralls pyyaml
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes configparser logutils mock; fi
   - if [ ${WITH_PANDAS} == "true" ]; then conda install --yes pandas; fi
   # Have to use pip for nose-cov because its entry points are not supported by conda yet

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.17.1
+scikit-learn==0.18.1
 six
 PrettyTable
 beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.17.1
+scikit-learn==0.18.1
 six
 PrettyTable
 beautifulsoup4

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,7 +1,7 @@
 configparser==3.5.0b2
 logutils
 mock
-scikit-learn==0.17.1
+scikit-learn==0.18.1
 six
 PrettyTable
 beautifulsoup4

--- a/skll/__init__.py
+++ b/skll/__init__.py
@@ -18,7 +18,6 @@ from .experiments import run_configuration
 from .learner import Learner
 from .metrics import (kappa, kendall_tau, spearman, pearson,
                       f1_score_least_frequent)
-from .version import __version__, VERSION
 
 
 __all__ = ['FeatureSet', 'Learner', 'Reader', 'kappa', 'kendall_tau',
@@ -27,12 +26,12 @@ __all__ = ['FeatureSet', 'Learner', 'Reader', 'kappa', 'kendall_tau',
 
 # Add our scorers to the sklearn dictionary here so that they will always be
 # available if you import anything from skll
-_scorers = {'f1_score_micro': make_scorer(f1_score, average='micro',
-                                          pos_label=None),
-            'f1_score_macro': make_scorer(f1_score, average='macro',
-                                          pos_label=None),
-            'f1_score_weighted': make_scorer(f1_score, average='weighted',
-                                             pos_label=None),
+_scorers = {'f1_score_micro': make_scorer(f1_score,
+                                          average='micro'),
+            'f1_score_macro': make_scorer(f1_score,
+                                          average='macro'),
+            'f1_score_weighted': make_scorer(f1_score,
+                                             average='weighted'),
             'f1_score_least_frequent': make_scorer(f1_score_least_frequent),
             'pearson': make_scorer(pearson),
             'spearman': make_scorer(spearman),

--- a/skll/config.py
+++ b/skll/config.py
@@ -245,7 +245,7 @@ def _setup_config_parser(config_path, validate=True):
             config.remove_option('Tuning', 'objective')
         else:
             # else convert objective into objectives and delete objective
-            objective_value = yaml.load(_fix_json(objective_value))
+            objective_value = yaml.safe_load(_fix_json(objective_value), )
             if isinstance(objective_value, string_types):
                 config.set(
                     'Tuning', 'objectives', "['{}']".format(objective_value))
@@ -324,7 +324,7 @@ def _parse_config_file(config_path):
     else:
         raise ValueError("Configuration file does not contain list of learners "
                          "in [Input] section.")
-    learners = yaml.load(_fix_json(learners_string))
+    learners = yaml.safe_load(_fix_json(learners_string))
 
     if len(learners) == 0:
         raise ValueError("Configuration file contains an empty list of learners"
@@ -340,7 +340,7 @@ def _parse_config_file(config_path):
 
     # get the featuresets
     featuresets_string = config.get("Input", "featuresets")
-    featuresets = yaml.load(_fix_json(featuresets_string))
+    featuresets = yaml.safe_load(_fix_json(featuresets_string))
 
     # ensure that featuresets is either a list of features or a list of lists
     # of features
@@ -350,7 +350,7 @@ def _parse_config_file(config_path):
                          "features or a list of lists of features. You "
                          "specified: {}".format(featuresets))
 
-    featureset_names = yaml.load(_fix_json(config.get("Input",
+    featureset_names = yaml.safe_load(_fix_json(config.get("Input",
                                                       "featureset_names")))
 
     # ensure that featureset_names is a list of strings, if specified
@@ -365,12 +365,12 @@ def _parse_config_file(config_path):
     # do we need to shuffle the training data
     do_shuffle = config.getboolean("Input", "shuffle")
 
-    fixed_parameter_list = yaml.load(_fix_json(config.get("Input",
+    fixed_parameter_list = yaml.safe_load(_fix_json(config.get("Input",
                                                           "fixed_parameters")))
     fixed_sampler_parameters = _fix_json(config.get("Input",
                                                     "sampler_parameters"))
-    fixed_sampler_parameters = yaml.load(fixed_sampler_parameters)
-    param_grid_list = yaml.load(_fix_json(config.get("Tuning", "param_grids")))
+    fixed_sampler_parameters = yaml.safe_load(fixed_sampler_parameters)
+    param_grid_list = yaml.safe_load(_fix_json(config.get("Tuning", "param_grids")))
     pos_label_str = config.get("Tuning", "pos_label_str")
 
     # ensure that feature_scaling is specified only as one of the
@@ -462,7 +462,7 @@ def _parse_config_file(config_path):
 
     # Get class mapping dictionary if specified
     class_map_string = config.get("Input", "class_map")
-    original_class_map = yaml.load(_fix_json(class_map_string))
+    original_class_map = yaml.safe_load(_fix_json(class_map_string))
     if original_class_map:
         # Change class_map to map from originals to replacements instead of
         # from replacement to list of originals
@@ -523,7 +523,7 @@ def _parse_config_file(config_path):
 
     # what are the objective functions for the grid search?
     grid_objectives = config.get("Tuning", "objectives")
-    grid_objectives = yaml.load(_fix_json(grid_objectives))
+    grid_objectives = yaml.safe_load(_fix_json(grid_objectives))
     if not isinstance(grid_objectives, list):
         raise TypeError("objectives should be a "
                         "list of objectives")

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -139,7 +139,7 @@ def _write_summary_file(result_json_paths, output_file, ablation=0):
                 if ablation != 0 and '_minus_' in featureset_name:
                     parent_set = featureset_name.split('_minus_', 1)[0]
                     all_features[parent_set].update(
-                        yaml.load(obj[0]['featureset']))
+                        yaml.safe_load(obj[0]['featureset']))
                 learner_result_dicts.extend(obj)
 
     # Build and write header
@@ -158,7 +158,7 @@ def _write_summary_file(result_json_paths, output_file, ablation=0):
         if ablation != 0:
             parent_set = featureset_name.split('_minus_', 1)[0]
             ablated_features = all_features[parent_set].difference(
-                yaml.load(lrd['featureset']))
+                yaml.safe_load(lrd['featureset']))
             lrd['ablated_features'] = ''
             if ablated_features:
                 lrd['ablated_features'] = json.dumps(sorted(ablated_features))

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -179,9 +179,9 @@ def test_sparse_predict():
                                               'AdaBoostClassifier',
                                               'MultinomialNB',
                                               'KNeighborsClassifier'],
-                                             [(0.45, 0.51), (0.5, 0.51),
-                                              (0.46, 0.46), (0.5, 0.5),
-                                              (0.44, 0), (0.51, 0.43)]):
+                                             [(0.45, 0.52), (0.52, 0.5),
+                                              (0.48, 0.5), (0.49, 0.5),
+                                              (0.43, 0), (0.53, 0.57)]):
         yield check_sparse_predict, learner_name, expected_scores[0], False
         if learner_name != 'MultinomialNB':
             yield check_sparse_predict, learner_name, expected_scores[1], True
@@ -206,7 +206,7 @@ def check_sparse_predict_sampler(use_feature_hashing=False):
     learner.train(train_fs, grid_search=False)
     test_score = learner.evaluate(test_fs)[1]
 
-    expected_score = 0.44 if use_feature_hashing else 0.48999999999999999
+    expected_score = 0.48 if use_feature_hashing else 0.45
     assert_almost_equal(test_score, expected_score)
 
 
@@ -264,7 +264,7 @@ def test_train_file_test_file():
                                        '_file.jsonlines_RandomForestClassifier'
                                        '_accuracy.results.json'))) as f:
         result_dict = json.load(f)[0]
-    assert_almost_equal(result_dict['score'], 0.925)
+    assert_almost_equal(result_dict['score'], 0.95)
 
     # objective function f1
     with open(join(_my_dir, 'output', ('train_test_single_file_train_train_'
@@ -272,7 +272,7 @@ def test_train_file_test_file():
                                        '_file.jsonlines_RandomForestClassifier'
                                        '_f1.results.json'))) as f:
         result_dict = json.load(f)[0]
-    assert_almost_equal(result_dict['score'], 0.928)
+    assert_almost_equal(result_dict['score'], 0.9491525423728813)
 
 
 @raises(ValueError)
@@ -332,7 +332,7 @@ def test_adaboost_predict():
                                                                'SVC'],
                                                               ['SAMME.R', 'SAMME.R',
                                                                'SAMME', 'SAMME'],
-                                                              [0.45, 0.5, 0.45, 0.43]):
+                                                              [0.46, 0.52, 0.45, 0.5]):
         yield check_adaboost_predict, base_estimator_name, algorithm, expected_score
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -169,7 +169,7 @@ def check_summary_score(use_feature_hashing=False):
     # this line. See _print_fancy_output
     for report_name, val in (("LogisticRegression", .5),
                              ("MultinomialNB", .5),
-                             ("SVC", .7)):
+                             ("SVC", .6333)):
         filename = "test_summary_test_summary_{}.results".format(report_name)
         results_path = join(_my_dir, 'output', filename)
         with open(results_path) as results_file:

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -255,13 +255,13 @@ def check_scaling_features(use_feature_hashing=False, use_scaling=False):
 
     # these are the expected values of the f-measures, sorted
     if not use_feature_hashing:
-        expected_fmeasures = ([0.77319587628865982, 0.78640776699029125] if
+        expected_fmeasures = ([0.55276381909547745, 0.55721393034825872] if
                               not use_scaling else
-                              [0.94930875576036866, 0.93989071038251359])
+                              [0.65217391304347827, 0.70370370370370372])
     else:
-        expected_fmeasures = ([0.42774566473988435, 0.5638766519823788] if
+        expected_fmeasures = ([0.54255319148936176, 0.59433962264150941] if
                               not use_scaling else
-                              [0.87323943661971837, 0.85561497326203206])
+                              [0.69950738916256161, 0.69035532994923865])
 
     assert_almost_equal(expected_fmeasures, fmeasures)
 


### PR DESCRIPTION
- The major change in this version is that most the cross-validation and grid-search stuff has been moved to `sklearn.model_selection` AND the interface of the cross-validation generators has changed. They are no longer utterable directly but rather you have to initialize and then call the `.split()` method on them when you want the actual train/test indices.

- There are also some other major updates in the underlying algorithms themselves and in `make_classification()` which required changing the expected values in several of the tests. 

- I also address #231 by updating the F1-measure metrics in `metrics.py` and `__init__.py`.

- Finally, there are some minor changes like using `ruamel.yaml.safe_load()` instead of `ruamel.yaml.load()` since using the latter is no longer considered safe and raises warnings.