### PR TITLE
Allow gradient boosting models to take sparse matrices.

### DIFF
--- a/skll/learner.py
+++ b/skll/learner.py
@@ -196,8 +196,6 @@ _INT_CLASS_OBJ_FUNCS = frozenset(['unweighted_kappa',
                                   'neg_log_loss'])
 
 _REQUIRES_DENSE = (BayesianRidge,
-                   GradientBoostingClassifier,
-                   GradientBoostingRegressor,
                    Lars,
                    TheilSenRegressor)
 


### PR DESCRIPTION
- Remove `GradientBoostingClassifier` and `GradientBoostingRegressor` from list of learners that require dense matrices as input.