### PR TITLE
Make MLP regression and classification tests run faster

### DIFF
--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -210,7 +210,7 @@ def test_mlp_classification():
     learner = Learner('MLPClassifier')
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=ConvergenceWarning)
-        learner.train(train_fs, grid_search=True)
+        learner.train(train_fs, grid_search=False)
 
     # now generate the predictions on the test set
     predictions = learner.predict(test_fs)
@@ -220,7 +220,7 @@ def test_mlp_classification():
     # using make_regression_data. To do this, we just
     # make sure that they are correlated
     accuracy = accuracy_score(predictions, test_fs.labels)
-    assert_almost_equal(accuracy, 0.825)
+    assert_almost_equal(accuracy, 0.858, places=3)
 
 
 def check_sparse_predict_sampler(use_feature_hashing=False):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -611,7 +611,7 @@ def test_ransac_regression():
                                                      'SGDRegressor',
                                                      'DecisionTreeRegressor',
                                                      'SVR'],
-                                                     [0.95, 0.45, 0.75, 0.65]):
+                                                    [0.95, 0.45, 0.75, 0.65]):
         yield check_ransac_regression, base_estimator_name, pearson_value
 
 
@@ -627,7 +627,7 @@ def check_mlp_regression(use_rescaling=False):
     # we don't want to see any convergence warnings during the grid search
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=ConvergenceWarning)
-        learner.train(train_fs, grid_search=True, grid_objective='pearson')
+        learner.train(train_fs, grid_search=False)
 
     # now generate the predictions on the test set
     predictions = learner.predict(test_fs)


### PR DESCRIPTION
- Turn off grid search in MLP tests We need to do this since otherwise the travis builds time out. 
- This seems to be a problem on Linux machines (see #434).
- Turning off grid search is not ideal but it's not a terrible option.