### PR TITLE
Fix issue with missing loggers in Learner instances loaded via `from_file()`

### DIFF
--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -989,7 +989,7 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
     write_summary : bool, optional
         Write a TSV file with a summary of the results.
         Defaults to ``True``.
-    quite : bool, optional
+    quiet : bool, optional
         Suppress printing of "Loading..." messages.
         Defaults to ``False``.
     ablation : int, optional

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -949,7 +949,7 @@ class Learner(object):
 
         # create the learner logger attribute to the logger that's passed in
         # or if nothing was passed in, then a new logger should be linked
-        # learner.logger = logger if logger else logging.getLogger(__name__)
+        learner.logger = logger if logger else logging.getLogger(__name__)
 
         # For backward compatibility, convert string model types to labels.
         if isinstance(learner._model_type, string_types):

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -921,7 +921,7 @@ class Learner(object):
             self._model_kwargs.update(model_kwargs)
 
     @classmethod
-    def from_file(cls, learner_path):
+    def from_file(cls, learner_path, logger=None):
         """
         Load a saved ``Learner`` instance from a file path.
 
@@ -929,6 +929,9 @@ class Learner(object):
         ----------
         learner_path : str
             The path to a saved ``Learner`` instance file.
+        logger : logging object, optional
+            A logging object. If ``None`` is passed, get logger from ``__name__``.
+            Defaults to ``None``.
 
         Returns
         -------
@@ -943,6 +946,10 @@ class Learner(object):
             If the pickled version of the ``Learner`` instance is out of date.
         """
         skll_version, learner = joblib.load(learner_path)
+
+        # create the learner logger attribute to the logger that's passed in
+        # or if nothing was passed in, then a new logger should be linked
+        # learner.logger = logger if logger else logging.getLogger(__name__)
 
         # For backward compatibility, convert string model types to labels.
         if isinstance(learner._model_type, string_types):

--- a/skll/utilities/generate_predictions.py
+++ b/skll/utilities/generate_predictions.py
@@ -26,7 +26,7 @@ class Predictor(object):
     predictions for feature strings.
     """
 
-    def __init__(self, model_path, threshold=None, positive_label=1):
+    def __init__(self, model_path, threshold=None, positive_label=1, logger=None):
         """
         Initialize the predictor.
 
@@ -46,7 +46,11 @@ class Predictor(object):
             predicting. 1 = second class, which is default
             for binary classification.
             Defaults to 1.
+        logger : logging object, optional
+            A logging object. If ``None`` is passed, get logger from ``__name__``.
+            Defaults to ``None``.
         """
+        # self.logger = logger if logger else logging.getLogger(__name__)
         self._learner = Learner.from_file(model_path)
         self._pos_index = positive_label
         self.threshold = threshold
@@ -145,7 +149,8 @@ def main(argv=None):
     # Create the classifier and load the model
     predictor = Predictor(args.model_file,
                           positive_label=args.positive_label,
-                          threshold=args.threshold)
+                          threshold=args.threshold,
+                          logger=logger)
 
     # Iterate over all the specified input files
     for input_file in args.input_file:

--- a/tests/configs/test_single_file_saved_subset.template.cfg
+++ b/tests/configs/test_single_file_saved_subset.template.cfg
@@ -1,0 +1,11 @@
+[General]
+experiment_name=train_test_single_file
+task=evaluate
+
+[Input]
+learners=["RandomForestClassifier"]
+
+[Tuning]
+
+[Output]
+probability=false

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -288,7 +288,7 @@ def check_generate_predictions(use_feature_hashing=False,
                                use_threshold=False,
                                test_on_subset=False):
 
-    # create some simple classification data without feature hashing
+    # create some simple classification feature sets for training and testing
     train_fs, test_fs = make_classification_data(num_examples=1000,
                                                  num_features=5,
                                                  use_feature_hashing=use_feature_hashing,
@@ -300,11 +300,13 @@ def check_generate_predictions(use_feature_hashing=False,
     # train the learner with grid search
     learner.train(train_fs, grid_search=True)
 
-    # get the predictions on the test featureset, if we are asked to
-    # just use a subset of the test features, filter the test set
-    # to get rid of the fifth feature
+    # if we are asked to use only a subset, then filter out
+    # one of the features if we are not using feature hashing,
+    # do nothing if we are using feature hashing
     if test_on_subset and not use_feature_hashing:
         test_fs.filter(features=['f01', 'f02', 'f03', 'f04'])
+
+    # get the predictions on the test featureset
     predictions = learner.predict(test_fs)
 
     # if we asked for probabilities, then use the threshold


### PR DESCRIPTION
- Create logger attribute via `from_file()` either created as a brand new one or passed in from the code calling `from_file()`.
-  Link the logger from `generate_predictions()` to the wrapper learner loaded via `from_file()`.
- Add a new test for `generate_predictions`. This test triggers a warning that should be printed using the Learner's logger that should exist even though the Learner was loaded using `from_file()` and not directly instantiated. This test uses a subset of features for evaluation since that will trigger a warning that forces the use of the logger. 
- Add a new test to `test_classification` that also uses a pre-trained model to evaluate on a subset  of the training features. 

@benbuleong please check using this branch to make sure that your experiment in #412 works fine. @aoifecahill @Lguyogiro @mulhod @jbiggsets if you could also test this too, that'd be great. 