### PR TITLE
Remove all references to the `stable` branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,7 @@ GitHub:
 
           $ git checkout -b feature/my-new-addition
 
-   and start making changes. Never work in the ``master`` or ``stable``
-   branches!
+   and start making changes. Never work in the ``master`` branch!
 
 4. Work on this copy on your computer using Git to do the version
    control. When you're done editing, do:

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 SciKit-Learn Laboratory
 -----------------------
 
-.. image:: https://img.shields.io/travis/EducationalTestingService/skll/stable.svg
+.. image:: https://img.shields.io/travis/EducationalTestingService/skll/master.svg
    :alt: Build status
    :target: https://travis-ci.org/EducationalTestingService/skll
 
-.. image:: https://img.shields.io/coveralls/EducationalTestingService/skll/stable.svg
+.. image:: https://img.shields.io/coveralls/EducationalTestingService/skll/master.svg
     :target: https://coveralls.io/r/EducationalTestingService/skll
 
 .. image:: https://img.shields.io/pypi/v/skll.svg

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -31,7 +31,7 @@ The first step to getting the Titanic data is logging into Kaggle and
 downloading `train.csv <http://www.kaggle.com/c/titanic-gettingStarted/download/train.csv>`__
 and `test.csv <http://www.kaggle.com/c/titanic-gettingStarted/download/test.csv>`__.
 Once you have those files, you'll also want to grab the
-`examples folder <https://github.com/EducationalTestingService/skll/tree/stable/examples>`__
+`examples folder <https://github.com/EducationalTestingService/skll/tree/master/examples>`__
 on our GitHub page and put ``train.csv`` and ``test.csv`` in ``examples``.
 
 The provided script, :download:`make_titanic_example_data.py <../examples/make_titanic_example_data.py>`,


### PR DESCRIPTION
The `stable` branch of SKLL no longer serves any purpose since we now have packages and people who don't want to use `master` can just use the package for the last released version. 

- The public version of the documentation already points to `master`.
- In this PR, I remove all references to the `stable` branch.

I will delete the stable branch once this PR is merged.