### PR TITLE
Improve SKLL logging

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -1138,7 +1138,7 @@ In addition to the above log files that are specific to each "job"
 in the configuration file), SKLL also produces a single, top level "experiment"
 log file with only ``EXPERIMENT`` as the prefix. While the job-level log files
 contain messages that pertain to the specific characteristics of the job, the
-experiment-level log file will contains logging messages that pertain to the
+experiment-level log file will contain logging messages that pertain to the
 overall experiment and configuration file. The messages in the log files are
 in the following format:
 
@@ -1146,7 +1146,7 @@ in the following format:
 
     TIMESTAMP - LEVEL - MSG
 
-where ``TIMESTAMP`` refers to the exact time when the messages was logged,
+where ``TIMESTAMP`` refers to the exact time when the message was logged,
 ``LEVEL`` refers to the level of the logging message (e.g., ``INFO``, ``WARNING``,
 etc.), and ``MSG`` is the actual content of the message. All of the messages
 are also printed to the console in addition to being saved in the job-level log

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -1133,6 +1133,25 @@ the result, log, model, and prediction files will share the prefix
 ``EXPERIMENT_FEATURESET_LEARNER``. For backward-compatibility, the same
 applies when a single objective is specified using ``objective=x``.
 
+In addition to the above log files that are specific to each "job"
+(a specific combination of featuresets, learners, and objectives specified
+in the configuration file), SKLL also produces a single, top level "experiment"
+log file with only ``EXPERIMENT`` as the prefix. While the job-level log files
+contain messages that pertain to the specific characteristics of the job, the
+experiment-level log file will contains logging messages that pertain to the
+overall experiment and configuration file. The messages in the log files are
+in the following format:
+
+.. code-block:: bash
+
+    TIMESTAMP - LEVEL - MSG
+
+where ``TIMESTAMP`` refers to the exact time when the messages was logged,
+``LEVEL`` refers to the level of the logging message (e.g., ``INFO``, ``WARNING``,
+etc.), and ``MSG`` is the actual content of the message. All of the messages
+are also printed to the console in addition to being saved in the job-level log
+files and the experiment-level log file.
+
 For every experiment you run, there will also be a result summary file
 generated that is a tab-delimited file summarizing the results for each
 learner-featureset combination you have in your configuration file. It is named

--- a/skll/__init__.py
+++ b/skll/__init__.py
@@ -12,7 +12,7 @@ common scikit-learn experiments with pre-generated features.
 from __future__ import absolute_import, print_function, unicode_literals
 
 from sklearn.metrics import f1_score, make_scorer, SCORERS
-
+from .logutils import get_skll_logger
 from .data import FeatureSet, Reader, Writer
 from .experiments import run_configuration
 from .learner import Learner
@@ -22,7 +22,7 @@ from .metrics import (kappa, kendall_tau, spearman, pearson,
 
 __all__ = ['FeatureSet', 'Learner', 'Reader', 'kappa', 'kendall_tau',
            'spearman', 'pearson', 'f1_score_least_frequent',
-           'run_configuration', 'Writer']
+           'get_skll_logger', 'run_configuration', 'Writer']
 
 # Add our scorers to the sklearn dictionary here so that they will always be
 # available if you import anything from skll

--- a/skll/config.py
+++ b/skll/config.py
@@ -24,6 +24,7 @@ import numpy as np
 import ruamel.yaml as yaml
 
 from six import string_types, iteritems  # Python 2/3
+from skll import get_skll_logger
 from sklearn.metrics import SCORERS
 
 
@@ -269,13 +270,11 @@ def _setup_config_parser(config_path, validate=True):
     return config
 
 
-def _parse_config_file(config_path):
+def _parse_config_file(config_path, log_level=logging.INFO):
     """
     Parses a SKLL experiment configuration file with the given path.
+    Log messages with the given log level (default: INFO).
     """
-
-    # Initialize logger
-    logger = logging.getLogger(__name__)
 
     # check that config_path is not empty
     if config_path == "":
@@ -296,6 +295,26 @@ def _parse_config_file(config_path):
     else:
         raise ValueError("Configuration file does not contain experiment_name "
                          "in the [General] section.")
+
+    # next, get the log path before anything else since we need to
+    # save all logging messages to a log file in addition to displaying
+    # them on the console
+    log_path = _locate_file(config.get("Output", "log"), config_dir)
+    if log_path:
+        log_path = join(config_dir, log_path)
+        if not exists(log_path):
+            os.makedirs(log_path)
+
+    # Create a top-level log file under the log path
+    main_log_file =join(log_path, '{}.log'.format(experiment_name))
+
+    # Now create a SKLL logger that will log to this file as well
+    # as to the console. Use the log level provided - note that
+    # we only have to do this the first time we call `get_skll_logger()`
+    # with a given name.
+    logger = get_skll_logger('experiment',
+                             filepath=main_log_file,
+                             log_level=log_level)
 
     if config.has_option("General", "task"):
         task = config.get("General", "task")

--- a/skll/config.py
+++ b/skll/config.py
@@ -555,13 +555,6 @@ def _parse_config_file(config_path, log_level=logging.INFO):
         if not exists(prediction_dir):
             os.makedirs(prediction_dir)
 
-    # make sure log path exists
-    log_path = _locate_file(config.get("Output", "log"), config_dir)
-    if log_path:
-        log_path = join(config_dir, log_path)
-        if not exists(log_path):
-            os.makedirs(log_path)
-
     # make sure model path exists
     model_path = _locate_file(config.get("Output", "models"), config_dir)
     if model_path:

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -696,9 +696,9 @@ def safe_float(text, replace_dict=None, logger=None):
                          floats. Anything not in the mapping will be kept the
                          same.
     :type replace_dict: dict from str to str
-    :param text: The Logger instance to use to log messages. Used instead of
+    :param logger: The Logger instance to use to log messages. Used instead of
                  creating a new Logger instance by default.
-    :type text: logging.Logger
+    :type logger: logging.Logger
     """
 
     # convert to text to be "Safe"!

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -31,6 +31,7 @@ from six import iterkeys, iteritems  # Python 2/3
 from six.moves import zip
 from sklearn import __version__ as SCIKIT_VERSION
 
+from skll import get_skll_logger
 from skll.config import _munge_featureset_name, _parse_config_file
 from skll.data.readers import Reader
 from skll.learner import (Learner, MAX_CONCURRENT_PROCESSES,
@@ -143,7 +144,7 @@ def _write_summary_file(result_json_paths, output_file, ablation=0):
     learner_result_dicts = []
     # Map from feature set names to all features in them
     all_features = defaultdict(set)
-    logger = logging.getLogger(__name__)
+    logger = get_skll_logger('experiment')
     for json_path in result_json_paths:
         if not exists(json_path):
             logger.error(('JSON results file %s not found. Skipping summary '
@@ -167,7 +168,9 @@ def _write_summary_file(result_json_paths, output_file, ablation=0):
     if ablation != 0:
         header.add('ablated_features')
     header = sorted(header)
-    writer = csv.DictWriter(output_file, header, extrasaction='ignore',
+    writer = csv.DictWriter(output_file,
+                            header,
+                            extrasaction='ignore',
                             dialect=csv.excel_tab)
     writer.writeheader()
 
@@ -204,7 +207,7 @@ def _write_learning_curve_file(result_json_paths, output_file):
     learner_result_dicts = []
 
     # Map from feature set names to all features in them
-    logger = logging.getLogger(__name__)
+    logger = get_skll_logger('experiment')
     for json_path in result_json_paths:
         if not exists(json_path):
             logger.error(('JSON results file %s not found. Skipping summary '
@@ -341,7 +344,7 @@ def _print_fancy_output(learner_result_dicts, output_file=sys.stdout):
 
 def _load_featureset(dir_path, feat_files, suffix, id_col='id', label_col='y',
                      ids_to_floats=False, quiet=False, class_map=None,
-                     feature_hasher=False, num_features=None):
+                     feature_hasher=False, num_features=None, logger=None):
     """
     Load a list of feature files and merge them.
 
@@ -376,6 +379,9 @@ def _load_featureset(dir_path, feat_files, suffix, id_col='id', label_col='y',
                          This should always be set to the power of 2 greater
                          than the actual number of features you're using.
     :type num_features: int
+    :param logger: A logger instance to use to log messages instead of creating
+                   a new one by default.
+    :type logger: logging.Logger
 
     :returns: The labels, IDs, features, and feature vectorizer representing
               the given featureset.
@@ -384,20 +390,28 @@ def _load_featureset(dir_path, feat_files, suffix, id_col='id', label_col='y',
     # if the training file is specified via train_file, then dir_path
     # actually contains the entire file name
     if isfile(dir_path):
-        return Reader.for_path(dir_path, label_col=label_col, id_col=id_col,
-                               ids_to_floats=ids_to_floats, quiet=quiet,
+        return Reader.for_path(dir_path,
+                               label_col=label_col,
+                               id_col=id_col,
+                               ids_to_floats=ids_to_floats,
+                               quiet=quiet,
                                class_map=class_map,
                                feature_hasher=feature_hasher,
-                               num_features=num_features).read()
+                               num_features=num_features,
+                               logger=logger).read()
     else:
         merged_set = None
         for file_name in sorted(join(dir_path, featfile + suffix) for
                                 featfile in feat_files):
-            fs = Reader.for_path(file_name, label_col=label_col, id_col=id_col,
-                                 ids_to_floats=ids_to_floats, quiet=quiet,
+            fs = Reader.for_path(file_name,
+                                 label_col=label_col,
+                                 id_col=id_col,
+                                 ids_to_floats=ids_to_floats,
+                                 quiet=quiet,
                                  class_map=class_map,
                                  feature_hasher=feature_hasher,
-                                 num_features=num_features).read()
+                                 num_features=num_features,
+                                 logger=logger).read()
             if merged_set is None:
                 merged_set = fs
             else:
@@ -431,7 +445,8 @@ def _classify_featureset(args):
     grid_search = args.pop("grid_search")
     grid_objective = args.pop("grid_objective")
     suffix = args.pop("suffix")
-    log_path = args.pop("log_path")
+    job_log_file = args.pop("log_file")
+    job_log_level = args.pop("log_level")
     probability = args.pop("probability")
     results_path = args.pop("results_path")
     fixed_parameters = args.pop("fixed_parameters")
@@ -462,263 +477,271 @@ def _classify_featureset(args):
                           "{}").format(args.keys()))
     start_timestamp = datetime.datetime.now()
 
-    with open(log_path, 'w') as log_file:
-        # logging
-        print("Task:", task, file=log_file)
-        if task == 'cross_validate':
-            if isinstance(cv_folds, int):
-                num_folds = cv_folds
-            else:  # cv_folds_file was used, so count the unique fold ids.
-                num_folds = len(set(cv_folds.values()))
-            print(("Cross-validating ({} folds) on {}, feature " +
-                   "set {} ...").format(num_folds, train_set_name, featureset),
-                  file=log_file)
-        elif task == 'evaluate':
-            print(("Training on {}, Test on {}, " +
-                   "feature set {} ...").format(train_set_name, test_set_name,
-                                                featureset),
-                  file=log_file)
-        elif task == 'train':
-            print("Training on {}, feature set {} ...".format(train_set_name,
-                                                              featureset),
-                  file=log_file)
-        elif task == 'learning_curve':
-            print(("Generating learning curve "
-                   "({} 80/20 folds, sizes={}, objective={}) on {}, "
-                   "feature set {} ...").format(learning_curve_cv_folds,
+    # create a new SKLL logger for this specific job and
+    # use the given log level
+    logger = get_skll_logger(job_name,
+                             job_log_file,
+                             log_level=job_log_level)
+
+    # log messages
+    logger.info("Task: {}".format(task))
+    if task == 'cross_validate':
+        if isinstance(cv_folds, int):
+            num_folds = cv_folds
+        else:  # cv_folds_file was used, so count the unique fold ids.
+            num_folds = len(set(cv_folds.values()))
+        logger.info("Cross-validating ({} folds) on {}, feature "
+                    "set {} ...".format(num_folds,
+                                        train_set_name,
+                                        featureset))
+    elif task == 'evaluate':
+        logger.info("Training on {}, Test on {}, "
+                    "feature set {} ...".format(train_set_name,
+                                                test_set_name,
+                                                featureset))
+    elif task == 'train':
+        logger.info("Training on {}, feature set {} ...".format(train_set_name,
+                                                                featureset))
+    elif task == 'learning_curve':
+        logger.info("Generating learning curve "
+                    "({} 80/20 folds, sizes={}, objective={}) on {}, "
+                    "feature set {} ...".format(learning_curve_cv_folds,
                                                 learning_curve_train_sizes,
                                                 grid_objective,
                                                 train_set_name,
-                                                featureset),
-                  file=log_file)
-        else:  # predict
-            print(("Training on {}, Making predictions about {}, " +
-                   "feature set {} ...").format(train_set_name, test_set_name,
-                                                featureset),
-                  file=log_file)
+                                                featureset))
+    else:  # predict
+        logger.info("Training on {}, Making predictions about {}, "
+                    "feature set {} ...".format(train_set_name,
+                                                test_set_name,
+                                                featureset))
 
-        # check whether a trained model on the same data with the same
-        # featureset already exists if so, load it and then use it on test data
-        modelfile = join(model_path, '{}.model'.format(job_name))
-        if (task in ['cross_validate', 'learning_curve'] or
-            not exists(modelfile) or
-            overwrite):
-            train_examples = _load_featureset(train_path, featureset, suffix,
-                                              label_col=label_col,
-                                              id_col=id_col,
-                                              ids_to_floats=ids_to_floats,
-                                              quiet=quiet, class_map=class_map,
-                                              feature_hasher=feature_hasher,
-                                              num_features=hasher_features)
+    # check whether a trained model on the same data with the same
+    # featureset already exists if so, load it and then use it on test data
+    modelfile = join(model_path, '{}.model'.format(job_name))
+    if (task in ['cross_validate', 'learning_curve'] or
+        not exists(modelfile) or
+        overwrite):
+        train_examples = _load_featureset(train_path,
+                                          featureset,
+                                          suffix,
+                                          label_col=label_col,
+                                          id_col=id_col,
+                                          ids_to_floats=ids_to_floats,
+                                          quiet=quiet,
+                                          class_map=class_map,
+                                          feature_hasher=feature_hasher,
+                                          num_features=hasher_features,
+                                          logger=logger)
 
-            train_set_size = len(train_examples.ids)
-            if not train_examples.has_labels:
-                raise ValueError('Training examples do not have labels')
-            # initialize a classifer object
-            learner = Learner(learner_name,
-                              probability=probability,
-                              feature_scaling=feature_scaling,
-                              model_kwargs=fixed_parameters,
-                              pos_label_str=pos_label_str,
-                              min_feature_count=min_feature_count,
-                              sampler=sampler,
-                              sampler_kwargs=sampler_parameters,
-                              custom_learner_path=custom_learner_path)
-        # load the model if it already exists
-        else:
-            # import the custom learner path here in case we are reusing a
-            # saved model
-            if custom_learner_path:
-                _import_custom_learner(custom_learner_path, learner_name)
-            train_set_size = 'unknown'
-            if exists(modelfile) and not overwrite:
-                print(('\tloading pre-existing %s model: %s') % (learner_name,
-                                                                 modelfile))
-            learner = Learner.from_file(modelfile)
+        train_set_size = len(train_examples.ids)
+        if not train_examples.has_labels:
+            raise ValueError('Training examples do not have labels')
+        # initialize a classifer object
+        learner = Learner(learner_name,
+                          probability=probability,
+                          feature_scaling=feature_scaling,
+                          model_kwargs=fixed_parameters,
+                          pos_label_str=pos_label_str,
+                          min_feature_count=min_feature_count,
+                          sampler=sampler,
+                          sampler_kwargs=sampler_parameters,
+                          custom_learner_path=custom_learner_path,
+                          logger=logger)
+    # load the model if it already exists
+    else:
+        # import the custom learner path here in case we are reusing a
+        # saved model
+        if custom_learner_path:
+            _import_custom_learner(custom_learner_path, learner_name)
+        train_set_size = 'unknown'
+        if exists(modelfile) and not overwrite:
+            logger.info("\tloading pre-existing {} model: {}".format(learner_name,
+                                                                     modelfile))
+        learner = Learner.from_file(modelfile)
 
-        # Load test set if there is one
-        if task == 'evaluate' or task == 'predict':
-            test_examples = _load_featureset(test_path, featureset, suffix,
-                                             label_col=label_col,
-                                             id_col=id_col,
-                                             ids_to_floats=ids_to_floats,
-                                             quiet=quiet, class_map=class_map,
-                                             feature_hasher=feature_hasher,
-                                             num_features=hasher_features)
-            test_set_size = len(test_examples.ids)
-        else:
-            test_set_size = 'n/a'
+        # attach the job logger to this learner
+        learner.logger = logger
 
-        # compute information about xval and grid folds that can be put in results
-        # in readable form
-        if isinstance(cv_folds, dict):
-            cv_folds_to_print = '{} via folds file'.format(len(set(cv_folds.values())))
-        else:
-            cv_folds_to_print = str(cv_folds)
+    # Load test set if there is one
+    if task == 'evaluate' or task == 'predict':
+        test_examples = _load_featureset(test_path, featureset, suffix,
+                                         label_col=label_col,
+                                         id_col=id_col,
+                                         ids_to_floats=ids_to_floats,
+                                         quiet=quiet, class_map=class_map,
+                                         feature_hasher=feature_hasher,
+                                         num_features=hasher_features)
+        test_set_size = len(test_examples.ids)
+    else:
+        test_set_size = 'n/a'
 
-        if isinstance(grid_search_folds, dict):
-            grid_search_folds_to_print = '{} via folds file'.format(len(set(grid_search_folds.values())))
-        else:
-            grid_search_folds_to_print = str(grid_search_folds)
+    # compute information about xval and grid folds that can be put in results
+    # in readable form
+    if isinstance(cv_folds, dict):
+        cv_folds_to_print = '{} via folds file'.format(len(set(cv_folds.values())))
+    else:
+        cv_folds_to_print = str(cv_folds)
+
+    if isinstance(grid_search_folds, dict):
+        grid_search_folds_to_print = '{} via folds file'.format(len(set(grid_search_folds.values())))
+    else:
+        grid_search_folds_to_print = str(grid_search_folds)
 
 
-        # create a list of dictionaries of the results information
-        learner_result_dict_base = {'experiment_name': experiment_name,
-                                    'train_set_name': train_set_name,
-                                    'train_set_size': train_set_size,
-                                    'test_set_name': test_set_name,
-                                    'test_set_size': test_set_size,
-                                    'featureset': json.dumps(featureset),
-                                    'featureset_name': featureset_name,
-                                    'shuffle': shuffle,
-                                    'learner_name': learner_name,
-                                    'task': task,
-                                    'start_timestamp':
-                                    start_timestamp.strftime('%d %b %Y %H:%M:'
-                                                             '%S.%f'),
-                                    'version': __version__,
-                                    'feature_scaling': feature_scaling,
-                                    'folds_file': folds_file,
-                                    'grid_search': grid_search,
-                                    'grid_objective': grid_objective,
-                                    'grid_search_folds': grid_search_folds_to_print,
-                                    'min_feature_count': min_feature_count,
-                                    'cv_folds': cv_folds_to_print,
-                                    'using_folds_file': isinstance(cv_folds, dict) \
-                                                         or isinstance(grid_search_folds, dict),
-                                    'save_cv_folds': save_cv_folds,
-                                    'use_folds_file_for_grid_search': use_folds_file_for_grid_search,
-                                    'stratified_folds': stratified_folds,
-                                    'scikit_learn_version': SCIKIT_VERSION}
+    # create a list of dictionaries of the results information
+    learner_result_dict_base = {'experiment_name': experiment_name,
+                                'train_set_name': train_set_name,
+                                'train_set_size': train_set_size,
+                                'test_set_name': test_set_name,
+                                'test_set_size': test_set_size,
+                                'featureset': json.dumps(featureset),
+                                'featureset_name': featureset_name,
+                                'shuffle': shuffle,
+                                'learner_name': learner_name,
+                                'task': task,
+                                'start_timestamp':
+                                start_timestamp.strftime('%d %b %Y %H:%M:'
+                                                         '%S.%f'),
+                                'version': __version__,
+                                'feature_scaling': feature_scaling,
+                                'folds_file': folds_file,
+                                'grid_search': grid_search,
+                                'grid_objective': grid_objective,
+                                'grid_search_folds': grid_search_folds_to_print,
+                                'min_feature_count': min_feature_count,
+                                'cv_folds': cv_folds_to_print,
+                                'using_folds_file': isinstance(cv_folds, dict) \
+                                                     or isinstance(grid_search_folds, dict),
+                                'save_cv_folds': save_cv_folds,
+                                'use_folds_file_for_grid_search': use_folds_file_for_grid_search,
+                                'stratified_folds': stratified_folds,
+                                'scikit_learn_version': SCIKIT_VERSION}
 
-        # check if we're doing cross-validation, because we only load/save
-        # models when we're not.
-        task_results = None
-        if task == 'cross_validate':
-            print('\tcross-validating', file=log_file)
-            (task_results,
-             grid_scores,
-             skll_fold_ids) = learner.cross_validate(train_examples,
-                                                     shuffle=shuffle,
-                                                     stratified=stratified_folds,
-                                                     prediction_prefix=prediction_prefix,
-                                                     grid_search=grid_search,
-                                                     grid_search_folds=grid_search_folds,
-                                                     cv_folds=cv_folds,
-                                                     grid_objective=grid_objective,
-                                                     param_grid=param_grid,
-                                                     grid_jobs=grid_search_jobs,
-                                                     save_cv_folds=save_cv_folds,
-                                                     use_custom_folds_for_grid_search=use_folds_file_for_grid_search)
-        elif task == 'learning_curve':
-            print('\tgenerating learning curve', file=log_file)
-            (curve_train_scores,
-             curve_test_scores,
-             computed_curve_train_sizes) = learner.learning_curve(train_examples,
-                                                                  cv_folds=learning_curve_cv_folds,
-                                                                  train_sizes=learning_curve_train_sizes,
-                                                                  objective=grid_objective)
-        else:
-            # if we have do not have a saved model, we need to train one.
-            if not exists(modelfile) or overwrite:
-                print(('\tfeaturizing and training new ' +
-                       '{} model').format(learner_name),
-                      file=log_file)
-
-                best_score = learner.train(train_examples,
-                                           shuffle=shuffle,
-                                           grid_search=grid_search,
-                                           grid_search_folds=grid_search_folds,
-                                           grid_objective=grid_objective,
-                                           param_grid=param_grid,
-                                           grid_jobs=grid_search_jobs)
-                grid_scores = [best_score]
-
-                # save model
-                if model_path:
-                    learner.save(modelfile)
-
-                if grid_search:
-                    # note: bankers' rounding is used in python 3,
-                    # so these scores may be different between runs in
-                    # python 2 and 3 at the final decimal place.
-                    print('\tbest {} grid search score: {}'
-                          .format(grid_objective, round(best_score, 3)),
-                          file=log_file)
-            else:
-                grid_scores = [None]
-
-            # print out the tuned parameters and best CV score
-            param_out = ('{}: {}'.format(param_name, param_value)
-                         for param_name, param_value in
-                         iteritems(learner.model.get_params()))
-            print('\thyperparameters: {}'.format(', '.join(param_out)),
-                  file=log_file)
-
-            # run on test set or cross-validate on training data,
-            # depending on what was asked for
-            if task == 'evaluate':
-                print('\tevaluating predictions', file=log_file)
-                task_results = [learner.evaluate(test_examples,
+    # check if we're doing cross-validation, because we only load/save
+    # models when we're not.
+    task_results = None
+    if task == 'cross_validate':
+        logger.info("\tcross-validating")
+        (task_results,
+         grid_scores,
+         skll_fold_ids) = learner.cross_validate(train_examples,
+                                                 shuffle=shuffle,
+                                                 stratified=stratified_folds,
                                                  prediction_prefix=prediction_prefix,
-                                                 grid_objective=grid_objective)]
-            elif task == 'predict':
-                print('\twriting predictions', file=log_file)
-                learner.predict(test_examples,
-                                prediction_prefix=prediction_prefix)
-            # do nothing here for train
+                                                 grid_search=grid_search,
+                                                 grid_search_folds=grid_search_folds,
+                                                 cv_folds=cv_folds,
+                                                 grid_objective=grid_objective,
+                                                 param_grid=param_grid,
+                                                 grid_jobs=grid_search_jobs,
+                                                 save_cv_folds=save_cv_folds,
+                                                 use_custom_folds_for_grid_search=use_folds_file_for_grid_search)
+    elif task == 'learning_curve':
+        logger.info("\tgenerating learning curve")
+        (curve_train_scores,
+         curve_test_scores,
+         computed_curve_train_sizes) = learner.learning_curve(train_examples,
+                                                              cv_folds=learning_curve_cv_folds,
+                                                              train_sizes=learning_curve_train_sizes,
+                                                              objective=grid_objective)
+    else:
+        # if we have do not have a saved model, we need to train one.
+        if not exists(modelfile) or overwrite:
+            logger.info("\tfeaturizing and training new {} model".format(learner_name))
 
-        end_timestamp = datetime.datetime.now()
-        learner_result_dict_base['end_timestamp'] = end_timestamp.strftime(
-            '%d %b %Y %H:%M:%S.%f')
-        total_time = end_timestamp - start_timestamp
-        learner_result_dict_base['total_time'] = str(total_time)
+            best_score = learner.train(train_examples,
+                                       shuffle=shuffle,
+                                       grid_search=grid_search,
+                                       grid_search_folds=grid_search_folds,
+                                       grid_objective=grid_objective,
+                                       param_grid=param_grid,
+                                       grid_jobs=grid_search_jobs)
+            grid_scores = [best_score]
 
-        if task == 'cross_validate' or task == 'evaluate':
-            results_json_path = join(results_path,
-                                     '{}.results.json'.format(job_name))
+            # save model
+            if model_path:
+                learner.save(modelfile)
 
-            res = _create_learner_result_dicts(task_results,
-                                               grid_scores,
-                                               learner_result_dict_base)
-
-            # write out the result dictionary to a json file
-            file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
-            with open(results_json_path, file_mode) as json_file:
-                json.dump(res, json_file, cls=NumpyTypeEncoder)
-
-            with open(join(results_path,
-                           '{}.results'.format(job_name)),
-                      'w') as output_file:
-                _print_fancy_output(res, output_file)
-        elif task == 'learning_curve':
-            results_json_path = join(results_path,
-                                     '{}.results.json'.format(job_name))
-
-            res = {}
-            res.update(learner_result_dict_base)
-            res.update({'learning_curve_cv_folds': learning_curve_cv_folds,
-                        'given_curve_train_sizes': learning_curve_train_sizes,
-                        'learning_curve_train_scores_means': np.mean(curve_train_scores, axis=1),
-                        'learning_curve_test_scores_means': np.mean(curve_test_scores, axis=1),
-                        'learning_curve_train_scores_stds': np.std(curve_train_scores, axis=1, ddof=1),
-                        'learning_curve_test_scores_stds': np.std(curve_test_scores, axis=1, ddof=1),
-                        'computed_curve_train_sizes': computed_curve_train_sizes})
-
-            # write out the result dictionary to a json file
-            file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
-            with open(results_json_path, file_mode) as json_file:
-                json.dump([res], json_file, cls=NumpyTypeEncoder)
+            if grid_search:
+                # note: bankers' rounding is used in python 3,
+                # so these scores may be different between runs in
+                # python 2 and 3 at the final decimal place.
+                logger.info("\tbest {} grid search score: {}".format(grid_objective,
+                                                                     round(best_score, 3)))
         else:
-            res = [learner_result_dict_base]
+            grid_scores = [None]
 
-        # write out the cv folds if required
-        if task == 'cross_validate' and save_cv_folds:
-            skll_fold_ids_file = experiment_name + '_skll_fold_ids.csv'
-            file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
-            with open(join(results_path, skll_fold_ids_file),
-                      file_mode) as output_file:
-                _write_skll_folds(skll_fold_ids, output_file)
+        # print out the tuned parameters and best CV score
+        param_out = ('{}: {}'.format(param_name, param_value)
+                     for param_name, param_value in
+                     iteritems(learner.model.get_params()))
+        logger.info("\thyperparameters: {}".format(', '.join(param_out)))
+
+        # run on test set or cross-validate on training data,
+        # depending on what was asked for
+        if task == 'evaluate':
+            logger.info("\tevaluating predictions")
+            task_results = [learner.evaluate(test_examples,
+                                             prediction_prefix=prediction_prefix,
+                                             grid_objective=grid_objective)]
+        elif task == 'predict':
+            logger.info("\twriting predictions")
+            learner.predict(test_examples,
+                            prediction_prefix=prediction_prefix)
+        # do nothing here for train
+
+    end_timestamp = datetime.datetime.now()
+    learner_result_dict_base['end_timestamp'] = end_timestamp.strftime(
+        '%d %b %Y %H:%M:%S.%f')
+    total_time = end_timestamp - start_timestamp
+    learner_result_dict_base['total_time'] = str(total_time)
+
+    if task == 'cross_validate' or task == 'evaluate':
+        results_json_path = join(results_path,
+                                 '{}.results.json'.format(job_name))
+
+        res = _create_learner_result_dicts(task_results,
+                                           grid_scores,
+                                           learner_result_dict_base)
+
+        # write out the result dictionary to a json file
+        file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
+        with open(results_json_path, file_mode) as json_file:
+            json.dump(res, json_file, cls=NumpyTypeEncoder)
+
+        with open(join(results_path,
+                       '{}.results'.format(job_name)),
+                  'w') as output_file:
+            _print_fancy_output(res, output_file)
+    elif task == 'learning_curve':
+        results_json_path = join(results_path,
+                                 '{}.results.json'.format(job_name))
+
+        res = {}
+        res.update(learner_result_dict_base)
+        res.update({'learning_curve_cv_folds': learning_curve_cv_folds,
+                    'given_curve_train_sizes': learning_curve_train_sizes,
+                    'learning_curve_train_scores_means': np.mean(curve_train_scores, axis=1),
+                    'learning_curve_test_scores_means': np.mean(curve_test_scores, axis=1),
+                    'learning_curve_train_scores_stds': np.std(curve_train_scores, axis=1, ddof=1),
+                    'learning_curve_test_scores_stds': np.std(curve_test_scores, axis=1, ddof=1),
+                    'computed_curve_train_sizes': computed_curve_train_sizes})
+
+        # write out the result dictionary to a json file
+        file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
+        with open(results_json_path, file_mode) as json_file:
+            json.dump([res], json_file, cls=NumpyTypeEncoder)
+    else:
+        res = [learner_result_dict_base]
+
+    # write out the cv folds if required
+    if task == 'cross_validate' and save_cv_folds:
+        skll_fold_ids_file = experiment_name + '_skll_fold_ids.csv'
+        file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
+        with open(join(results_path, skll_fold_ids_file),
+                  file_mode) as output_file:
+            _write_skll_folds(skll_fold_ids, output_file)
 
     return res
 
@@ -847,7 +870,7 @@ def _create_learner_result_dicts(task_results,
 
 def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
                       hosts=None, write_summary=True, quiet=False,
-                      ablation=0, resume=False):
+                      ablation=0, resume=False, log_level=logging.INFO):
     """
     Takes a configuration file and runs the specified jobs on the grid.
 
@@ -879,14 +902,14 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
                    overwrite them. This is very useful when doing a large
                    ablation experiment and part of it crashes.
     :type resume: bool
+    :param log_level: The level for logging messages (default: INFO)
+    :type log_level: str
 
     :return: A list of paths to .json results files for each variation in the
              experiment.
     :rtype: list of str
 
     """
-    # Initialize logger
-    logger = logging.getLogger(__name__)
 
     # Read configuration
     (experiment_name, task, sampler, fixed_sampler_parameters, feature_hasher,
@@ -897,7 +920,12 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
      use_folds_file_for_grid_search, do_stratified_folds, fixed_parameter_list,
      param_grid_list, featureset_names, learners, prediction_dir, log_path, train_path,
      test_path, ids_to_floats, class_map, custom_learner_path, learning_curve_cv_folds_list,
-     learning_curve_train_sizes) = _parse_config_file(config_file)
+     learning_curve_train_sizes) = _parse_config_file(config_file, log_level=log_level)
+
+    # get the main experiment logger that will already have been
+    # created by the configuration parser so we don't need anything
+    # except the name `experiment`.
+    logger = get_skll_logger('experiment')
 
     # Check if we have gridmap
     if not local and not _HAVE_GRIDMAP:
@@ -975,6 +1003,8 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
                           ' auto-generated name would be longer than the file '
                           'system can handle'.format(featureset_name))
 
+
+
     # Run each featureset-learner-objective combination
     for featureset, featureset_name in zip(featuresets, featureset_names):
         for learner_num, learner_name in enumerate(learners):
@@ -1033,7 +1063,8 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
                 job_args["grid_search"] = do_grid_search
                 job_args["grid_objective"] = grid_objective
                 job_args["suffix"] = suffix
-                job_args["log_path"] = logfile
+                job_args["log_file"] = logfile
+                job_args["log_level"] = log_level
                 job_args["probability"] = probability
                 job_args["results_path"] = results_path
                 job_args["sampler_parameters"] = (fixed_sampler_parameters
@@ -1065,11 +1096,13 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
                 job_args["learning_curve_train_sizes"] = learning_curve_train_sizes
 
                 if not local:
-                    jobs.append(Job(_classify_featureset, [job_args],
+                    jobs.append(Job(_classify_featureset,
+                                    [job_args],
                                     num_slots=(MAX_CONCURRENT_PROCESSES if
                                                (do_grid_search or
                                                 task == 'learning_curve') else 1),
-                                    name=job_name, queue=queue))
+                                    name=job_name,
+                                    queue=queue))
                 else:
                     _classify_featureset(job_args)
     test_set_name = basename(test_path)
@@ -1087,8 +1120,7 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
     if (task == 'cross_validate' or task == 'evaluate') and write_summary:
         summary_file_name = experiment_name + '_summary.tsv'
         file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
-        with open(join(results_path, summary_file_name),
-                  file_mode) as output_file:
+        with open(join(results_path, summary_file_name), file_mode) as output_file:
             _write_summary_file(result_json_paths,
                                 output_file,
                                 ablation=ablation)
@@ -1116,7 +1148,7 @@ def _check_job_results(job_results):
     """
     See if we have a complete results dictionary for every job.
     """
-    logger = logging.getLogger(__name__)
+    logger = get_skll_logger('experiment')
     logger.info('Checking job results')
     for result_dicts in job_results:
         if not result_dicts or 'task' not in result_dicts[0]:

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -996,7 +996,7 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
 
                 # the log file that stores the actual output of this script (e.g.,
                 # the tuned parameters, what kind of experiment was run, etc.)
-                temp_logfile = join(log_path, '{}.log'.format(job_name))
+                logfile = join(log_path, '{}.log'.format(job_name))
 
                 # Figure out result json file path
                 result_json_path = join(results_path,
@@ -1033,7 +1033,7 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
                 job_args["grid_search"] = do_grid_search
                 job_args["grid_objective"] = grid_objective
                 job_args["suffix"] = suffix
-                job_args["log_path"] = temp_logfile
+                job_args["log_path"] = logfile
                 job_args["probability"] = probability
                 job_args["results_path"] = results_path
                 job_args["sampler_parameters"] = (fixed_sampler_parameters

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -556,8 +556,8 @@ def _classify_featureset(args):
             _import_custom_learner(custom_learner_path, learner_name)
         train_set_size = 'unknown'
         if exists(modelfile) and not overwrite:
-            logger.info("\tloading pre-existing {} model: {}".format(learner_name,
-                                                                     modelfile))
+            logger.info("Loading pre-existing {} model: {}".format(learner_name,
+                                                                   modelfile))
         learner = Learner.from_file(modelfile)
 
         # attach the job logger to this learner
@@ -622,7 +622,7 @@ def _classify_featureset(args):
     # models when we're not.
     task_results = None
     if task == 'cross_validate':
-        logger.info("\tcross-validating")
+        logger.info("Cross-validating")
         (task_results,
          grid_scores,
          skll_fold_ids) = learner.cross_validate(train_examples,
@@ -638,7 +638,7 @@ def _classify_featureset(args):
                                                  save_cv_folds=save_cv_folds,
                                                  use_custom_folds_for_grid_search=use_folds_file_for_grid_search)
     elif task == 'learning_curve':
-        logger.info("\tgenerating learning curve")
+        logger.info("Generating learning curve(s)")
         (curve_train_scores,
          curve_test_scores,
          computed_curve_train_sizes) = learner.learning_curve(train_examples,
@@ -648,7 +648,7 @@ def _classify_featureset(args):
     else:
         # if we have do not have a saved model, we need to train one.
         if not exists(modelfile) or overwrite:
-            logger.info("\tfeaturizing and training new {} model".format(learner_name))
+            logger.info("Featurizing and training new {} model".format(learner_name))
 
             best_score = learner.train(train_examples,
                                        shuffle=shuffle,
@@ -667,8 +667,8 @@ def _classify_featureset(args):
                 # note: bankers' rounding is used in python 3,
                 # so these scores may be different between runs in
                 # python 2 and 3 at the final decimal place.
-                logger.info("\tbest {} grid search score: {}".format(grid_objective,
-                                                                     round(best_score, 3)))
+                logger.info("Best {} grid search score: {}".format(grid_objective,
+                                                                   round(best_score, 3)))
         else:
             grid_scores = [None]
 
@@ -676,17 +676,17 @@ def _classify_featureset(args):
         param_out = ('{}: {}'.format(param_name, param_value)
                      for param_name, param_value in
                      iteritems(learner.model.get_params()))
-        logger.info("\thyperparameters: {}".format(', '.join(param_out)))
+        logger.info("Hyperparameters: {}".format(', '.join(param_out)))
 
         # run on test set or cross-validate on training data,
         # depending on what was asked for
         if task == 'evaluate':
-            logger.info("\tevaluating predictions")
+            logger.info("Evaluating predictions")
             task_results = [learner.evaluate(test_examples,
                                              prediction_prefix=prediction_prefix,
                                              grid_objective=grid_objective)]
         elif task == 'predict':
-            logger.info("\twriting predictions")
+            logger.info("Writing predictions")
             learner.predict(test_examples,
                             prediction_prefix=prediction_prefix)
         # do nothing here for train

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -902,7 +902,9 @@ class Learner(object):
         learner_dir = os.path.dirname(learner_path)
         if not os.path.exists(learner_dir):
             os.makedirs(learner_dir)
-        # write out the files
+        # write out the files but loggers can't be pickled
+        # so delete the logger instance before pickling
+        del self.logger
         joblib.dump((VERSION, self), learner_path)
 
     def _create_estimator(self):

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -213,7 +213,6 @@ class FilteredLeaveOneGroupOut(LeaveOneGroupOut):
         self.keep = keep
         self.example_ids = example_ids
         self._warned = False
-        self.logger = logging.getLogger(__name__)
 
     def split(self, X, y, groups):
         for train_index, test_index in super(FilteredLeaveOneGroupOut,
@@ -629,7 +628,8 @@ class Learner(object):
 
     def __init__(self, model_type, probability=False, feature_scaling='none',
                  model_kwargs=None, pos_label_str=None, min_feature_count=1,
-                 sampler=None, sampler_kwargs=None, custom_learner_path=None):
+                 sampler=None, sampler_kwargs=None, custom_learner_path=None,
+                 logger=None):
         """
         Initializes a learner object with the specified settings.
         """
@@ -646,6 +646,7 @@ class Learner(object):
         self._min_feature_count = min_feature_count
         self._model_kwargs = {}
         self._sampler_kwargs = {}
+        self.logger = logger if logger else logging.getLogger(__name__)
 
         if model_type not in globals():
             # here, we need to import the custom model and add it
@@ -678,11 +679,10 @@ class Learner(object):
             self._model_kwargs['cache_size'] = 1000
             self._model_kwargs['probability'] = self.probability
             if self.probability:
-                logger = logging.getLogger(__name__)
-                logger.warning('Because LibSVM does an internal ' +
-                               'cross-validation to produce probabilities, ' +
-                               'results will not be exactly replicable when ' +
-                               'using SVC and probability mode.')
+                self.logger.warning('Because LibSVM does an internal '
+                                    'cross-validation to produce probabilities, '
+                                    'results will not be exactly replicable when '
+                                    'using SVC and probability mode.')
         elif issubclass(self._model_type,
                         (RandomForestClassifier, RandomForestRegressor,
                          GradientBoostingClassifier, GradientBoostingRegressor,
@@ -887,10 +887,8 @@ class Learner(object):
         # LinearSVC doesn't support predict_proba
         self._probability = value
         if not hasattr(self.model_type, "predict_proba") and value:
-            logger = logging.getLogger(__name__)
-            logger.warning(("probability was set to True, but {} does not have"
-                            " a predict_proba() method.")
-                           .format(self.model_type))
+            self.logger.warning("Probability was set to True, but {} does not have "
+                                "a predict_proba() method.".format(self.model_type.__name__))
             self._probability = False
 
     def save(self, learner_path):
@@ -940,18 +938,16 @@ class Learner(object):
                 raise TypeError("You have feature values that are strings.  "
                                 "Convert them to floats.")
 
-    @staticmethod
-    def _check_max_feature_value(feat_array):
+    def _check_max_feature_value(self, feat_array):
         """
         Check if the the maximum absolute value of any feature is too large
         """
         max_feat_abs = np.max(np.abs(feat_array.data))
         if max_feat_abs > 1000.0:
-            logger = logging.getLogger(__name__)
-            logger.warning(("You have a feature with a very large absolute " +
-                            "value (%s).  That may cause the learning " +
-                            "algorithm to crash or perform " +
-                            "poorly."), max_feat_abs)
+            self.logger.warning("You have a feature with a very large absolute "
+                                "value ({}).  That may cause the learning "
+                                "algorithm to crash or perform "
+                                "poorly.".format(max_feat_abs))
 
     def _create_label_dict(self, examples):
         """
@@ -1054,7 +1050,6 @@ class Learner(object):
                  not doing grid search.
         :rtype: float
         """
-        logger = logging.getLogger(__name__)
 
         # if we are asked to do grid search, check that the grid objective
         # function is valid for the selected learner
@@ -1109,9 +1104,9 @@ class Learner(object):
         # we make a copy of everything (and then get rid of the old version)
         if grid_search or shuffle:
             if grid_search and not shuffle:
-                logger.warning('Training data will be shuffled to randomize '
-                               'grid search folds.  Shuffling may yield '
-                               'different results compared to scikit-learn.')
+                self.logger.warning('Training data will be shuffled to randomize '
+                                    'grid search folds.  Shuffling may yield '
+                                    'different results compared to scikit-learn.')
             ids, labels, features = sk_shuffle(examples.ids, examples.labels,
                                                examples.features,
                                                random_state=123456789)
@@ -1158,9 +1153,9 @@ class Learner(object):
 
         # Sampler
         if self.sampler:
-            logger.warning('Sampler converts sparse matrix to dense')
+            self.logger.warning('Sampler converts sparse matrix to dense')
             if isinstance(self.sampler, SkewedChi2Sampler):
-                logger.warning('SkewedChi2Sampler uses a dense matrix')
+                self.logger.warning('SkewedChi2Sampler uses a dense matrix')
                 xtrain = self.sampler.fit_transform(xtrain.todense())
             else:
                 xtrain = self.sampler.fit_transform(xtrain)
@@ -1181,11 +1176,11 @@ class Learner(object):
         # then there's no point doing the grid search at all
         if grid_search and not param_grid:
             if default_param_grid == [{}]:
-                logger.warning("SKLL has no default parameter grid "
-                               "available for the {} learner and no "
-                               "parameter grids were supplied. Using "
-                               "default values instead of grid "
-                               "search.".format(self._model_type.__name__))
+                self.logger.warning("SKLL has no default parameter grid "
+                                    "available for the {} learner and no "
+                                    "parameter grids were supplied. Using "
+                                    "default values instead of grid "
+                                    "search.".format(self._model_type.__name__))
                 grid_search = False
             else:
                 param_grid = default_param_grid
@@ -1368,7 +1363,6 @@ class Learner(object):
         :return: The predictions returned by the learner.
         :rtype: array
         """
-        logger = logging.getLogger(__name__)
         example_ids = examples.ids
 
         # Need to do some transformations so the features are in the right
@@ -1377,8 +1371,8 @@ class Learner(object):
         if isinstance(self.feat_vectorizer, FeatureHasher):
             if (self.feat_vectorizer.n_features !=
                     examples.vectorizer.n_features):
-                logger.warning("There is mismatch between the training model "
-                               "features and the data passed to predict.")
+                self.logger.warning("There is mismatch between the training model "
+                                    "features and the data passed to predict.")
 
             self_feat_vec_tuple = (self.feat_vectorizer.dtype,
                                    self.feat_vectorizer.input_type,
@@ -1398,8 +1392,8 @@ class Learner(object):
         else:
             if (set(self.feat_vectorizer.feature_names_) !=
                     set(examples.vectorizer.feature_names_)):
-                logger.warning("There is mismatch between the training model "
-                               "features and the data passed to predict.")
+                self.logger.warning("There is mismatch between the training model "
+                                    "features and the data passed to predict.")
             if self.feat_vectorizer == examples.vectorizer:
                 xtest = examples.features
             else:
@@ -1413,9 +1407,9 @@ class Learner(object):
 
         # Sampler
         if self.sampler:
-            logger.warning('Sampler converts sparse matrix to dense')
+            self.logger.warning('Sampler converts sparse matrix to dense')
             if isinstance(self.sampler, SkewedChi2Sampler):
-                logger.warning('SkewedChi2Sampler uses a dense matrix')
+                self.logger.warning('SkewedChi2Sampler uses a dense matrix')
                 xtest = self.sampler.fit_transform(xtest.todense())
             else:
                 xtest = self.sampler.fit_transform(xtest)
@@ -1446,8 +1440,11 @@ class Learner(object):
                         not class_labels)
                     else self._model.predict(xtest))
         except NotImplementedError as e:
-            logger.error("Model type: %s\nModel: %s\nProbability: %s\n",
-                         self._model_type.__name__, self._model, self.probability)
+            self.logger.error("Model type: {}\n"
+                              "Model: {}\n"
+                              "Probability: {}\n".format(self._model_type.__name__,
+                                                         self._model,
+                                                         self.probability))
             raise e
 
         # write out the predictions if we are asked to
@@ -1503,10 +1500,9 @@ class Learner(object):
             raise ValueError(('The training set has only {} example for a' +
                               ' label.').format(min_examples_per_label))
         if min_examples_per_label < cv_folds:
-            logger = logging.getLogger(__name__)
-            logger.warning('The minimum number of examples per label was %s.  '
-                           'Setting the number of cross-validation folds to '
-                           'that value.', min_examples_per_label)
+            self.logger.warning('The minimum number of examples per label was {}. '
+                                'Setting the number of cross-validation folds to '
+                                'that value.'.format(min_examples_per_label))
             cv_folds = min_examples_per_label
         return cv_folds
 
@@ -1579,8 +1575,6 @@ class Learner(object):
         # Seed the random number generator so that randomized algorithms are
         # replicable.
         random_state = np.random.RandomState(123456789)
-        # Set up logger.
-        logger = logging.getLogger(__name__)
 
         # Shuffle so that the folds are random for the inner grid search CV.
         # If grid search is True but shuffle isn't, shuffle anyway.
@@ -1588,9 +1582,9 @@ class Learner(object):
         # we make a copy of everything (and then get rid of the old version)
         if grid_search or shuffle:
             if grid_search and not shuffle:
-                logger.warning('Training data will be shuffled to randomize '
-                               'grid search folds. Shuffling may yield '
-                               'different results compared to scikit-learn.')
+                self.logger.warning('Training data will be shuffled to randomize '
+                                    'grid search folds. Shuffling may yield '
+                                    'different results compared to scikit-learn.')
             ids, labels, features = sk_shuffle(examples.ids, examples.labels,
                                                examples.features,
                                                random_state=random_state)
@@ -1634,8 +1628,8 @@ class Learner(object):
             # when we are using the API; otherwise the configparser should
             # take care of this even before this method is called
             if grid_search and use_custom_folds_for_grid_search and grid_search_folds != cv_folds:
-                logger.warning("The specified custom folds will be used for "
-                               "the inner grid search.")
+                self.logger.warning("The specified custom folds will be used for "
+                                    "the inner grid search.")
                 grid_search_folds = cv_folds
 
         # Save the cross-validation fold information, if required
@@ -1733,9 +1727,6 @@ class Learner(object):
         # Seed the random number generator so that randomized algorithms are
         # replicable.
         random_state = np.random.RandomState(123456789)
-
-        # Set up logger.
-        logger = logging.getLogger(__name__)
 
         # Call train setup before since we need to train
         # the learner eventually

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -891,6 +891,15 @@ class Learner(object):
                                 "a predict_proba() method.".format(self.model_type.__name__))
             self._probability = False
 
+    def __getstate__(self):
+        """
+        Return the attributes that should be pickled. We need this
+        because we cannot pickle loggers.
+        """
+        attribute_dict = dict(self.__dict__)
+        del attribute_dict['logger']
+        return attribute_dict
+
     def save(self, learner_path):
         """
         Save the learner to a file.
@@ -902,9 +911,7 @@ class Learner(object):
         learner_dir = os.path.dirname(learner_path)
         if not os.path.exists(learner_dir):
             os.makedirs(learner_dir)
-        # write out the files but loggers can't be pickled
-        # so delete the logger instance before pickling
-        del self.logger
+        # write out the learner to disk
         joblib.dump((VERSION, self), learner_path)
 
     def _create_estimator(self):

--- a/skll/logutils.py
+++ b/skll/logutils.py
@@ -8,8 +8,6 @@ Functions related to logging in SKLL.
 import logging
 from logging import FileHandler
 
-_INSTANTIATED_SKLL_LOGGERS = {}
-
 def get_skll_logger(name, filepath=None, log_level=logging.INFO):
     """
     Create and return logger instances that are appropriate for use

--- a/skll/logutils.py
+++ b/skll/logutils.py
@@ -1,0 +1,53 @@
+# License: BSD 3 clause
+"""
+Functions related to logging in SKLL.
+
+:author: Nitin Madnani (nmadnani@ets.org)
+"""
+
+import logging
+from logging import FileHandler
+
+_INSTANTIATED_SKLL_LOGGERS = {}
+
+def get_skll_logger(name, filepath=None, log_level=logging.INFO):
+    """
+    Create and return logger instances that are appropriate for use
+    in SKLL code, e.g., that they can log to both STDERR as well
+    as a file. This function will try to reuse any previously created
+    logger based on the given name and filepath.
+
+    Parameters
+    ----------
+    name : str
+        The name to be used for the logger.
+    filepath : str, optional
+        The file to be used for the logger via a FileHandler.
+        Default: None in which case no file is attached to the
+        logger.
+
+    Returns
+    -------
+    logging.Logger
+        A Logger instance.
+    """
+
+    # first get the logger instance associated with the
+    # given name if one already exists
+    logger = logging.getLogger(name)
+
+    # if we are given a file path and this existing logger doesn't already
+    # have a file handler for this file, then add one.
+    if filepath:
+        is_file_handler = lambda handler: isinstance(handler, FileHandler) \
+                                                and handler.stream.name == filepath
+        need_file_handler = not any([is_file_handler(handler) for handler in logger.handlers])
+        if need_file_handler:
+            formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+            file_handler = logging.FileHandler(filepath, mode='w')
+            file_handler.setFormatter(formatter)
+            file_handler.setLevel(log_level)
+            logger.addHandler(file_handler)
+
+    # return the logger instance
+    return logger

--- a/skll/metrics.py
+++ b/skll/metrics.py
@@ -76,10 +76,9 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
     try:
         y_true = [int(np.round(float(y))) for y in y_true]
         y_pred = [int(np.round(float(y))) for y in y_pred]
-    except ValueError as e:
+    except ValueError:
         raise ValueError("For kappa, the labels should be integers or strings "
                          "that can be converted to ints (E.g., '4.0' or '3').")
-        raise e
 
     # Figure out normalized expected values
     min_rating = min(min(y_true), min(y_pred))

--- a/skll/metrics.py
+++ b/skll/metrics.py
@@ -11,8 +11,6 @@ evaluate the performance of learners.
 
 from __future__ import print_function, unicode_literals
 
-import logging
-
 import numpy as np
 from scipy.stats import kendalltau, spearmanr, pearsonr
 from six import string_types
@@ -63,7 +61,6 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
                              for when building the weights matrix.
     :type allow_off_by_one: bool
     """
-    logger = logging.getLogger(__name__)
 
     # Ensure that the lists are both the same length
     assert(len(y_true) == len(y_pred))
@@ -80,8 +77,8 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
         y_true = [int(np.round(float(y))) for y in y_true]
         y_pred = [int(np.round(float(y))) for y in y_pred]
     except ValueError as e:
-        logger.error("For kappa, the labels should be integers or strings "
-                     "that can be converted to ints (E.g., '4.0' or '3').")
+        raise ValueError("For kappa, the labels should be integers or strings "
+                         "that can be converted to ints (E.g., '4.0' or '3').")
         raise e
 
     # Figure out normalized expected values

--- a/skll/utilities/run_experiment.py
+++ b/skll/utilities/run_experiment.py
@@ -28,61 +28,72 @@ def main(argv=None):
     :type argv: list of str
     """
     # Get command line arguments
-    parser = argparse.ArgumentParser(
-        description="Runs the scikit-learn experiments in a given config file.\
-                     If Grid Map is installed, jobs will automatically be \
-                     created and run on a DRMAA-compatible cluster.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        conflict_handler='resolve')
+    parser = argparse.ArgumentParser(description='Runs the scikit-learn '
+                                                 'experiments in a given config file. '
+                                                 'If Grid Map is installed, jobs will '
+                                                 'automatically be created and run on '
+                                                 'a DRMAA-compatible cluster.',
+                                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                                 conflict_handler='resolve')
     parser.add_argument('config_file',
-                        help='Configuration file describing the sklearn task\
-                              to run.',
+                        help='Configuration file describing the task to run.',
                         nargs='+')
-    parser.add_argument('-a', '--ablation',
-                        help='Runs an ablation study where repeated \
-                              experiments are conducted where the specified \
-                              number of features in each featureset in the \
-                              configuration file are held out.',
-                        type=int, default=0,
+    parser.add_argument('-a',
+                        '--ablation',
+                        help='Runs an ablation study where repeated '
+                             'experiments are conducted where the specified '
+                             'number of features in each featureset in the '
+                             'configuration file are held out.',
+                        type=int,
+                        default=0,
                         metavar='NUM_FEATURES')
-    parser.add_argument('-A', '--ablation_all',
-                        help='Runs an ablation study where repeated \
-                              experiments are conducted with all combinations \
-                              of features in each featureset in the \
-                              configuration file. Overrides --ablation \
-                              setting.',
+    parser.add_argument('-A',
+                        '--ablation_all',
+                        help='Runs an ablation study where repeated '
+                             'experiments are conducted with all combinations '
+                             'of features in each featureset in the '
+                             'configuration file. Overrides --ablation '
+                             'setting.',
                         action='store_true')
-    parser.add_argument('-k', '--keep_models',
-                        help='If trained models already exists, re-use them\
-                              instead of overwriting them.',
+    parser.add_argument('-k',
+                        '--keep_models',
+                        help='If trained models already exists, re-use them '
+                             'instead of overwriting them.',
                         action='store_true')
-    parser.add_argument('-l', '--local',
-                        help='Do not use the Grid Engine for running jobs and\
-                              just run everything sequentially on the local \
-                              machine. This is for debugging.',
+    parser.add_argument('-l',
+                        '--local',
+                        help='Do not use the Grid Engine for running jobs and '
+                             'just run everything sequentially on the local '
+                             'machine. ',
                         action='store_true')
-    parser.add_argument('-m', '--machines',
-                        help="comma-separated list of machines to add to\
-                              gridmap's whitelist (if not specified, all\
-                              available machines are used). Note that full \
-                              names must be specified, e.g., \
-                              \"nlp.research.ets.org\"",
+    parser.add_argument('-m',
+                        '--machines',
+                        help='comma-separated list of machines to add to '
+                             'the gridmap whitelist (if not specified, all '
+                             'available machines are used). Note that full '
+                             'names must be specified, e.g., '
+                             '"nlp.research.ets.org"',
                         default=None)
-    parser.add_argument('-q', '--queue',
+    parser.add_argument('-q',
+                        '--queue',
                         help="Use this queue for gridmap.",
                         default='all.q')
-    parser.add_argument('-r', '--resume',
-                        help='If result files already exist for an experiment, \
-                              do not overwrite them. This is very useful when \
-                              doing a large ablation experiment and part of it \
-                              crashes.',
+    parser.add_argument('-r',
+                        '--resume',
+                        help='If result files already exist for an experiment '
+                             'do not overwrite them. This is very useful when '
+                             'doing a large ablation experiment and part of it '
+                             'crashes.',
                         action='store_true')
-    parser.add_argument('-v', '--verbose',
-                        help='Print more status information. For every ' +
-                             'additional time this flag is specified, ' +
+    parser.add_argument('-v',
+                        '--verbose',
+                        help='Include debug information. For every '
+                             'additional time this flag is specified, '
                              'output gets more verbose.',
-                        default=0, action='count')
-    parser.add_argument('--version', action='version',
+                        default=0,
+                        action='count')
+    parser.add_argument('--version',
+                        action='version',
                         version='%(prog)s {0}'.format(__version__))
     args = parser.parse_args(argv)
 

--- a/skll/utilities/run_experiment.py
+++ b/skll/utilities/run_experiment.py
@@ -12,8 +12,9 @@ config file.
 
 from __future__ import print_function, unicode_literals
 
-import argparse
 import logging
+
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 from skll.experiments import run_configuration
 from skll.version import __version__
@@ -28,13 +29,13 @@ def main(argv=None):
     :type argv: list of str
     """
     # Get command line arguments
-    parser = argparse.ArgumentParser(description='Runs the scikit-learn '
-                                                 'experiments in a given config file. '
-                                                 'If Grid Map is installed, jobs will '
-                                                 'automatically be created and run on '
-                                                 'a DRMAA-compatible cluster.',
-                                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-                                                 conflict_handler='resolve')
+    parser = ArgumentParser(description='Runs the scikit-learn '
+                                        'experiments in a given config file. '
+                                        'If Grid Map is installed, jobs will '
+                                        'automatically be created and run on '
+                                        'a DRMAA-compatible cluster.',
+                            formatter_class=ArgumentDefaultsHelpFormatter,
+                            conflict_handler='resolve')
     parser.add_argument('config_file',
                         help='Configuration file describing the task to run.',
                         nargs='+')

--- a/skll/utilities/run_experiment.py
+++ b/skll/utilities/run_experiment.py
@@ -87,18 +87,17 @@ def main(argv=None):
                         action='store_true')
     parser.add_argument('-v',
                         '--verbose',
-                        help='Include debug information. For every '
-                             'additional time this flag is specified, '
-                             'output gets more verbose.',
-                        default=0,
-                        action='count')
+                        help='Include debug information in the logging output.',
+                        default=False,
+                        action='store_true')
     parser.add_argument('--version',
                         action='version',
                         version='%(prog)s {0}'.format(__version__))
     args = parser.parse_args(argv)
 
-    # Logging levels are really integer multiples of 10, so convert verbose flag
-    log_level = max(logging.WARNING - (args.verbose * 10), logging.DEBUG)
+    # Default logging level is INFO unless we are being verbose
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+
     # Make warnings from built-in warnings module get formatted more nicely
     logging.captureWarnings(True)
     logging.basicConfig(format=('%(asctime)s - %(name)s - %(levelname)s - ' +
@@ -114,9 +113,14 @@ def main(argv=None):
 
     # Run each config file sequentially
     for config_file in args.config_file:
-        run_configuration(config_file, local=args.local, overwrite=not
-                          args.keep_models, queue=args.queue, hosts=machines,
-                          ablation=ablation, resume=args.resume)
+        run_configuration(config_file,
+                          local=args.local,
+                          overwrite=not args.keep_models,
+                          queue=args.queue,
+                          hosts=machines,
+                          ablation=ablation,
+                          resume=args.resume,
+                          log_level=log_level)
 
 
 if __name__ == '__main__':

--- a/tests/configs/test_folds_file_grid.template.cfg
+++ b/tests/configs/test_folds_file_grid.template.cfg
@@ -1,0 +1,16 @@
+[General]
+experiment_name = test_folds_file_logging
+task=cross_validate
+
+[Input]
+featuresets=[["test_save_cv_folds"]]
+learners=["LogisticRegression"]
+suffix=.jsonlines
+cv_folds_file = ../train/folds_file_test.csv
+
+[Tuning]
+grid_search=True
+use_folds_file_for_grid_search=False
+
+[Output]
+results=output

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -273,27 +273,65 @@ def test_retrieve_cv_folds():
     assert_equal(skll_fold_ids, custom_cv_folds)
 
 
-def test_folds_file_logging():
+def test_folds_file_logging_num_folds():
     """
     Test that, when `folds_file` is used, the log prints the number of folds,
-     instead of the entire cv_folds data.
+     instead of the entire cv_folds data. And that the folds file warning shows up
+     in the log file.
     """
     # Run experiment
     suffix = '.jsonlines'
     train_path = join(_my_dir, 'train', 'f0{}'.format(suffix))
 
-    config_path = fill_in_config_paths_for_single_file(join(_my_dir, "configs",
+    config_path = fill_in_config_paths_for_single_file(join(_my_dir,
+                                                            "configs",
                                                             "test_folds_file"
                                                             ".template.cfg"),
                                                        train_path,
                                                        None)
     run_configuration(config_path, quiet=True)
 
-    # Check log output
-    with open(join(_my_dir, 'output', 'test_folds_file_logging_train_f0.' +
-            'jsonlines_LogisticRegression.log')) as f:
-        cv_folds_pattern = re.compile("Task: cross_validate\nCross-validating \([0-9]+ folds\)")
+    # Check experiment log output
+    with open(join(_my_dir,
+                   'output',
+                   'test_folds_file_logging.log')) as f:
+        cv_file_pattern = re.compile('Specifying "folds_file" overrides both explicit and default "num_cv_folds".')
+        matches = re.findall(cv_file_pattern, f.read())
+        assert_equal(len(matches), 1)
+
+    # Check job log output
+    with open(join(_my_dir,
+                   'output',
+                   'test_folds_file_logging_train_f0.'
+                   'jsonlines_LogisticRegression.log')) as f:
+        cv_folds_pattern = re.compile("(Task: cross_validate\n)(.+)(Cross-validating \([0-9]+ folds\))")
         matches = re.findall(cv_folds_pattern, f.read())
+        assert_equal(len(matches), 1)
+
+
+def test_folds_file_logging_grid_search():
+    """
+    Test that, when `folds_file` is used but `use_folds_file` for grid search
+    is specified, that we get an appropriate message in the log.
+    """
+    # Run experiment
+    suffix = '.jsonlines'
+    train_path = join(_my_dir, 'train', 'f0{}'.format(suffix))
+
+    config_path = fill_in_config_paths_for_single_file(join(_my_dir,
+                                                            "configs",
+                                                            "test_folds_file_grid"
+                                                            ".template.cfg"),
+                                                       train_path,
+                                                       None)
+    run_configuration(config_path, quiet=True)
+
+    # Check experiment log output
+    with open(join(_my_dir,
+                   'output',
+                   'test_folds_file_logging.log')) as f:
+        cv_file_pattern = re.compile('Specifying "folds_file" overrides both explicit and default "num_cv_folds".\n(.+)The specified "folds_file" will not be used for inner grid search.')
+        matches = re.findall(cv_file_pattern, f.read())
         assert_equal(len(matches), 1)
 
 

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -65,9 +65,12 @@ def tearDown():
     output_dir = join(_my_dir, 'output')
     config_dir = join(_my_dir, 'configs')
 
-    cfg_file = join(config_dir, 'test_save_cv_folds.cfg')
-    if exists(cfg_file):
-        os.unlink(cfg_file)
+    cfg_files = [join(config_dir, 'test_save_cv_folds.cfg'),
+                 join(config_dir, 'test_folds_file.cfg'),
+                 join(config_dir, 'test_folds_file_grid.cfg')]
+    for cfg_file in cfg_files:
+        if exists(cfg_file):
+            os.unlink(cfg_file)
 
     for output_file in (glob(join(output_dir,
                                   'test_save_cv_folds_*')) +


### PR DESCRIPTION
The goal of this PR is to improve how logging works in SKLL. The current situation is that many, if not all, of the warning messages are logged to the console but never stored in any of the log files. This is not great since a lot of people may not pay attention to the console messages. 

In an ideal situation, the solution would be quite simple. The way that `logging` works is that `logging.getLogger(<name>)` _always_ returns the same logger instance no matter where that call is made _as long as_ the call is within the same Python interpreter process. However, the problem is that SKLL jobs can also run on other machines in completely different Python processes. 

The solution in this PR works as follows:

1. I create a function called `get_skll_logger()` that returns a `Logger` instance that can log messages both to the `sys.stderr` as well as to a specified file. Repeated invocations of `get_skll_logger()` with the same name (and the same file path) will return the same `Logger` instance. 

2. `get_skll_logger()` is first called from `config.py` to create an experiment-level logger where messages that are relevant to configuration parsing are logged. It is called again from `experiments.py` at the top level to log messages (to the _same_ `Logger` instance) about the _whole_ experiment (not the individual jobs). This logger writes to the console as well as to a file named `<experiment_name>.log` that is automatically created in the `log` directory.

3. `get_skll_logger()` is called a third time from inside `_classify_featureset()`. This is a second `Logger `instance that is at the individual job level (where job = featureset + learner + objective). All of the messages from `learner.py`, `readers.py`, and `writers.py` are logged by this logger. This logger writes to the console as well as to the files named `<job_name>.log` that SKLL already creates in the `log` directory.

4. So, at the end of the experiment, there is (a) `<experiment_name>.log` containing messages pertaining to configuration parsing as well as the top-level experiment, and (b) multiple `<job_name>.log` files containing messages specific to each job.

**Notes**:

- To get `Learner`, `Reader`, and `Writer` to log to the same job log file, I had to modify them to accept loggers as keyword arguments. 

- Although the console output shows the logger names (`"experiment"` for the main logger and `<job_name>` for the job logger(s)), the log files themselves just show the time stamps, the logging level, and the actual message. This is because the names of the files themselves tell you what is what.

- I also had to pass in logger arguments to some top-level functions for things to work perfectly and make a one of the static methods be a regular method instead. 

- I changed the default logging level for SKLL to be `INFO` rather than warnings since the INFO messages are actually quite useful. The `-v` flag for `run_experiment` changes the logging level to include DEBUG messages as well. 

- I ran several tests both on and off the grid and the log files are created properly and with the right messages. However, I encourage you to run some tests (e.g., the SKLL examples) yourself.

- I added a couple of tests that look at the new log files.