### PR TITLE
Fix the example data creation scripts

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -16,7 +16,7 @@ things work, do the following from the command prompt:
 .. code-block:: bash
 
     $ cd examples
-    $ python make_example_iris_data.py          # download a simple dataset
+    $ python make_iris_example_data.py          # download a simple dataset
     $ cd iris
     $ run_experiment --local evaluate.cfg        # run an experiment
 

--- a/examples/make_boston_example_data.py
+++ b/examples/make_boston_example_data.py
@@ -16,7 +16,7 @@ import os
 import sys
 
 import sklearn.datasets
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 
 def main():

--- a/examples/make_iris_example_data.py
+++ b/examples/make_iris_example_data.py
@@ -15,7 +15,7 @@ import os
 import sys
 
 import sklearn.datasets
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 
 def main():

--- a/examples/make_titanic_example_data.py
+++ b/examples/make_titanic_example_data.py
@@ -53,9 +53,12 @@ def main():
         os.makedirs('titanic/test')
 
     # Read and write training FeatureSet
-    train_fs = Reader.for_path('train.csv', label_col='Survived',
-                               id_col='PassengerId', quiet=False,
+    train_fs = Reader.for_path('train.csv',
+                               label_col='Survived',
+                               id_col='PassengerId',
+                               quiet=False,
                                sparse=False).read()
+
     train_fs.filter(features=features_to_keep)
     num_train_dev = len(train_fs)
     num_train = int((num_train_dev / 5) * 4)
@@ -87,17 +90,20 @@ def main():
     writer.write()
 
     # Read and write test FeatureSet
-    test_fs = Reader.for_path('test.csv', label_col='Survived', quiet=False,
+    test_fs = Reader.for_path('test.csv',
+                              label_col='Survived',
+                              quiet=False,
                               sparse=False).read()
+
     test_fs.filter(features=features_to_keep)
     num_test = len(test_fs)
     test_fs.ids = list(range(num_train_dev + 1, num_test + num_train_dev + 1))
     writer = Writer.for_path('titanic/test/.csv',
-                                       test_fs,
-                                       label_col='Survived',
-                                       id_col='PassengerId',
-                                       quiet=False,
-                                       subsets=subset_dict)
+                             test_fs,
+                             label_col='Survived',
+                             id_col='PassengerId',
+                             quiet=False,
+                             subsets=subset_dict)
     writer.write()
 
 

--- a/examples/make_titanic_example_data.py
+++ b/examples/make_titanic_example_data.py
@@ -60,30 +60,30 @@ def main():
     num_train_dev = len(train_fs)
     num_train = int((num_train_dev / 5) * 4)
     writer = Writer.for_path('titanic/train/.csv',
-                                       train_fs[:num_train],
-                                       id_col='PassengerId',
-                                       label_col='Survived',
-                                       quiet=False,
-                                       subsets=subset_dict)
+                             train_fs[:num_train],
+                             id_col='PassengerId',
+                             label_col='Survived',
+                             quiet=False,
+                             subsets=subset_dict)
     writer.write()
 
     # Write train+dev set for training model to use to generate predictions on
     # test
     writer = Writer.for_path('titanic/train+dev/.csv',
-                                       train_fs,
-                                       label_col='Survived',
-                                       id_col='PassengerId',
-                                       quiet=False,
-                                       subsets=subset_dict)
+                             train_fs,
+                             label_col='Survived',
+                             id_col='PassengerId',
+                             quiet=False,
+                             subsets=subset_dict)
     writer.write()
 
     # Write dev FeatureSet
     writer = Writer.for_path('titanic/dev/.csv',
-                                       train_fs[num_train:],
-                                       label_col='Survived',
-                                       id_col='PassengerId',
-                                       quiet=False,
-                                       subsets=subset_dict)
+                             train_fs[num_train:],
+                             label_col='Survived',
+                             id_col='PassengerId',
+                             quiet=False,
+                             subsets=subset_dict)
     writer.write()
 
     # Read and write test FeatureSet

--- a/skll/data/featureset.py
+++ b/skll/data/featureset.py
@@ -127,13 +127,15 @@ class FeatureSet(object):
                 raise ValueError('FeatureSets can only be iterated through if '
                                  'they use a DictVectorizer for their feature '
                                  'vectorizer.')
-            for id_, label_, feats in zip(self.ids, self.labels,
-                                          self.features):
+            for id_, label_, feats in zip(self.ids, self.labels, self.features):
+
+                # convert feats to a 2D array since that's required
+                feats = feats.reshape(1, -1)
+
                 # When calling inverse_transform we have to add [0] to get the
                 # results for the current instance because it always returns a
                 # 2D array
-                yield (id_, label_,
-                       self.vectorizer.inverse_transform(feats)[0])
+                yield (id_, label_, self.vectorizer.inverse_transform(feats)[0])
         else:
             return
 
@@ -300,6 +302,8 @@ class FeatureSet(object):
             # Skip instances with labels not in filter
             if labels is not None and (label_ in labels) == inverse:
                 continue
+            # reshape the feature 1D array to make it 2D
+            feats = feats.reshape(1, -1)
             feat_dict = self.vectorizer.inverse_transform(feats)[0]
             if features is not None:
                 feat_dict = {name: value for name, value in

--- a/skll/data/featureset.py
+++ b/skll/data/featureset.py
@@ -129,8 +129,9 @@ class FeatureSet(object):
                                  'vectorizer.')
             for id_, label_, feats in zip(self.ids, self.labels, self.features):
 
-                # convert feats to a 2D array since that's required
-                feats = feats.reshape(1, -1)
+                # reshape to a 2D matrix if we are not using a sparse matrix
+                # to store the features
+                feats = feats.reshape(1, -1) if not sp.issparse(feats) else feats
 
                 # When calling inverse_transform we have to add [0] to get the
                 # results for the current instance because it always returns a
@@ -302,8 +303,10 @@ class FeatureSet(object):
             # Skip instances with labels not in filter
             if labels is not None and (label_ in labels) == inverse:
                 continue
-            # reshape the feature 1D array to make it 2D
-            feats = feats.reshape(1, -1)
+
+            # reshape to a 2D matrix if we are not using a sparse matrix
+            # to store the features
+            feats = feats.reshape(1, -1) if not sp.issparse(feats) else feats
             feat_dict = self.vectorizer.inverse_transform(feats)[0]
             if features is not None:
                 feat_dict = {name: value for name, value in

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -23,7 +23,7 @@ from io import open, BytesIO, StringIO
 import numpy as np
 from bs4 import UnicodeDammit
 from six import iteritems, PY2, PY3, string_types, text_type
-from six.moves import map, zip
+from six.moves import zip
 from sklearn.feature_extraction import FeatureHasher
 
 from skll.data import FeatureSet


### PR DESCRIPTION
- Fix bug in `FeatureSet` iteration methods that would have failed if we were storing the feature values in non-sparse matrices (e.g., by setting `sparse=False` in `Reader` methods).
- Rename all data creation scripts to be consistent in their naming (`make_<name>_example_data.py`).
- Fix imports in those scripts to be consistent with scikit-learn v0.19.
- Fix indentation and remove unneeded imports. 