### PR TITLE
Decouple evaluation metrics from tuning objectives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,9 @@ like:
   objectives = ['accuracy']
 
   [Output]
-  # again, these can/should be absolute paths
+  # Also compute the area under the ROC curve as an additional metric
+  metrics = ['roc_auc']
+  # The following can/should be absolute paths
   log = output
   results = output
   predictions = output

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -838,7 +838,9 @@ Regression:
 
 Defaults to ``['f1_score_micro']``.
 
-**Note**: Using ``objective=x`` instead of ``objectives=['x']`` is also acceptable, for backward-compatibility.
+.. note::
+    1. Using ``objective=x`` instead of ``objectives=['x']`` is also acceptable, for backward-compatibility.
+    2. Also see the :ref:`metrics <metrics>` option below.
 
 .. _param_grids:
 
@@ -985,6 +987,26 @@ results *(Optional)*
 
 Directory to store result files in. If omitted, the current working
 directory is used.
+
+.. _metrics:
+
+metrics *(Optional)*
+""""""""""""""""""""
+For the ``evaluate`` and ``cross_validate`` tasks, this is a list of
+additional metrics that will be computed *in addition to* the tuning
+objectives and added to the results files. For the ``learning_curve`` task,
+this will be the list of metrics for which the learning curves
+will be plotted. Can take all of the same functions as those
+available for the :ref:`tuning objectives <objectives>`.
+
+.. note::
+
+    1. For learning curves, ``metrics`` can be specified instead of
+       ``objectives`` since both serve the same purpose. If both are
+       specified, ``objectives`` will be ignored.
+    2. For the ``evaluate`` and ``cross_validate`` tasks,  any functions
+       that are specified in both ``metrics`` and  ``objectives``
+       are assumed to be the latter.
 
 .. _log:
 

--- a/examples/titanic/evaluate_tuned.cfg
+++ b/examples/titanic/evaluate_tuned.cfg
@@ -18,6 +18,7 @@ objectives = ['accuracy']
 
 [Output]
 # again, these can be absolute paths
+metrics = ['roc_auc']
 log = output
 results = output
 predictions = output

--- a/skll/config.py
+++ b/skll/config.py
@@ -70,6 +70,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                     'min_feature_count': '1',
                     'models': '',
                     'num_cv_folds': '10',
+                    'metrics': "[]",
                     'objectives': "['f1_score_micro']",
                     'objective': "f1_score_micro",
                     'param_grids': '[]',
@@ -109,6 +110,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                                    'learning_curve_cv_folds_list': 'Input',
                                    'learning_curve_train_sizes': 'Input',
                                    'min_feature_count': 'Tuning',
+                                   'metrics': 'Output',
                                    'models': 'Output',
                                    'num_cv_folds': 'Input',
                                    'objectives': 'Tuning',
@@ -380,7 +382,7 @@ def _parse_config_file(config_path, log_level=logging.INFO):
                          "specified: {}".format(featuresets))
 
     featureset_names = yaml.safe_load(_fix_json(config.get("Input",
-                                                      "featureset_names")))
+                                                           "featureset_names")))
 
     # ensure that featureset_names is a list of strings, if specified
     if featureset_names:
@@ -569,6 +571,12 @@ def _parse_config_file(config_path, log_level=logging.INFO):
         if not exists(results_path):
             os.makedirs(results_path)
 
+    # what are the output metrics?
+    output_metrics = config.get("Output", "metrics")
+    output_metrics = _parse_and_validate_metrics(output_metrics,
+                                                     'metrics',
+                                                     logger=logger)
+
     # 4. Tuning
     # do we need to run a grid search for the hyperparameters or are we just
     # using the defaults?
@@ -592,22 +600,9 @@ def _parse_config_file(config_path, log_level=logging.INFO):
 
     # what are the objective functions for the grid search?
     grid_objectives = config.get("Tuning", "objectives")
-    grid_objectives = yaml.safe_load(_fix_json(grid_objectives))
-    if not isinstance(grid_objectives, list):
-        raise TypeError("objectives should be a "
-                        "list of objectives")
-
-    # `mean_squared_error` should be replaced with `neg_mean_squared_error`
-    if 'mean_squared_error' in grid_objectives:
-        logger.warning("The objective function \"mean_squared_error\" "
-                       "is deprecated and will be removed in the next "
-                       "release, please use the function "
-                       "\"neg_mean_squared_error\" instead.")
-        grid_objectives[grid_objectives.index('mean_squared_error')] = 'neg_mean_squared_error'
-
-    if not all([objective in SCORERS for objective in grid_objectives]):
-        raise ValueError('Invalid grid objective function(s): {}'
-                         .format(grid_objectives))
+    grid_objectives = _parse_and_validate_metrics(grid_objectives,
+                                                  'objectives',
+                                                  logger=logger)
 
     # check whether the right things are set for the given task
     if (task == 'evaluate' or task == 'predict') and not test_path:
@@ -627,6 +622,35 @@ def _parse_config_file(config_path, log_level=logging.INFO):
     if task in ['cross_validate', 'learning_curve'] and model_path:
         raise ValueError('The models path should not be set when task is '
                          '{}.'.format(task))
+    if task == 'learning_curve':
+        if len(grid_objectives) > 0 and len(output_metrics) == 0:
+            logger.warning("The \"objectives\" option "
+                           "is deprecated for the learning_curve "
+                           "task and will not be supported "
+                           "starting with the next release; please "
+                           "use the \"metrics\" option in the [Output] "
+                           "section instead.")
+        elif len(grid_objectives) == 0 and len(output_metrics) == 0:
+            raise ValueError('The "metrics" option must be set when '
+                             'the task is "learning_curve".')
+        elif len(grid_objectives) > 0 and len(output_metrics) > 0:
+            logger.warning("Ignoring \"objectives\" for the learning_curve "
+                           "task since \"metrics\" is already specified.")
+            grid_objectives = []
+    elif task in ['evaluate', 'cross_validate']:
+        # for other appropriate tasks, if metrics and objectives have
+        # some overlaps - we will assume that the user meant to include
+        # use the metric for tuning _and_ evaluation, not just evaluation
+        if (len(grid_objectives) > 0 and
+            len(output_metrics) > 0):
+            common_metrics_and_objectives = set(grid_objectives).intersection(output_metrics)
+            if common_metrics_and_objectives:
+                logger.warning('The following are specified both as '
+                               'objective functions and evaluation metrics: {}. '
+                               'They will be used as the '
+                               'former.'.format(common_metrics_and_objectives))
+                output_metrics = [metric for metric in output_metrics
+                                  if metric not in common_metrics_and_objectives]
 
     # set the folds appropriately based on the task:
     #  (a) if the task is `train` and if an external fold mapping is specified
@@ -678,7 +702,7 @@ def _parse_config_file(config_path, log_level=logging.INFO):
             param_grid_list, featureset_names, learners, prediction_dir,
             log_path, train_path, test_path, ids_to_floats, class_map,
             custom_learner_path, learning_curve_cv_folds_list,
-            learning_curve_train_sizes)
+            learning_curve_train_sizes, output_metrics)
 
 
 def _munge_featureset_name(featureset):
@@ -702,6 +726,37 @@ def _fix_json(json_string):
     json_string = json_string.replace('False', 'false')
     json_string = json_string.replace("'", '"')
     return json_string
+
+
+def _parse_and_validate_metrics(metrics, option_name, logger=None):
+    """
+    Given a string containing a list of metrics, this function parses
+    that string into a list and validates the given list.
+    """
+
+    # create a logger if one was not passed in
+    if not logger:
+        logger = logging.getLogger(__name__)
+
+    # what are the objective functions for the grid search?
+    metrics = yaml.safe_load(_fix_json(metrics))
+    if not isinstance(metrics, list):
+        raise TypeError("{} should be a list".format(option_name))
+
+    # `mean_squared_error` should be replaced with `neg_mean_squared_error`
+    if 'mean_squared_error' in metrics:
+        logger.warning("The metric \"mean_squared_error\" "
+                       "is deprecated and will be removed in the next "
+                       "release, please use the metric "
+                       "\"neg_mean_squared_error\" instead.")
+        metrics[metrics.index('mean_squared_error')] = 'neg_mean_squared_error'
+
+    invalid_metrics = [metric for metric in metrics if metric not in SCORERS]
+    if invalid_metrics:
+        raise ValueError('Invalid metric(s) {} '
+                         'specified for {}'.format(invalid_metrics, option_name))
+
+    return metrics
 
 
 def _load_cv_folds(folds_file, ids_to_floats=False):

--- a/skll/config.py
+++ b/skll/config.py
@@ -627,7 +627,7 @@ def _parse_config_file(config_path, log_level=logging.INFO):
             logger.warning("The \"objectives\" option "
                            "is deprecated for the learning_curve "
                            "task and will not be supported "
-                           "starting with the next release; please "
+                           "after the next release; please "
                            "use the \"metrics\" option in the [Output] "
                            "section instead.")
             output_metrics = grid_objectives
@@ -641,7 +641,7 @@ def _parse_config_file(config_path, log_level=logging.INFO):
             grid_objectives = []
     elif task in ['evaluate', 'cross_validate']:
         # for other appropriate tasks, if metrics and objectives have
-        # some overlaps - we will assume that the user meant to include
+        # some overlaps - we will assume that the user meant to
         # use the metric for tuning _and_ evaluation, not just evaluation
         if (len(grid_objectives) > 0 and
             len(output_metrics) > 0):

--- a/skll/config.py
+++ b/skll/config.py
@@ -630,6 +630,8 @@ def _parse_config_file(config_path, log_level=logging.INFO):
                            "starting with the next release; please "
                            "use the \"metrics\" option in the [Output] "
                            "section instead.")
+            output_metrics = grid_objectives
+            grid_objectives = []
         elif len(grid_objectives) == 0 and len(output_metrics) == 0:
             raise ValueError('The "metrics" option must be set when '
                              'the task is "learning_curve".')

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -307,6 +307,9 @@ def _print_fancy_output(learner_result_dicts, output_file=sys.stdout):
         lrd['cv_folds'].endswith('folds file')):
         print('Using Folds File for Grid Search: {}'.format(lrd['use_folds_file_for_grid_search']),
               file=output_file)
+    if lrd['task'] in ['evaluate', 'cross_validate'] and lrd['additional_scores']:
+        print('Additional Evaluation Metrics: {}'.format(list(lrd['additional_scores'].keys())),
+              file=output_file)
     print('Scikit-learn Version: {}'.format(lrd['scikit_learn_version']),
           file=output_file)
     print('Start Timestamp: {}'.format(

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -1278,7 +1278,8 @@ class Learner(object):
         metric_scores = {metric: None for metric in output_metrics}
 
         # make the prediction on the test data
-        yhat = self.predict(examples, prediction_prefix=prediction_prefix,
+        yhat = self.predict(examples,
+                            prediction_prefix=prediction_prefix,
                             append=append)
 
         # make a single list of metrics including the grid objective
@@ -1303,7 +1304,9 @@ class Learner(object):
         else:
             ytest = examples.labels
 
-        # compute all of the metrics that we need to
+        # compute all of the metrics that we need to but save the original
+        # predictions since we will need to use those for each metric
+        original_yhat = yhat
         for metric in metrics_to_compute:
 
             # if run in probability mode, convert yhat to list of labels predicted
@@ -1317,7 +1320,7 @@ class Learner(object):
 
                 yhat = np.array([max(range(len(row)),
                                      key=lambda i: row[i])
-                                 for row in yhat])
+                                 for row in original_yhat])
 
             # calculate grid search objective function score, if specified
             if (metric and (metric not in _CORRELATION_METRICS or

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -1331,9 +1331,13 @@ class Learner(object):
                     metric_scores[metric] = float('NaN')
 
         # now separate out the grid objective score from the additional metric scores
-        objective_score = metric_scores[grid_objective]
+        # if a grid objective was actually passed in. If no objective was passed in
+        # then that score should just be none.
+        objective_score = None
         additional_scores = metric_scores.copy()
-        del additional_scores[grid_objective]
+        if grid_objective:
+            objective_score = metric_scores[grid_objective]
+            del additional_scores[grid_objective]
 
         if self.model_type._estimator_type == 'regressor':
             result_dict = {'descriptive': defaultdict(dict)}

--- a/tests/configs/test_learning_curve.template.cfg
+++ b/tests/configs/test_learning_curve.template.cfg
@@ -9,6 +9,6 @@ suffix=.jsonlines
 
 [Tuning]
 grid_search=false
-objectives=['accuracy', 'f1_score_micro']
 
 [Output]
+metrics=['accuracy', 'f1_score_micro']

--- a/tests/configs/test_learning_curve_with_objectives.template.cfg
+++ b/tests/configs/test_learning_curve_with_objectives.template.cfg
@@ -1,0 +1,14 @@
+[General]
+experiment_name=test_learning_curve
+task=learning_curve
+
+[Input]
+featuresets=[["test_learning_curve1"], ["test_learning_curve2"]]
+learners=["LogisticRegression", "MultinomialNB", "SVC"]
+suffix=.jsonlines
+
+[Tuning]
+grid_search=false
+objectives=['accuracy', 'f1_score_micro']
+
+[Output]

--- a/tests/configs/test_summary_feature_hasher_with_metrics.template.cfg
+++ b/tests/configs/test_summary_feature_hasher_with_metrics.template.cfg
@@ -1,0 +1,18 @@
+[General]
+experiment_name=test_summary_feature_hasher_with_metrics
+task=evaluate
+
+[Input]
+feature_hasher = true
+hasher_features = 10
+featuresets=[["test_summary"]]
+learners=["LogisticRegression", "SVC"]
+suffix=.jsonlines
+
+[Tuning]
+grid_search=true
+objective=accuracy
+
+[Output]
+metrics = ["unweighted_kappa", "f1_score_micro"]
+probability=true

--- a/tests/configs/test_summary_with_metrics.template.cfg
+++ b/tests/configs/test_summary_with_metrics.template.cfg
@@ -1,0 +1,16 @@
+[General]
+experiment_name=test_summary_with_metrics
+task=evaluate
+
+[Input]
+featuresets=[["test_summary"]]
+learners=["LogisticRegression", "MultinomialNB", "SVC"]
+suffix=.jsonlines
+
+[Tuning]
+grid_search=true
+objective=accuracy
+
+[Output]
+metrics=["unweighted_kappa", "f1_score_micro"]
+probability=true

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -405,11 +405,15 @@ def check_results_with_unseen_labels(res, n_labels, new_label_list):
      score,
      result_dict,
      model_params,
-     grid_score) = res
+     grid_score,
+     additional_scores) = res
 
     # check that the new label is included into the results
     for output in [confusion_matrix, result_dict]:
         eq_(len(output), n_labels)
+
+    # check that any additional metrics are zero
+    eq_(additional_scores, {})
 
     # check that all metrics for new label are 0
     for label in new_label_list:

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -26,7 +26,6 @@ from nose.tools import eq_, assert_almost_equal, raises
 
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.metrics import accuracy_score
-from sklearn.utils.testing import assert_greater
 
 from skll.data import FeatureSet
 from skll.data.writers import NDJWriter

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -161,7 +161,7 @@ def test_specified_cv_folds():
         cv_output = learner.cross_validate(cv_fs,
                                            cv_folds=folds,
                                            grid_search=True)
-        fold_test_scores = [t[-1] for t in cv_output[0]]
+        fold_test_scores = [t[-2] for t in cv_output[0]]
 
         overall_score = np.mean(fold_test_scores)
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,7 +1,6 @@
 # License: BSD 3 clause
 """
-Module for running a bunch of simple unit tests. Should be expanded more in
-the future.
+Tests for SKLL inputs, mainly configuration files.
 
 :author: Michael Heilman (mheilman@ets.org)
 :author: Nitin Madnani (nmadnani@ets.org)
@@ -624,7 +623,7 @@ def test_config_parsing_bad_objective_2():
 
 def test_config_parsing_bad_objectives():
     """
-    Test to ensure config file parsing raises an error with a grid objectives given as a string
+    Test to ensure config file parsing raises an error with grid objectives given as a string
     """
 
     train_dir = join(_my_dir, 'train')
@@ -651,7 +650,6 @@ def test_config_parsing_bad_objectives():
     yield check_config_parsing_type_error, config_path
 
 
-
 def test_config_parsing_bad_objective_and_objectives():
     """
     Test to ensure config file parsing raises an error with
@@ -676,6 +674,66 @@ def test_config_parsing_bad_objective_and_objectives():
                            values_to_fill_dict,
                            'bad_objective_and_objectives')
     yield check_config_parsing_value_error, config_path
+
+
+def test_config_parsing_bad_metric():
+    """
+    Test to ensure config file parsing raises an error with an invalid evaluation metric
+    """
+
+    train_dir = join(_my_dir, 'train')
+    test_dir = join(_my_dir, 'test')
+    output_dir = join(_my_dir, 'output')
+
+    # make a simple config file that has a bad task
+    # but everything else is correct
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'evaluate',
+                           'train_directory': train_dir,
+                           'test_directory': test_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'metrics': "['foobar', 'accuracy']"}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'bad_metric')
+
+    yield check_config_parsing_value_error, config_path
+
+
+def test_config_parsing_bad_metric_2():
+    """
+    Test to ensure config file parsing raises an error with metrics given as a string
+    """
+
+    train_dir = join(_my_dir, 'train')
+    test_dir = join(_my_dir, 'test')
+    output_dir = join(_my_dir, 'output')
+
+    # make a simple config file that has a bad task
+    # but everything else is correct
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'evaluate',
+                           'train_directory': train_dir,
+                           'test_directory': test_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'metrics': "accuracy"}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'bad_metric_as_string')
+
+    yield check_config_parsing_type_error, config_path
 
 
 def test_config_parsing_bad_task_paths():
@@ -943,7 +1001,8 @@ def test_config_parsing_mse_to_neg_mse():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(grid_objective, ['neg_mean_squared_error'])
 
@@ -979,7 +1038,8 @@ def test_config_parsing_relative_input_path():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(normpath(train_path), (join(_my_dir, 'train')))
 
@@ -1016,7 +1076,8 @@ def test_config_parsing_relative_input_paths():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
 
 def test_cv_folds_and_grid_search_folds():
@@ -1167,7 +1228,8 @@ def check_cv_folds_and_grid_search_folds(task,
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(cv_folds, chosen_cv_folds)
     eq_(grid_search_folds, chosen_grid_search_folds)
@@ -1204,7 +1266,8 @@ def test_default_number_of_cv_folds():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(cv_folds, 10)
 
@@ -1240,7 +1303,8 @@ def test_setting_number_of_cv_folds():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(cv_folds, 5)
 
@@ -1279,7 +1343,8 @@ def test_setting_param_grids():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(param_grid_list[0]['C'][0], 1e-6)
     eq_(param_grid_list[0]['C'][1], 1e-3)
@@ -1323,7 +1388,8 @@ def test_setting_fixed_parameters():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(fixed_parameter_list[0]['C'][0], 1e-6)
     eq_(fixed_parameter_list[0]['C'][1], 1e-3)
@@ -1362,7 +1428,8 @@ def test_default_learning_curve_options():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(learning_curve_cv_folds_list, [10, 10])
     ok_(np.all(learning_curve_train_sizes == np.linspace(0.1, 1.0, 5)))
@@ -1399,7 +1466,175 @@ def test_setting_learning_curve_options():
      use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
      prediction_dir, log_path, train_path, test_path, ids_to_floats,
-     class_map, custom_learner_path, learning_curve_cv_folds_list, learning_curve_train_sizes) = _parse_config_file(config_path)
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
     eq_(learning_curve_cv_folds_list, [100, 10])
     eq_(learning_curve_train_sizes, [10, 50, 100, 200, 500])
+
+
+def test_learning_curve_metrics_and_objectives():
+
+    train_dir = join(_my_dir, 'train')
+    output_dir = join(_my_dir, 'output')
+
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'learning_curve',
+                           'train_directory': train_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression', 'MultinomialNB']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'objective': 'f1_score_macro',
+                           'metrics': '["accuracy", "f1_score_micro"]'}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'learning_curve_metrics_and_objectives')
+
+    (experiment_name, task, sampler, fixed_sampler_parameters,
+     feature_hasher, hasher_features, id_col, label_col, train_set_name,
+     test_set_name, suffix, featuresets, do_shuffle, model_path,
+     do_grid_search, grid_objective, probability, results_path,
+     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
+     use_folds_file_for_grid_search, do_stratified_folds,
+     fixed_parameter_list, param_grid_list, featureset_names, learners,
+     prediction_dir, log_path, train_path, test_path, ids_to_floats,
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
+
+    eq_(output_metrics, ["accuracy", "f1_score_micro"])
+    eq_(grid_objective, [])
+
+
+def test_learning_curve_metrics_and_no_objectives():
+
+    train_dir = join(_my_dir, 'train')
+    output_dir = join(_my_dir, 'output')
+
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'learning_curve',
+                           'train_directory': train_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression', 'MultinomialNB']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'metrics': '["accuracy", "unweighted_kappa"]'}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'learning_curve_metrics_and_no_objectives')
+
+    (experiment_name, task, sampler, fixed_sampler_parameters,
+     feature_hasher, hasher_features, id_col, label_col, train_set_name,
+     test_set_name, suffix, featuresets, do_shuffle, model_path,
+     do_grid_search, grid_objective, probability, results_path,
+     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
+     use_folds_file_for_grid_search, do_stratified_folds,
+     fixed_parameter_list, param_grid_list, featureset_names, learners,
+     prediction_dir, log_path, train_path, test_path, ids_to_floats,
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
+
+    eq_(output_metrics, ["accuracy", "unweighted_kappa"])
+    eq_(grid_objective, [])
+
+
+def test_learning_curve_objectives_and_no_metrics():
+
+    train_dir = join(_my_dir, 'train')
+    output_dir = join(_my_dir, 'output')
+
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'learning_curve',
+                           'train_directory': train_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression', 'MultinomialNB']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'objectives': '["accuracy"]'}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'learning_curve_objectives_and_no_metrics')
+
+    (experiment_name, task, sampler, fixed_sampler_parameters,
+     feature_hasher, hasher_features, id_col, label_col, train_set_name,
+     test_set_name, suffix, featuresets, do_shuffle, model_path,
+     do_grid_search, grid_objective, probability, results_path,
+     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
+     use_folds_file_for_grid_search, do_stratified_folds,
+     fixed_parameter_list, param_grid_list, featureset_names, learners,
+     prediction_dir, log_path, train_path, test_path, ids_to_floats,
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
+
+    eq_(output_metrics, ["accuracy"])
+    eq_(grid_objective, [])
+
+
+def test_learning_curve_default_objectives_and_no_metrics():
+
+    train_dir = join(_my_dir, 'train')
+    output_dir = join(_my_dir, 'output')
+
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'learning_curve',
+                           'train_directory': train_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression', 'MultinomialNB']",
+                           'log': output_dir,
+                           'results': output_dir}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'learning_curve_default_objectives_and_no_metrics')
+
+    (experiment_name, task, sampler, fixed_sampler_parameters,
+     feature_hasher, hasher_features, id_col, label_col, train_set_name,
+     test_set_name, suffix, featuresets, do_shuffle, model_path,
+     do_grid_search, grid_objective, probability, results_path,
+     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
+     use_folds_file_for_grid_search, do_stratified_folds,
+     fixed_parameter_list, param_grid_list, featureset_names, learners,
+     prediction_dir, log_path, train_path, test_path, ids_to_floats,
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
+
+    eq_(output_metrics, ["f1_score_micro"])
+    eq_(grid_objective, [])
+
+
+def test_learning_curve_no_metrics_and_no_objectives():
+
+    train_dir = join(_my_dir, 'train')
+    output_dir = join(_my_dir, 'output')
+
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'learning_curve',
+                           'train_directory': train_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression', 'MultinomialNB']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'objectives': '[]'}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'learning_curve_no_metrics_and_no_objectives')
+
+    yield check_config_parsing_value_error, config_path

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -50,9 +50,9 @@ def tearDown():
     """
     Clean up after tests.
     """
-    # config_dir = join(_my_dir, 'configs')
-    # for config_file in glob(join(config_dir, 'test_config_parsing_*.cfg')):
-    #     os.unlink(config_file)
+    config_dir = join(_my_dir, 'configs')
+    for config_file in glob(join(config_dir, 'test_config_parsing_*.cfg')):
+        os.unlink(config_file)
 
 
 def check_safe_float_conversion(converted_val, expected_val):

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from nose.tools import eq_, ok_, raises
 
-from six import string_types
+from six import string_types, PY2
 
 from skll.config import _parse_config_file, _load_cv_folds, _locate_file
 from skll.data.readers import safe_float
@@ -50,9 +50,9 @@ def tearDown():
     """
     Clean up after tests.
     """
-    config_dir = join(_my_dir, 'configs')
-    for config_file in glob(join(config_dir, 'test_config_parsing_*.cfg')):
-        os.unlink(config_file)
+    # config_dir = join(_my_dir, 'configs')
+    # for config_file in glob(join(config_dir, 'test_config_parsing_*.cfg')):
+    #     os.unlink(config_file)
 
 
 def check_safe_float_conversion(converted_val, expected_val):
@@ -1137,6 +1137,8 @@ def test_config_parsing_metrics_and_objectives_overlap():
                                              [["f1_score_micro", "unweighted_kappa"],
                                               ["accuracy", "unweighted_kappa"]],
                                              [[], ["accuracy"]]):
+        metrics = [str(m) for m in metrics] if PY2 else metrics
+        objectives = [str(o) for o in objectives] if PY2 else objectives
         yield check_config_parsing_metrics_and_objectives_overlap, \
                 task, metrics, objectives
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1080,6 +1080,67 @@ def test_config_parsing_relative_input_paths():
      learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
 
+def check_config_parsing_metrics_and_objectives_overlap(task,
+                                                        metrics,
+                                                        objectives):
+
+    test_dir = join('..', 'test')
+    train_dir = join('..', 'train')
+    output_dir = join(_my_dir, 'output')
+
+    # make a simple config file that has an invalid option
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': task,
+                           'train_directory': train_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'metrics': str(metrics)}
+
+    if task == 'evaluate':
+        values_to_fill_dict['test_directory'] = test_dir
+
+    if objectives:
+        values_to_fill_dict['objectives'] = str(objectives)
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'metrics_and_objectives_overlap')
+
+    (experiment_name, task, sampler, fixed_sampler_parameters,
+     feature_hasher, hasher_features, id_col, label_col, train_set_name,
+     test_set_name, suffix, featuresets, do_shuffle, model_path,
+     do_grid_search, parsed_objectives, probability, results_path,
+     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
+     use_folds_file_for_grid_search, do_stratified_folds,
+     fixed_parameter_list, param_grid_list, featureset_names, learners,
+     prediction_dir, log_path, train_path, test_path, ids_to_floats,
+     class_map, custom_learner_path, learning_curve_cv_folds_list,
+     learning_curve_train_sizes, parsed_metrics) = _parse_config_file(config_path)
+
+    if not objectives:
+        objectives = ["f1_score_micro"]
+    common_metrics = set(objectives).intersection(metrics)
+    pruned_metrics = [metric for metric in metrics if metric not in common_metrics]
+    eq_(parsed_objectives, objectives)
+    eq_(parsed_metrics, pruned_metrics)
+
+
+def test_config_parsing_metrics_and_objectives_overlap():
+
+    for task, metrics, objectives in product(["evaluate", "cross_validate"],
+                                             [["f1_score_micro", "unweighted_kappa"],
+                                              ["accuracy", "unweighted_kappa"]],
+                                             [[], ["accuracy"]]):
+        yield check_config_parsing_metrics_and_objectives_overlap, \
+                task, metrics, objectives
+
+
 def test_cv_folds_and_grid_search_folds():
 
     # we want to test all possible combinations of the following variables:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -34,6 +34,8 @@ from skll.data import FeatureSet, NDJWriter, Reader
 from skll.experiments import _HAVE_PANDAS, _HAVE_SEABORN, run_configuration, _compute_ylimits_for_featureset
 from skll.learner import Learner, _DEFAULT_PARAM_GRIDS
 
+from six import PY2
+
 from utils import fill_in_config_options, fill_in_config_paths, make_classification_data
 
 
@@ -315,7 +317,10 @@ def check_xval_fancy_results_file(do_grid_search,
     values_to_fill_dict['use_folds_file_for_grid_search'] = str(use_folds_file_for_grid_search)
 
     if use_additional_metrics:
-        values_to_fill_dict['metrics'] = str(["accuracy", "unweighted_kappa"])
+        if PY2:
+            values_to_fill_dict['metrics'] = str([b"accuracy", b"unweighted_kappa"])
+        else:
+            values_to_fill_dict['metrics'] = str(["accuracy", "unweighted_kappa"])
 
     config_template_path = join(_my_dir,
                                'configs',
@@ -371,8 +376,10 @@ def check_xval_fancy_results_file(do_grid_search,
             eq_(results_dict['Grid Search Folds'], '4')
 
     if use_additional_metrics:
-        eq_(results_dict['Additional Evaluation Metrics'],
-            str(["accuracy", "unweighted_kappa"]))
+        expected_metrics = [b"accuracy", b"unweighted_kappa"] if PY2 else ["accuracy", "unweighted_kappa"]
+
+        eq_(sorted(literal_eval(results_dict['Additional Evaluation Metrics'])),
+            sorted(expected_metrics))
 
 
 def test_xval_fancy_results_file():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -266,7 +266,7 @@ def check_summary_score(use_feature_hashing,
     # accuracy score. Test proves that the report
     # written out at least has a correct format for
     # this line. See _print_fancy_output
-    if not use_feature_hashing:
+    if not use_feature_hashing and not use_additional_metrics:
         for report_name, val in (("LogisticRegression", .5),
                                  ("MultinomialNB", .5),
                                  ("SVC", .6333)):
@@ -434,7 +434,12 @@ def test_learning_curve_implementation():
     cv = ShuffleSplit(n_splits=cv_folds, test_size=0.2, random_state=random_state)
     estimator = MultinomialNB()
     train_sizes=np.linspace(.1, 1.0, 5)
-    train_sizes1, train_scores1, test_scores1 = learning_curve(estimator, X, y, cv=cv,  train_sizes=train_sizes, scoring='accuracy')
+    train_sizes1, train_scores1, test_scores1 = learning_curve(estimator,
+                                                               X,
+                                                               y,
+                                                               cv=cv,
+                                                               train_sizes=train_sizes,
+                                                               scoring='accuracy')
 
     # get the features from this data into a FeatureSet instance we can use
     # with the SKLL API
@@ -450,7 +455,7 @@ def test_learning_curve_implementation():
     train_scores2, test_scores2, train_sizes2 = l.learning_curve(fs,
                                                                  cv_folds=cv_folds,
                                                                  train_sizes=train_sizes,
-                                                                 objective='accuracy')
+                                                                 metric='accuracy')
 
     assert np.all(train_sizes1 == train_sizes2)
     assert np.allclose(train_scores1, train_scores2)
@@ -590,7 +595,7 @@ def test_learning_curve_ylimits():
         import pandas as pd
 
     # create a test data frame
-    df_test = pd.DataFrame.from_dict({'test_score_std': {0: 0.16809136190418694, 1: 0.18556201422712379, 2: 0.15002727816517414, 3: 0.15301923832338646, 4: 0.15589815327205431, 5: 0.68205316443171948, 6: 0.77441075727706354, 7: 0.83838056331276678, 8: 0.84770116657005623, 9: 0.8708014559726478}, 'value': {0: 0.4092496971394447, 1: 0.2820507715115001, 2: 0.24533811547921261, 3: 0.21808651942296109, 4: 0.19767367891431534, 5: -2.3540980769230773, 6: -3.1312445327182394, 7: -3.2956790939674137, 8: -3.4843050005436713, 9: -3.6357879085645455}, 'train_score_std': {0: 0.15950199460682787, 1: 0.090992452273091703, 2: 0.068488654201949981, 3: 0.055223120652733763, 4: 0.03172452509259388, 5: 1.0561586240460523, 6: 0.53955995320300709, 7: 0.40477740983901211, 8: 0.34148185048394258, 9: 0.20791478156554272}, 'variable': {0: 'train_score_mean', 1: 'train_score_mean', 2: 'train_score_mean', 3: 'train_score_mean', 4: 'train_score_mean', 5: 'train_score_mean', 6: 'train_score_mean', 7: 'train_score_mean', 8: 'train_score_mean', 9: 'train_score_mean'}, 'objective': {0: 'r2', 1: 'r2', 2: 'r2', 3: 'r2', 4: 'r2', 5: 'neg_mean_squared_error', 6: 'neg_mean_squared_error', 7: 'neg_mean_squared_error', 8: 'neg_mean_squared_error', 9: 'neg_mean_squared_error'}})
+    df_test = pd.DataFrame.from_dict({'test_score_std': {0: 0.16809136190418694, 1: 0.18556201422712379, 2: 0.15002727816517414, 3: 0.15301923832338646, 4: 0.15589815327205431, 5: 0.68205316443171948, 6: 0.77441075727706354, 7: 0.83838056331276678, 8: 0.84770116657005623, 9: 0.8708014559726478}, 'value': {0: 0.4092496971394447, 1: 0.2820507715115001, 2: 0.24533811547921261, 3: 0.21808651942296109, 4: 0.19767367891431534, 5: -2.3540980769230773, 6: -3.1312445327182394, 7: -3.2956790939674137, 8: -3.4843050005436713, 9: -3.6357879085645455}, 'train_score_std': {0: 0.15950199460682787, 1: 0.090992452273091703, 2: 0.068488654201949981, 3: 0.055223120652733763, 4: 0.03172452509259388, 5: 1.0561586240460523, 6: 0.53955995320300709, 7: 0.40477740983901211, 8: 0.34148185048394258, 9: 0.20791478156554272}, 'variable': {0: 'train_score_mean', 1: 'train_score_mean', 2: 'train_score_mean', 3: 'train_score_mean', 4: 'train_score_mean', 5: 'train_score_mean', 6: 'train_score_mean', 7: 'train_score_mean', 8: 'train_score_mean', 9: 'train_score_mean'}, 'metric': {0: 'r2', 1: 'r2', 2: 'r2', 3: 'r2', 4: 'r2', 5: 'neg_mean_squared_error', 6: 'neg_mean_squared_error', 7: 'neg_mean_squared_error', 8: 'neg_mean_squared_error', 9: 'neg_mean_squared_error'}})
 
     # compute the y-limits
     ylimits_dict = _compute_ylimits_for_featureset(df_test, ['r2', 'neg_mean_squared_error'])

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -71,6 +71,7 @@ def tearDown():
 
         config_files = ['test_{}.cfg'.format(suffix),
                         'test_{}_with_metrics.cfg'.format(suffix),
+                        'test_{}_with_objectives.cfg'.format(suffix),
                         'test_{}_feature_hasher.cfg'.format(suffix),
                         'test_{}_feature_hasher_with_metrics.cfg'.format(suffix)]
         for cf in config_files:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -468,6 +468,27 @@ def test_int_labels():
     run_configuration(config_path, quiet=True)
 
 
+def test_additional_metrics():
+    """
+    Test additional metrics in the results file for a regressor
+    """
+    train_fs, test_fs, _ = make_regression_data(num_examples=2000,
+                                                num_features=3)
+
+    # train a regression model using the train feature set
+    learner = Learner('LinearRegression')
+    learner.train(train_fs, grid_objective='pearson')
+
+    # evaluate the trained model using the test feature set
+    results = learner.evaluate(test_fs, output_metrics=['spearman',
+                                                        'kendall_tau'])
+
+    # check that the values for the additional metrics are as expected
+    additional_scores_dict = results[-1]
+    assert_almost_equal(additional_scores_dict['spearman'], 0.9996, places=4)
+    assert_almost_equal(additional_scores_dict['kendall_tau'], 0.9846, places=4)
+
+
 def test_fancy_output():
     """
     Test the descriptive statistics output in the results file for a regressor

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -153,7 +153,7 @@ def fill_in_config_options(config_template_path,
                   'Tuning': ['probability', 'grid_search', 'objective',
                              'use_folds_file_for_grid_search', 'grid_search_folds',
                              'param_grids', 'objectives', 'duplicate_option'],
-                  'Output': ['results', 'log', 'models',
+                  'Output': ['results', 'log', 'models', 'metrics',
                              'predictions']}
 
     for section in to_fill_in:


### PR DESCRIPTION
Right now, the only metrics computed for any SKLL experiment are the tuning objectives. However, one may want to compute additional evaluation metrics without tuning on them. This PR makes that possible. 

- For `evaluate` and `cross_validate` tasks, one can now specify a `metrics` list in the Output section and those will be computed and saved at the end of the results file under an  "Additional Evaluation Metrics" section. For `train` and `predict` tasks, `metrics` is ignored since it's not relevant. 

- For `learning_curve` tasks, it doesn't actually make sense to have `objectives` anyway so you can specify `metrics` instead. Using `objectives` is still supported for backward compatibility but you will get a deprecation warning. (*Note*: as an implementation detail, we still use the "objectives" variable internally because then we can piggyback on that to parallelize the various jobs.)

- The parsing and validation of `objectives` and `metrics` is now factored out into a separate function to avoid code duplication.

- Update documentation. 

- Add several new tests and update existing tests to deal with the new additional metrics being produced in the outputs.