### PR TITLE
Multiple minor bug fixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then export PATH=/home/travis/miniconda2/bin:$PATH; else export PATH=/home/travis/miniconda3/bin:$PATH; fi
   - conda update --yes conda
 install:
-  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy beautifulsoup4 six scikit-learn==0.19.0 joblib prettytable python-coveralls ruamel.yaml
+  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy beautifulsoup4 six scikit-learn==0.19.1 joblib prettytable python-coveralls ruamel.yaml
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes --channel defaults configparser mock; fi
   - if [ ${WITH_PANDAS_AND_SEABORN} == "true" ]; then conda install --yes --channel defaults pandas seaborn; fi
   # Have to use pip for nose-cov because its entry points are not supported by conda yet

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.19.0
+scikit-learn==0.19.1
 six
 PrettyTable
 beautifulsoup4

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -1080,6 +1080,12 @@ specified via command-line arguments instead of in the configuration file:
     If you would like to try all possible combinations of feature files, you
     can use the :option:`run_experiment --ablation_all` option instead.
 
+    .. warning::
+
+        Ablation will *not* work if you specify a :ref:`train_file <train_file>`
+        and :ref:`test_file <test_file>` since no featuresets are defined in
+        that scenario.
+
 .. option:: -A, --ablation_all
 
     Runs an ablation study where repeated experiments are conducted with all

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -794,6 +794,7 @@ Classification:
     *   **f1_score_least_frequent**: F:\ :sub:`1` score of the least frequent
         class. The least frequent class may vary from fold to fold for certain
         data distributions.
+    * **neg_log_loss**: The negative of the classification `log loss <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.log_loss.html>`__ . Since scikit-learn `recommends <http://scikit-learn.org/stable/modules/model_evaluation.html#common-cases-predefined-values>`__ using negated loss functions as scorer functions, SKLL does the same for the sake of consistency. To use this as the objective, :ref:`probability <probability>` must be set to ``True``.
     *   **average_precision**: `Area under PR curve <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html>`__
         (for binary classification)
     *   **roc_auc**: `Area under ROC curve <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html>`__
@@ -833,7 +834,7 @@ Regression or classification with binary labels:
 Regression:
 
     *   **r2**: `R2 <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html>`__
-    *   **neg_mean_squared_error**: The negative of the `mean squared error <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_squared_error.html>`__ regression loss. Since scikit-learn `recommends <https://github.com/scikit-learn/scikit-learn/blob/2f7f5a1a50c2a2022d42160fce9d0596ecac2ada/sklearn/metrics/scorer.py#L355>`__ using negated loss functions as scorer functions, SKLL does the same for the sake of consistency.
+    *   **neg_mean_squared_error**: The negative of the `mean squared error <http://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_squared_error.html>`__ regression loss. Since scikit-learn `recommends <http://scikit-learn.org/stable/modules/model_evaluation.html#common-cases-predefined-values>`__ using negated loss functions as scorer functions, SKLL does the same for the sake of consistency.
 
 
 Defaults to ``['f1_score_micro']``.

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -1009,7 +1009,7 @@ available for the :ref:`tuning objectives <objectives>`.
     2. For the ``evaluate`` and ``cross_validate`` tasks,  any functions
        that are specified in both ``metrics`` and  ``objectives``
        are assumed to be the latter.
-    3. If you just want to use `neg_log_loss`` as an additional metric,
+    3. If you just want to use ``neg_log_loss`` as an additional metric,
        you do not need to set :ref:`probability <probability>` to ``True``.
        That's only neeeded for ``neg_log_loss`` to be used as a tuning
        objective.

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -979,7 +979,8 @@ probability *(Optional)*
 
 Whether or not to output probabilities for each class instead of the
 most probable class for each instance. Only really makes a difference
-when storing predictions. Defaults to ``False``.
+when storing predictions. Defaults to ``False``. Note that this also
+applies to the tuning objective.
 
 .. _results:
 
@@ -1008,6 +1009,10 @@ available for the :ref:`tuning objectives <objectives>`.
     2. For the ``evaluate`` and ``cross_validate`` tasks,  any functions
        that are specified in both ``metrics`` and  ``objectives``
        are assumed to be the latter.
+    3. If you just want to use `neg_log_loss`` as an additional metric,
+       you do not need to set :ref:`probability <probability>` to ``True``.
+       That's only neeeded for ``neg_log_loss`` to be used as a tuning
+       objective.
 
 .. _log:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==0.19.0
+scikit-learn==0.19.1
 six
 PrettyTable
 beautifulsoup4

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,7 +1,7 @@
 configparser==3.5.0b2
 logutils
 mock
-scikit-learn==0.19.0
+scikit-learn==0.19.1
 six
 PrettyTable
 beautifulsoup4

--- a/skll/config.py
+++ b/skll/config.py
@@ -654,6 +654,12 @@ def _parse_config_file(config_path, log_level=logging.INFO):
                 output_metrics = [metric for metric in output_metrics
                                   if metric not in common_metrics_and_objectives]
 
+    # if the grid objectives contains `neg_log_loss`, then probability
+    # must be specified as true since that' needed to compute the loss
+    if 'neg_log_loss' in grid_objectives and not probability:
+        raise ValueError("The 'probability' option must be true in order "
+                         "to use `neg_log_loss` as the objective.")
+
     # set the folds appropriately based on the task:
     #  (a) if the task is `train` and if an external fold mapping is specified
     #      then use that mapping for grid search instead of the value

--- a/skll/config.py
+++ b/skll/config.py
@@ -655,7 +655,7 @@ def _parse_config_file(config_path, log_level=logging.INFO):
                                   if metric not in common_metrics_and_objectives]
 
     # if the grid objectives contains `neg_log_loss`, then probability
-    # must be specified as true since that' needed to compute the loss
+    # must be specified as true since that's needed to compute the loss
     if 'neg_log_loss' in grid_objectives and not probability:
         raise ValueError("The 'probability' option must be true in order "
                          "to use `neg_log_loss` as the objective.")

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -183,6 +183,7 @@ class Reader(object):
         # Get labels and IDs
         ids = []
         labels = []
+        ex_num = 0
         with open(self.path_or_list, 'r' if PY3 else 'rb') as f:
             for ex_num, (id_, class_, _) in enumerate(self._sub_read(f), start=1):
                 # Update lists of IDs, clases, and features
@@ -203,6 +204,9 @@ class Reader(object):
 
         # Remember total number of examples for percentage progress meter
         total = ex_num
+        if total == 0:
+            raise ValueError("No features found in possibly "
+                             "empty file '{}'.".format(self.path_or_list))
 
         # Convert everything to numpy arrays
         ids = np.array(ids)

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -978,6 +978,13 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
             logger.warning("Ablating features is not supported during "
                            "learning curve generation. Ignoring.")
 
+    # if we just had a train file and a test file, there are no real featuresets
+    # in which case there are no features to ablate
+    if len(featuresets) == 1 and len(featuresets[0]) == 1:
+        if ablation is None or ablation > 0:
+            ablation = 0
+            logger.warning("Not enough featuresets for ablation. Ignoring.")
+
     # if performing ablation, expand featuresets to include combinations of
     # features within those sets
     if ablation is None or ablation > 0:

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -169,7 +169,8 @@ _BINARY_CLASS_OBJ_FUNCS = frozenset(['unweighted_kappa',
                                      'qwk_off_by_one',
                                      'kendall_tau',
                                      'pearson',
-                                     'spearman'])
+                                     'spearman',
+                                     'neg_log_loss'])
 
 _REGRESSION_ONLY_OBJ_FUNCS = frozenset(['r2',
                                         'neg_mean_squared_error'])
@@ -183,14 +184,16 @@ _CLASSIFICATION_ONLY_OBJ_FUNCS = frozenset(['accuracy',
                                             'f1_score_weighted',
                                             'f1_score_least_frequent',
                                             'average_precision',
-                                            'roc_auc'])
+                                            'roc_auc',
+                                            'neg_log_loss'])
 
 _INT_CLASS_OBJ_FUNCS = frozenset(['unweighted_kappa',
                                   'linear_weighted_kappa',
                                   'quadratic_weighted_kappa',
                                   'uwk_off_by_one',
                                   'lwk_off_by_one',
-                                  'qwk_off_by_one'])
+                                  'qwk_off_by_one',
+                                  'neg_log_loss'])
 
 _REQUIRES_DENSE = (BayesianRidge,
                    GradientBoostingClassifier,

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -16,6 +16,7 @@ import glob
 import itertools
 import json
 import os
+import re
 import warnings
 
 from io import open
@@ -337,6 +338,35 @@ def test_train_file_test_file():
                                        '_f1.results.json'))) as f:
         result_dict = json.load(f)[0]
     assert_almost_equal(result_dict['score'], 0.9491525423728813)
+
+
+def test_train_file_test_file_ablation():
+    """
+    Test that specifying ablation with train and test file is ignored
+    """
+    # Create data files
+    make_single_file_featureset_data()
+
+    # Run experiment
+    config_path = fill_in_config_paths_for_single_file(join(_my_dir, "configs",
+                                                            "test_single_file"
+                                                            ".template.cfg"),
+                                                       join(_my_dir, 'train',
+                                                            'train_single_file'
+                                                            '.jsonlines'),
+                                                       join(_my_dir, 'test',
+                                                            'test_single_file.'
+                                                            'jsonlines'))
+    run_configuration(config_path, quiet=True, ablation=None)
+
+    # check that we see the message that ablation was ignored in the experiment log
+    # Check experiment log output
+    with open(join(_my_dir,
+                   'output',
+                   'train_test_single_file.log')) as f:
+        cv_file_pattern = re.compile('Not enough featuresets for ablation. Ignoring.')
+        matches = re.findall(cv_file_pattern, f.read())
+        eq_(len(matches), 1)
 
 
 @raises(ValueError)

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -24,6 +24,7 @@ from numpy.testing import assert_array_equal
 from sklearn.feature_extraction import DictVectorizer, FeatureHasher
 from sklearn.datasets.samples_generator import make_classification
 
+import skll
 from skll.data import FeatureSet, Writer, Reader
 from skll.data.readers import DictListReader
 from skll.experiments import _load_featureset
@@ -52,6 +53,23 @@ def setup():
         os.makedirs(output_dir)
 
 
+def tearDown():
+    """
+    Clean up files created during testing.
+    """
+    for filetype in ['csv', 'jsonlines', 'libsvm', 'megam', 'tsv']:
+        filepath = join(_my_dir, 'other', 'empty.{}'.format(filetype))
+        if exists(filepath):
+            os.unlink(filepath)
+
+
+def _create_empty_file(filetype):
+    filepath = join(_my_dir, 'other', 'empty.{}'.format(filetype))
+    with open(filepath, 'w'):
+        pass
+    return filepath
+
+
 @raises(ValueError)
 def test_empty_ids():
     """
@@ -71,6 +89,20 @@ def test_empty_ids():
 
     # create a feature set with ids set to None and raise ValueError
     FeatureSet('test', None, features=features, labels=y)
+
+@raises(ValueError)
+def check_empty_file_read(filetype, reader_type):
+    empty_filepath = _create_empty_file(filetype)
+    reader = getattr(skll.data, reader_type).for_path(empty_filepath)
+    _ = reader.read()
+
+
+def test_empty_file_read():
+    for filetype, reader_type in zip(['csv',  'jsonlines',
+                                      'libsvm', 'megam', 'tsv'],
+                                     ['CSVReader', 'NDJReader',
+                                      'LibSVMReader', 'MegaMReader', 'TSVReader']):
+        yield check_empty_file_read, filetype, reader_type
 
 
 def test_empty_labels():

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -744,6 +744,36 @@ def test_config_parsing_bad_metric_2():
     yield check_config_parsing_type_error, config_path
 
 
+def test_config_parsing_log_loss_no_probability():
+    """
+    Test that config parsing raises an error if log loss is used without probability
+    """
+
+    train_dir = join(_my_dir, 'train')
+    test_dir = join(_my_dir, 'test')
+    output_dir = join(_my_dir, 'output')
+
+    # make a simple config file that has a bad task
+    # but everything else is correct
+    values_to_fill_dict = {'experiment_name': 'config_parsing',
+                           'task': 'evaluate',
+                           'train_directory': train_dir,
+                           'test_directory': test_dir,
+                           'featuresets': "[['f1', 'f2', 'f3']]",
+                           'learners': "['LogisticRegression']",
+                           'log': output_dir,
+                           'results': output_dir,
+                           'objective': 'neg_log_loss'}
+
+    config_template_path = join(_my_dir, 'configs',
+                                'test_config_parsing.template.cfg')
+    config_path = fill_in_config_options(config_template_path,
+                                         values_to_fill_dict,
+                                         'log_loss_no_probability')
+
+    yield check_config_parsing_value_error, config_path
+
+
 def test_config_parsing_bad_task_paths():
     # Test to ensure config file parsing raises an error with various
     # incorrectly set path


### PR DESCRIPTION
This is another short PR that encompasses several minor bugfixes and improvements:

1. Update to scikit-learn v0.19.1. In this particular scikit-learn release, the stratified split functions fail if the labels are floating point so we need to catch that condition in SKLL to provide a more informative message. Added such a condition to `learner.cross_validate()` and a test.

2. Deal with empty feature files by raising an exception. Added a test and also fixed an unbound variable bug.

3. Add `neg_log_loss` as a possible metric and tuning objective for classifiers. This requires `probability` to be `True` so add a check for that and a test.

4. If we are just specifying a `train_file` and a `test_file`, there are no featuresets and hence it doesn't make any sense to do ablation in that case. Added a warning and a fall-through to handle this scenario. 

5. Updated documentation for all of the above as appropriate. 