### PR TITLE
Fix learning curve gridmap bug and tweak y-limit computation.

### DIFF
--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -1217,13 +1217,15 @@ def _compute_ylimits_for_featureset(df, metrics):
                                            test_values_upper]))
 
         # squeeze the limits to hide unnecessary parts of the graph
+        # set the limits with a little buffer on either side but not too much
         if min_score < 0:
-            lower_limit = -1.1 if min_score >= -1 else math.floor(min_score)
+            lower_limit = max(min_score - 0.1, math.floor(min_score))
         else:
             lower_limit = 0
 
         if max_score > 0:
-            upper_limit = 1.1 if max_score <= 1 else math.ceil(max_score)
+            upper_limit = min(max_score + 0.1, math.ceil(max_score))
+            # upper_limit = 1.1 if max_score >= 1 else math.ceil(max_score)
         else:
             upper_limit = 0
 

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -1225,7 +1225,6 @@ def _compute_ylimits_for_featureset(df, metrics):
 
         if max_score > 0:
             upper_limit = min(max_score + 0.1, math.ceil(max_score) + 0.05)
-            # upper_limit = 1.1 if max_score >= 1 else math.ceil(max_score)
         else:
             upper_limit = 0
 

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -1219,12 +1219,12 @@ def _compute_ylimits_for_featureset(df, metrics):
         # squeeze the limits to hide unnecessary parts of the graph
         # set the limits with a little buffer on either side but not too much
         if min_score < 0:
-            lower_limit = max(min_score - 0.1, math.floor(min_score))
+            lower_limit = max(min_score - 0.1, math.floor(min_score) - 0.05)
         else:
             lower_limit = 0
 
         if max_score > 0:
-            upper_limit = min(max_score + 0.1, math.ceil(max_score))
+            upper_limit = min(max_score + 0.1, math.ceil(max_score) + 0.05)
             # upper_limit = 1.1 if max_score >= 1 else math.ceil(max_score)
         else:
             upper_limit = 0

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -745,10 +745,13 @@ def _classify_featureset(args):
                     'learning_curve_test_scores_stds': np.std(curve_test_scores, axis=1, ddof=1),
                     'computed_curve_train_sizes': computed_curve_train_sizes})
 
+        # we need to return and write out a list of dictionaries
+        res = [res]
+
         # write out the result dictionary to a json file
         file_mode = 'w' if sys.version_info >= (3, 0) else 'wb'
         with open(results_json_path, file_mode) as json_file:
-            json.dump([res], json_file, cls=NumpyTypeEncoder)
+            json.dump(res, json_file, cls=NumpyTypeEncoder)
     else:
         res = [learner_result_dict_base]
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -483,7 +483,7 @@ def test_learning_curve_implementation():
 
 def test_learning_curve_output():
     """
-    Test learning output for experiment with metrics option
+    Test learning curve output for experiment with metrics option
     """
 
     # Test to validate learning curve output
@@ -520,7 +520,7 @@ def test_learning_curve_output():
 
 def test_learning_curve_output_with_objectives():
     """
-    Test learning output for experiment with objectives option
+    Test learning curve output for experiment with objectives option
     """
 
     # Test to validate learning curve output
@@ -620,5 +620,7 @@ def test_learning_curve_ylimits():
     ylimits_dict = _compute_ylimits_for_featureset(df_test, ['r2', 'neg_mean_squared_error'])
 
     eq_(len(ylimits_dict), 2)
-    eq_(ylimits_dict['neg_mean_squared_error'], (-4, 0))
-    eq_(ylimits_dict['r2'], (0, 1.1))
+    assert_almost_equal(ylimits_dict['neg_mean_squared_error'][0], -3.94, decimal=2)
+    eq_(ylimits_dict['neg_mean_squared_error'][1], 0)
+    eq_(ylimits_dict['r2'][0], 0)
+    assert_almost_equal(ylimits_dict['r2'][1], 0.67, decimal=2)


### PR DESCRIPTION
This is a very short PR.

- Fix return statement in `_classify_featureset()` such that running a learning curve task via `gridmap` actually works (see issue #386).
- Tweak how the y-limits for learning curves are computed so that we don't have a lot of wasted space (see issue #389). The curve below shows the new version of the curve that was attached in the issue.
- Update the y-limits test based on the tweak.

![titanic_learning_curve_all](https://user-images.githubusercontent.com/161680/32678434-553fbb7a-c630-11e7-9b7e-02dc0f8e38ab.png)
