### PR TITLE
SKLL Release v1.5.1

### DIFF
--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: skll
-  version: 1.5
+  version: 1.5.1
 
 source:
   path: ../../../skll

--- a/skll/version.py
+++ b/skll/version.py
@@ -7,5 +7,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :organization: ETS
 """
 
-__version__ = '1.5'
+__version__ = '1.5.1'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
- All that was required was to change the version numbers.
- Conda and PyPI already updated.
- The release notes are already drafted and I will publish them once this PR is merged. 