### PR TITLE
Refactor travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ notifications:
 env:
   - WITH_PANDAS_AND_SEABORN=true
   - WITH_PANDAS_AND_SEABORN=false
+  - TESTFILES="tests/test_regression.py"
+  - TESTFILES="tests/test_featureset.py"
+  - TESTFILES="tests/test_output.py tests/test_input.py tests/test_preprocessing.py tests/test_cv.py tests/test_metrics.py tests/test_ablation.py tests/test_classification.py tests/test_custom_learner.py tests/test_utilities.py"
+matrix:
+  exclude:
+    - WITH_PANDAS_AND_SEABORN=true
+      TESTFILES="tests/test_regression.py"
 
 # run on the new Travis infrastructure
 sudo: false
@@ -30,7 +37,7 @@ install:
 
 # Run test
 script:
-  - if [ ${WITH_PANDAS_AND_SEABORN} == "true" ]; then MPLBACKEND=Agg nosetests -v --with-cov --cov skll --cov-config .coveragerc --logging-level=DEBUG -a have_pandas_and_seaborn; else nosetests -v --with-cov --cov skll --cov-config .coveragerc --logging-level=DEBUG -a '!have_pandas_and_seaborn'; fi
+  - if [ ${WITH_PANDAS_AND_SEABORN} == "true" ]; then MPLBACKEND=Agg nosetests -v --with-cov --cov skll --cov-config .coveragerc --logging-level=DEBUG -a have_pandas_and_seaborn ${TESTFILES}; else nosetests -v --with-cov --cov skll --cov-config .coveragerc --logging-level=DEBUG -a '!have_pandas_and_seaborn' ${TESTFILES}; fi
 
 # Calculate coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,11 @@ notifications:
   slack:
     secure: d+NSaR+cfRkcJfX/uEVwdyQDlayZO6c8QV96grl1stmWxG3XOXvXg1tM6v7EBeb9VRw5T4VglnnJGNJA62j1ReEJ0XyWr5XtaNWiF6Lc4UOty/TTG36IQdkWS1vQA8v2Hre73YbvOhtBb6biNneVAk+rrfRSgomEa+ec22cjgUo=
 env:
-  - WITH_PANDAS_AND_SEABORN=true
-  - WITH_PANDAS_AND_SEABORN=false
-  - TESTFILES="tests/test_regression.py"
-  - TESTFILES="tests/test_featureset.py"
-  - TESTFILES="tests/test_output.py tests/test_input.py tests/test_preprocessing.py tests/test_cv.py tests/test_metrics.py tests/test_ablation.py tests/test_classification.py tests/test_custom_learner.py tests/test_utilities.py"
-matrix:
-  exclude:
-    - WITH_PANDAS_AND_SEABORN=true
-      TESTFILES="tests/test_regression.py"
+  - WITH_PANDAS_AND_SEABORN=true TESTFILES="tests/test_featureset.py"
+  - WITH_PANDAS_AND_SEABORN=true TESTFILES="tests/test_output.py"
+  - WITH_PANDAS_AND_SEABORN=false TESTFILES="tests/test_regression.py"
+  - WITH_PANDAS_AND_SEABORN=false TESTFILES="tests/test_featureset.py"
+  - WITH_PANDAS_AND_SEABORN=false TESTFILES="tests/test_output.py tests/test_input.py tests/test_preprocessing.py tests/test_cv.py tests/test_metrics.py tests/test_ablation.py tests/test_classification.py tests/test_custom_learner.py tests/test_utilities.py"
 
 # run on the new Travis infrastructure
 sudo: false

--- a/tests/configs/test_ablation.template.cfg
+++ b/tests/configs/test_ablation.template.cfg
@@ -1,5 +1,5 @@
 [General]
-experiment_name=ablation_cv
+experiment_name=ablation_cv_plain
 task=cross_validate
 
 [Input]

--- a/tests/configs/test_ablation_all_combos.template.cfg
+++ b/tests/configs/test_ablation_all_combos.template.cfg
@@ -1,16 +1,15 @@
 [General]
-experiment_name=ablation_cv_sampler
+experiment_name=ablation_cv_plain_all_combos
 task=cross_validate
 
 [Input]
-sampler=RBFSampler
 featuresets=[["f0", "f1", "f2"], ["f3", "f4"]]
 learners=["LogisticRegression", "LinearSVC"]
 suffix=.jsonlines
 
 [Tuning]
 grid_search=False
-objective=accuracy
+objectives=["accuracy"]
 
 [Output]
 probability=true

--- a/tests/configs/test_ablation_feature_hasher_all_combos.template.cfg
+++ b/tests/configs/test_ablation_feature_hasher_all_combos.template.cfg
@@ -1,9 +1,10 @@
 [General]
-experiment_name=ablation_cv_sampler
+experiment_name=ablation_cv_feature_hasher_all_combos
 task=cross_validate
 
 [Input]
-sampler=RBFSampler
+feature_hasher = true
+hasher_features = 10
 featuresets=[["f0", "f1", "f2"], ["f3", "f4"]]
 learners=["LogisticRegression", "LinearSVC"]
 suffix=.jsonlines

--- a/tests/configs/test_ablation_feature_hasher_sampler.template.cfg
+++ b/tests/configs/test_ablation_feature_hasher_sampler.template.cfg
@@ -1,5 +1,5 @@
 [General]
-experiment_name=ablation_cv_feature_hasher
+experiment_name=ablation_cv_feature_hasher_sampler
 task=cross_validate
 
 [Input]

--- a/tests/configs/test_ablation_feature_hasher_sampler_all_combos.template.cfg
+++ b/tests/configs/test_ablation_feature_hasher_sampler_all_combos.template.cfg
@@ -1,9 +1,11 @@
 [General]
-experiment_name=ablation_cv_sampler
+experiment_name=ablation_cv_feature_hasher_sampler_all_combos
 task=cross_validate
 
 [Input]
 sampler=RBFSampler
+feature_hasher = true
+hasher_features = 10
 featuresets=[["f0", "f1", "f2"], ["f3", "f4"]]
 learners=["LogisticRegression", "LinearSVC"]
 suffix=.jsonlines

--- a/tests/configs/test_ablation_sampler_all_combos.template.cfg
+++ b/tests/configs/test_ablation_sampler_all_combos.template.cfg
@@ -1,5 +1,5 @@
 [General]
-experiment_name=ablation_cv_sampler
+experiment_name=ablation_cv_sampler_all_combos
 task=cross_validate
 
 [Input]

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -20,7 +20,6 @@ from io import open
 from os.path import abspath, dirname, exists, join
 
 from nose.tools import eq_
-from skll.data import FeatureSet
 from skll.experiments import run_configuration
 from skll.learner import _DEFAULT_PARAM_GRIDS
 
@@ -46,11 +45,6 @@ def setup():
     if not exists(output_dir):
         os.makedirs(output_dir)
 
-    # Remove old CV data
-    for old_file in glob(join(_my_dir, 'output',
-                              'ablation_cv_*.results')):
-        os.unlink(old_file)
-
     # create jsonlines feature files if they don't already exist
     feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
     if not all([exists(ff) for ff in feature_files]):
@@ -64,13 +58,17 @@ def tearDown():
     output_dir = join(_my_dir, 'output')
     config_dir = join(_my_dir, 'configs')
 
-    for output_file in glob.glob(join(output_dir, 'ablation_cv_*')):
+    for output_file in glob(join(output_dir, 'ablation_cv_*')):
         os.unlink(output_file)
 
     config_files = ['test_ablation.cfg',
+                    'test_ablation_all_combos.cfg',
                     'test_ablation_feature_hasher.cfg',
+                    'test_ablation_feature_hasher_all_combos.cfg',
                     'test_ablation_sampler.cfg',
-                    'test_ablation_feature_hasher_sampler.cfg']
+                    'test_ablation_sampler_all_combos.cfg',
+                    'test_ablation_feature_hasher_sampler.cfg',
+                    'test_ablation_feature_hasher_sampler_all_combos.cfg']
     for cf in config_files:
         if exists(join(config_dir, cf)):
             os.unlink(join(config_dir, cf))
@@ -105,7 +103,8 @@ def test_ablation_cv():
     Test ablation + cross-validation
     """
 
-    config_template_path = join(_my_dir, 'configs',
+    config_template_path = join(_my_dir,
+                                'configs',
                                 'test_ablation.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
@@ -114,14 +113,15 @@ def test_ablation_cv():
     # read in the summary file and make sure it has
     # 7 ablated featuresets * (10 folds + 1 average line) * 2 learners = 154
     # lines
-    with open(join(_my_dir, 'output', 'ablation_cv_summary.tsv')) as f:
+    with open(join(_my_dir, 'output', 'ablation_cv_plain_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 154)
 
-    # make sure there are 6 ablated featuresets * 2 learners = 12 results files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          'ablation_cv_*.results')))
+    # make sure there are 7 ablated featuresets * 2 learners = 12 results files
+    num_result_files = len(glob(join(_my_dir,
+                                     'output',
+                                     'ablation_cv_plain*.results')))
     eq_(num_result_files, 14)
 
 
@@ -130,8 +130,9 @@ def test_ablation_cv_all_combos():
     Test ablation all-combos + cross-validation
     """
 
-    config_template_path = join(_my_dir, 'configs',
-                                'test_ablation.template.cfg')
+    config_template_path = join(_my_dir,
+                                'configs',
+                                'test_ablation_all_combos.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, ablation=None)
@@ -139,15 +140,16 @@ def test_ablation_cv_all_combos():
     # read in the summary file and make sure it has
     # 10 ablated featuresets * (10 folds + 1 average line) * 2 learners = 220
     # lines
-    with open(join(_my_dir, 'output', 'ablation_cv_summary.tsv')) as f:
+    with open(join(_my_dir, 'output', 'ablation_cv_plain_all_combos_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 220)
 
     # make sure there are 10 ablated featuresets * 2 learners = 20 results
     # files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          'ablation_cv_*results')))
+    num_result_files = len(glob(join(_my_dir,
+                                     'output',
+                                     'ablation_cv_plain_all_combos*results')))
     eq_(num_result_files, 20)
 
 
@@ -156,7 +158,8 @@ def test_ablation_cv_feature_hasher():
     Test ablation + cross-validation + feature hashing
     """
 
-    config_template_path = join(_my_dir, 'configs',
+    config_template_path = join(_my_dir,
+                                'configs',
                                 'test_ablation_feature_hasher.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
@@ -165,16 +168,17 @@ def test_ablation_cv_feature_hasher():
     # read in the summary file and make sure it has
     # 7 ablated featuresets * (10 folds + 1 average line) * 2 learners = 154
     # lines
-    with open(join(_my_dir, 'output',
+    with open(join(_my_dir,
+                   'output',
                    'ablation_cv_feature_hasher_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 154)
 
-    # make sure there are 6 ablated featuresets * 2 learners = 12 results files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          ('ablation_cv_feature_hasher_'
-                                           '*.results'))))
+    # make sure there are 7 ablated featuresets * 2 learners = 14 results files
+    num_result_files = len(glob(join(_my_dir,
+                                     'output',
+                                     'ablation_cv_feature_hasher_*.results')))
     eq_(num_result_files, 14)
 
 
@@ -183,8 +187,9 @@ def test_ablation_cv_feature_hasher_all_combos():
     Test ablation all-combos + cross-validation + feature hashing
     """
 
-    config_template_path = join(_my_dir, 'configs',
-                                'test_ablation_feature_hasher.template.cfg')
+    config_template_path = join(_my_dir,
+                                'configs',
+                                'test_ablation_feature_hasher_all_combos.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, ablation=None)
@@ -192,17 +197,18 @@ def test_ablation_cv_feature_hasher_all_combos():
     # read in the summary file and make sure it has
     # 10 ablated featuresets * (10 folds + 1 average line) * 2 learners = 220
     # lines
-    with open(join(_my_dir, 'output',
-                   'ablation_cv_feature_hasher_summary.tsv')) as f:
+    with open(join(_my_dir,
+                   'output',
+                   'ablation_cv_feature_hasher_all_combos_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 220)
 
     # make sure there are 10 ablated featuresets * 2 learners = 20 results
     # files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          ('ablation_cv_feature_hasher_'
-                                           '*results'))))
+    num_result_files = len(glob(join(_my_dir,
+                                    'output',
+                                    'ablation_cv_feature_hasher_all_combos*.results')))
     eq_(num_result_files, 20)
 
 
@@ -211,7 +217,8 @@ def test_ablation_cv_sampler():
     Test ablation + cross-validation + samplers
     """
 
-    config_template_path = join(_my_dir, 'configs',
+    config_template_path = join(_my_dir,
+                                'configs',
                                 'test_ablation_sampler.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
@@ -220,14 +227,15 @@ def test_ablation_cv_sampler():
     # read in the summary file and make sure it has
     # 7 ablated featuresets * (10 folds + 1 average line) * 2 learners = 154
     # lines
-    with open(join(_my_dir, 'output', 'ablation_cv_summary.tsv')) as f:
+    with open(join(_my_dir, 'output', 'ablation_cv_sampler_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 154)
 
     # make sure there are 6 ablated featuresets * 2 learners = 12 results files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          'ablation_cv_*.results')))
+    num_result_files = len(glob(join(_my_dir,
+                                    'output',
+                                    'ablation_cv_sampler*.results')))
     eq_(num_result_files, 14)
 
 
@@ -236,8 +244,9 @@ def test_ablation_cv_all_combos_sampler():
     Test ablation all-combos + cross-validation + samplers
     """
 
-    config_template_path = join(_my_dir, 'configs',
-                                'test_ablation_sampler.template.cfg')
+    config_template_path = join(_my_dir,
+                                'configs',
+                                'test_ablation_sampler_all_combos.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, ablation=None)
@@ -245,15 +254,16 @@ def test_ablation_cv_all_combos_sampler():
     # read in the summary file and make sure it has
     # 10 ablated featuresets * (10 folds + 1 average line) * 2 learners = 220
     # lines
-    with open(join(_my_dir, 'output', 'ablation_cv_summary.tsv')) as f:
+    with open(join(_my_dir, 'output', 'ablation_cv_sampler_all_combos_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 220)
 
     # make sure there are 10 ablated featuresets * 2 learners = 20 results
     # files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          'ablation_cv_*results')))
+    num_result_files = len(glob(join(_my_dir,
+                                     'output',
+                                     'ablation_cv_sampler_all_combos*.results')))
     eq_(num_result_files, 20)
 
 
@@ -262,9 +272,9 @@ def test_ablation_cv_feature_hasher_sampler():
     Test ablation + cross-validation + feature hashing + samplers
     """
 
-    config_template_path = join(_my_dir, 'configs', ('test_ablation_feature_'
-                                                     'hasher_sampler.template'
-                                                     '.cfg'))
+    config_template_path = join(_my_dir,
+                                'configs',
+                                'test_ablation_feature_hasher_sampler.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, ablation=1)
@@ -272,16 +282,17 @@ def test_ablation_cv_feature_hasher_sampler():
     # read in the summary file and make sure it has
     # 7 ablated featuresets * (10 folds + 1 average line) * 2 learners = 154
     # lines
-    with open(join(_my_dir, 'output',
-                   'ablation_cv_feature_hasher_summary.tsv')) as f:
+    with open(join(_my_dir,
+                   'output',
+                   'ablation_cv_feature_hasher_sampler_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 154)
 
-    # make sure there are 6 ablated featuresets * 2 learners = 12 results files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          ('ablation_cv_feature_hasher_'
-                                           '*.results'))))
+    # make sure there are 7 ablated featuresets * 2 learners = 14 results files
+    num_result_files = len(glob(join(_my_dir,
+                                     'output',
+                                     'ablation_cv_feature_hasher_sampler*.results')))
     eq_(num_result_files, 14)
 
 
@@ -290,9 +301,9 @@ def test_ablation_cv_feature_hasher_all_combos_sampler():
     Test ablation all-combos + cross-validation + feature hashing + samplers
     """
 
-    config_template_path = join(_my_dir, 'configs', ('test_ablation_feature_'
-                                                     'hasher_sampler.template'
-                                                     '.cfg'))
+    config_template_path = join(_my_dir,
+                                'configs',
+                                'test_ablation_feature_hasher_sampler_all_combos.template.cfg')
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, ablation=None)
@@ -300,15 +311,16 @@ def test_ablation_cv_feature_hasher_all_combos_sampler():
     # read in the summary file and make sure it has
     # 10 ablated featuresets * (10 folds + 1 average line) * 2 learners = 220
     # lines
-    with open(join(_my_dir, 'output',
-                   'ablation_cv_feature_hasher_summary.tsv')) as f:
+    with open(join(_my_dir,
+                   'output',
+                   'ablation_cv_feature_hasher_all_combos_summary.tsv')) as f:
         reader = csv.DictReader(f, dialect=csv.excel_tab)
         num_rows = check_ablation_rows(reader)
         eq_(num_rows, 220)
 
     # make sure there are 10 ablated featuresets * 2 learners = 20 results
     # files
-    num_result_files = len(glob.glob(join(_my_dir, 'output',
-                                          ('ablation_cv_feature_hasher_'
-                                           '*results'))))
+    num_result_files = len(glob(join(_my_dir,
+                                     'output',
+                                     'ablation_cv_feature_hasher_sampler_all_combos*.results')))
     eq_(num_result_files, 20)

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -45,10 +45,9 @@ def setup():
     if not exists(output_dir):
         os.makedirs(output_dir)
 
-    # create jsonlines feature files if they don't already exist
-    feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
-    if not all([exists(ff) for ff in feature_files]):
-        create_jsonlines_feature_files()
+    # create jsonlines feature files
+    train_path = join(_my_dir, 'train')
+    create_jsonlines_feature_files(train_path)
 
 
 def tearDown():

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -56,11 +56,9 @@ def setup():
     if not exists(output_dir):
         os.makedirs(output_dir)
 
-    # create jsonlines feature files if they don't already exist
-    feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
-    if not all([exists(ff) for ff in feature_files]):
-        create_jsonlines_feature_files()
-
+    # create jsonlines feature files
+    train_path = join(_my_dir, 'train')
+    create_jsonlines_feature_files(train_path)
 
 
 def tearDown():

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -27,15 +27,18 @@ from six import PY2
 
 from sklearn.feature_extraction import FeatureHasher
 from sklearn.datasets.samples_generator import make_classification
-from sklearn.utils.testing import assert_greater, assert_less, assert_equal, \
-                                    assert_almost_equal
+from sklearn.utils.testing import (assert_greater,
+                                   assert_less,
+                                   assert_equal,
+                                   assert_almost_equal)
 from skll.config import _load_cv_folds
 from skll.data import FeatureSet
 from skll.learner import Learner
 from skll.learner import _DEFAULT_PARAM_GRIDS
 from skll.experiments import _load_featureset
 from sklearn.model_selection import StratifiedKFold
-from utils import fill_in_config_paths_for_single_file
+from utils import (create_jsonlines_feature_files,
+                   fill_in_config_paths_for_single_file)
 from skll.experiments import run_configuration
 
 _ALL_MODELS = list(_DEFAULT_PARAM_GRIDS.keys())
@@ -52,6 +55,12 @@ def setup():
     output_dir = join(_my_dir, 'output')
     if not exists(output_dir):
         os.makedirs(output_dir)
+
+    # create jsonlines feature files if they don't already exist
+    feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
+    if not all([exists(ff) for ff in feature_files]):
+        create_jsonlines_feature_files()
+
 
 
 def tearDown():

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -22,11 +22,14 @@ from nose.tools import eq_, ok_, raises
 
 from six import string_types, PY2
 
-from skll.config import _parse_config_file, _load_cv_folds, _locate_file
+from skll.config import (_parse_config_file,
+                         _load_cv_folds,
+                         _locate_file)
 from skll.data.readers import safe_float
 from skll.experiments import _load_featureset
 
-from utils import fill_in_config_options
+from utils import (create_jsonlines_feature_files,
+                   fill_in_config_options)
 
 _my_dir = abspath(dirname(__file__))
 
@@ -44,6 +47,11 @@ def setup():
     output_dir = join(_my_dir, 'output')
     if not exists(output_dir):
         os.makedirs(output_dir)
+
+    # create jsonlines feature files if they don't already exist
+    feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
+    if not all([exists(ff) for ff in feature_files]):
+        create_jsonlines_feature_files()
 
 
 def tearDown():

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -48,10 +48,9 @@ def setup():
     if not exists(output_dir):
         os.makedirs(output_dir)
 
-    # create jsonlines feature files if they don't already exist
-    feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
-    if not all([exists(ff) for ff in feature_files]):
-        create_jsonlines_feature_files()
+    # create jsonlines feature files
+    train_path = join(_my_dir, 'train')
+    create_jsonlines_feature_files(train_path)
 
 
 def tearDown():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -31,12 +31,18 @@ from sklearn.model_selection import ShuffleSplit, learning_curve
 from sklearn.naive_bayes import MultinomialNB
 
 from skll.data import FeatureSet, NDJWriter, Reader
-from skll.experiments import _HAVE_PANDAS, _HAVE_SEABORN, run_configuration, _compute_ylimits_for_featureset
+from skll.experiments import (_HAVE_PANDAS,
+                              _HAVE_SEABORN,
+                              _compute_ylimits_for_featureset,
+                              run_configuration)
 from skll.learner import Learner, _DEFAULT_PARAM_GRIDS
 
 from six import PY2
 
-from utils import fill_in_config_options, fill_in_config_paths, make_classification_data
+from utils import (create_jsonlines_feature_files,
+                   fill_in_config_options,
+                   fill_in_config_paths,
+                   make_classification_data)
 
 
 _ALL_MODELS = list(_DEFAULT_PARAM_GRIDS.keys())
@@ -51,6 +57,11 @@ def setup():
         new_dir = join(_my_dir, dir_name)
         if not exists(new_dir):
             os.makedirs(new_dir)
+
+    # create jsonlines feature files if they don't already exist
+    feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
+    if not all([exists(ff) for ff in feature_files]):
+        create_jsonlines_feature_files()
 
 
 def tearDown():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -58,10 +58,9 @@ def setup():
         if not exists(new_dir):
             os.makedirs(new_dir)
 
-    # create jsonlines feature files if they don't already exist
-    feature_files = [join(_my_dir, 'train', 'f{}.jsonlines'.format(i)) for i in range(5)]
-    if not all([exists(ff) for ff in feature_files]):
-        create_jsonlines_feature_files()
+    # create jsonlines feature files
+    train_path = join(_my_dir, 'train')
+    create_jsonlines_feature_files(train_path)
 
 
 def tearDown():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,12 +5,10 @@ Utilities functions to make SKLL testing simpler
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 import re
 
 from collections import OrderedDict
-from glob import glob
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, exists, join
 
 import numpy as np
 from numpy.random import RandomState
@@ -204,37 +202,42 @@ def fill_in_config_paths_for_fancy_output(config_template_path):
     return new_config_path
 
 
-def create_jsonlines_feature_files():
-    num_examples = 1000
+def create_jsonlines_feature_files(path):
 
-    np.random.seed(1234567890)
+    # we only need to create the feature files if they
+    # don't already exist under the given path
+    feature_files_to_create = [join(path, 'f{}.jsonlines'.format(i)) for i in range(5)]
+    if all([exists(ff) for ff in feature_files_to_create]):
+        return
+    else:
+        num_examples = 1000
+        np.random.seed(1234567890)
 
-    # Create lists we will write files from
-    ids = []
-    features = []
-    labels = []
-    for j in range(num_examples):
-        y = "dog" if j % 2 == 0 else "cat"
-        ex_id = "{}{}".format(y, j)
-        x = {"f{}".format(feat_num): np.random.randint(0, 4) for feat_num in
-             range(5)}
-        x = OrderedDict(sorted(x.items(), key=lambda t: t[0]))
-        ids.append(ex_id)
-        labels.append(y)
-        features.append(x)
+        # Create lists we will write files from
+        ids = []
+        features = []
+        labels = []
+        for j in range(num_examples):
+            y = "dog" if j % 2 == 0 else "cat"
+            ex_id = "{}{}".format(y, j)
+            x = {"f{}".format(feat_num): np.random.randint(0, 4) for feat_num in
+                 range(5)}
+            x = OrderedDict(sorted(x.items(), key=lambda t: t[0]))
+            ids.append(ex_id)
+            labels.append(y)
+            features.append(x)
 
-    for i in range(5):
-        train_path = join(_my_dir, 'train', 'f{}.jsonlines'.format(i))
-        sub_features = []
-        for example_num in range(num_examples):
-            feat_num = i
-            x = {"f{}".format(feat_num):
-                 features[example_num]["f{}".format(feat_num)]}
-            sub_features.append(x)
-        train_fs = FeatureSet('ablation_cv', ids, features=sub_features,
-                              labels=labels)
-        writer = NDJWriter(train_path, train_fs)
-        writer.write()
+        for i in range(5):
+            file_path = join(path, 'f{}.jsonlines'.format(i))
+            sub_features = []
+            for example_num in range(num_examples):
+                feat_num = i
+                x = {"f{}".format(feat_num):
+                     features[example_num]["f{}".format(feat_num)]}
+                sub_features.append(x)
+            fs = FeatureSet('ablation_cv', ids, features=sub_features, labels=labels)
+            writer = NDJWriter(file_path, fs)
+            writer.write()
 
 
 def make_classification_data(num_examples=100, train_test_ratio=0.5,


### PR DESCRIPTION
Travis has a 50 minute hard limit on any job in any build and that includes VM boot up time. Now that we have so many tests, hitting that 50 minute job limit seems to be happening with more recent PRs. This PR breaks up the running of the test files into multiple jobs rather than running them all together. The solution implemented is detailed in #385.  

With this refactoring, the Travis CI plan runs for a total 26 minutes, taking into account the parallelization of the build jobs. And the longest running job is only ~20 min. See more details on [Travis CI](https://travis-ci.org/EducationalTestingService/skll).

This PR also solves some problems with `test_ablation.py`:
- Currently unless you run `test_ablation` first, some of the other tests will fail because they rely on a jsonlines file that is created by the ablation tests. I refactored the code such that the files are now created on demand even if `test_ablation` hasn't been run first.
- Create separate templates for all tests so that there are no strange conflicts when cleaning up.
- Improve readability.