### PR TITLE
Update to scikit-learn v0.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then export PATH=/home/travis/miniconda2/bin:$PATH; else export PATH=/home/travis/miniconda3/bin:$PATH; fi
   - conda update --yes conda
 install:
-  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy beautifulsoup4 six scikit-learn==0.18.1 joblib prettytable python-coveralls ruamel.yaml
+  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy beautifulsoup4 six scikit-learn==0.19.0 joblib prettytable python-coveralls ruamel.yaml
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes --channel defaults configparser mock; fi
   - if [ ${WITH_PANDAS_AND_SEABORN} == "true" ]; then conda install --yes --channel defaults pandas seaborn; fi
   # Have to use pip for nose-cov because its entry points are not supported by conda yet

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.18.1
+scikit-learn==0.19.0
 six
 PrettyTable
 beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.18.1
+scikit-learn==0.19.0
 six
 PrettyTable
 beautifulsoup4

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,7 +1,7 @@
 configparser==3.5.0b2
 logutils
 mock
-scikit-learn==0.18.1
+scikit-learn==0.19.0
 six
 PrettyTable
 beautifulsoup4

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -771,6 +771,7 @@ class Learner(object):
 
             for i, label in enumerate(label_list):
                 coef = self.model.coef_[i]
+                coef = coef.reshape(1, -1)
                 coef = self.feat_selector.inverse_transform(coef)[0]
                 for feat, idx in iteritems(self.feat_vectorizer.vocabulary_):
                     if coef[idx]:


### PR DESCRIPTION
We only needed one very minor change to accommodate scikit-learn 0.19.1: which was that in  `learner.model_params`, we now call `reshape()` per sklearn's requirement on a 1D array before passing it to a method that expects a 2D array.

The rest of the changes are to the TravisCI config file and to the requirements files. I also tested the conda recipe with this version and it works fine though like with the python 3.6 switch, the change to the recipe will be pushed as part of the final release branch. 