### PR TITLE
Fix NDJWriter bug

### DIFF
--- a/skll/data/writers.py
+++ b/skll/data/writers.py
@@ -585,9 +585,21 @@ class NDJWriter(Writer):
         """
         example_dict = {}
         # Don't try to add class column if this is label-less data
+        # Try to convert the label to a scalar assuming it'a numpy
+        # non-scalar type (e.g., int64) but if that doesn't work
+        # then use it as is
         if self.feat_set.has_labels:
-            example_dict['y'] = np.asscalar(label_)
-        example_dict['id'] = np.asscalar(id_)
+            try:
+                example_dict['y'] = label_.item()
+            except AttributeError:
+                example_dict['y'] = label_
+        # Try to convert the ID to a scalar assuming it'a numpy
+        # non-scalar type (e.g., int64) but if that doesn't work
+        # then use it as is
+        try:
+            example_dict['id'] = id_.item()
+        except AttributeError:
+            example_dict['id'] = id_
         example_dict["x"] = feat_dict
         print(json.dumps(example_dict, sort_keys=True), file=output_file)
 

--- a/skll/data/writers.py
+++ b/skll/data/writers.py
@@ -237,24 +237,24 @@ class DelimitedFileWriter(Writer):
         type. For example ``/foo/.csv``.
     feature_set : skll.FeatureSet
         The ``FeatureSet`` instance to dump to the output file.
-    quiet : bool
+    quiet : bool, optional
         Do not print "Writing..." status message to stderr.
         Defaults to ``True``.
-    label_col : str
+    label_col : str, optional
         Name of the column which contains the class labels
         for ARFF/CSV/TSV files. If no column with that name
         exists, or ``None`` is specified, the data is
         considered to be unlabelled.
         Defaults to ``'y'``.
-    id_col : str
+    id_col : str, optional
         Name of the column which contains the instance IDs.
         If no column with that name exists, or ``None`` is
         specified, example IDs will be automatically generated.
         Defaults to ``'id'``.
-    dialect : str
-        Name of the column which contains the class labels for
-        CSV/TSV files.
-    logger : logging.Logger
+    dialect : str, optional
+        The dialect to use for writing out the delimited file.
+        Defaults to ``'excel-tab'``.
+    logger : logging.Logger, optional
         A logger instance to use to log messages instead of creating
         a new one by default.
         Defaults to ``None``.

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -25,7 +25,7 @@ from sklearn.feature_extraction import DictVectorizer, FeatureHasher
 from sklearn.datasets.samples_generator import make_classification
 
 import skll
-from skll.data import FeatureSet, Writer, Reader
+from skll.data import FeatureSet, Writer, Reader, NDJReader, NDJWriter
 from skll.data.readers import DictListReader
 from skll.experiments import _load_featureset
 from skll.learner import _DEFAULT_PARAM_GRIDS
@@ -61,6 +61,8 @@ def tearDown():
         filepath = join(_my_dir, 'other', 'empty.{}'.format(filetype))
         if exists(filepath):
             os.unlink(filepath)
+    os.unlink(join(_my_dir, 'other', 'string_ids_df.jsonlines'))
+    os.unlink(join(_my_dir, 'other', 'string_ids.jsonlines'))
 
 
 def _create_empty_file(filetype):
@@ -972,3 +974,51 @@ def test_featureset_creation_from_dataframe_without_labels_with_vectorizer():
                         rtol=1e-6) and
             np.all(np.isnan(expected.labels)) and
             np.all(np.isnan(current.labels)))
+
+
+def test_writing_ndj_featureset_with_string_ids():
+    test_dict_vectorizer = DictVectorizer()
+    test_feat_dict_list = [{'a': 1.0, 'b': 1.0}, {'b': 1.0, 'c': 1.0}]
+    Xtest = test_dict_vectorizer.fit_transform(test_feat_dict_list)
+    fs_test = FeatureSet('test',
+                         ids=['1', '2'],
+                         labels=[1, 2],
+                         features=Xtest,
+                         vectorizer=test_dict_vectorizer)
+    output_path = join(_my_dir, "other", "string_ids.jsonlines")
+    test_writer = NDJWriter(output_path, fs_test)
+    test_writer.write()
+
+    # read in the written file into a featureset and confirm that the
+    # two featuresets are equal
+    fs_test2 = NDJReader.for_path(output_path).read()
+
+    assert fs_test == fs_test2
+
+
+@attr('have_pandas_and_seaborn')
+def test_featureset_creation_from_dataframe_with_string_ids():
+
+    import pandas
+
+    dftest = pandas.DataFrame({"id": ['1', '2'],
+                               "score": [1, 2],
+                               "text": ["a b", "b c"]})
+    dftest.set_index("id", inplace=True)
+    test_feat_dict_list = [{'a': 1.0, 'b': 1.0}, {'b': 1.0, 'c': 1.0}]
+    test_dict_vectorizer = DictVectorizer()
+    Xtest = test_dict_vectorizer.fit_transform(test_feat_dict_list)
+    fs_test = FeatureSet('test',
+                         ids=dftest.index.values,
+                         labels=dftest['score'].values,
+                         features=Xtest,
+                         vectorizer=test_dict_vectorizer)
+    output_path = join(_my_dir, "other", "string_ids_df.jsonlines")
+    test_writer = NDJWriter(output_path, fs_test)
+    test_writer.write()
+
+    # read in the written file into a featureset and confirm that the
+    # two featuresets are equal
+    fs_test2 = NDJReader.for_path(output_path).read()
+
+    assert fs_test == fs_test2

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -61,8 +61,11 @@ def tearDown():
         filepath = join(_my_dir, 'other', 'empty.{}'.format(filetype))
         if exists(filepath):
             os.unlink(filepath)
-    os.unlink(join(_my_dir, 'other', 'string_ids_df.jsonlines'))
-    os.unlink(join(_my_dir, 'other', 'string_ids.jsonlines'))
+
+    filepaths = [join(_my_dir, 'other', '{}.jsonlines'.format(x)) for x in ['test_string_ids', 'test_string_ids_df']]
+    for filepath in filepaths:
+        if exists(filepath):
+            os.unlink(filepath)
 
 
 def _create_empty_file(filetype):
@@ -985,7 +988,7 @@ def test_writing_ndj_featureset_with_string_ids():
                          labels=[1, 2],
                          features=Xtest,
                          vectorizer=test_dict_vectorizer)
-    output_path = join(_my_dir, "other", "string_ids.jsonlines")
+    output_path = join(_my_dir, "other", "test_string_ids.jsonlines")
     test_writer = NDJWriter(output_path, fs_test)
     test_writer.write()
 
@@ -1013,7 +1016,7 @@ def test_featureset_creation_from_dataframe_with_string_ids():
                          labels=dftest['score'].values,
                          features=Xtest,
                          vectorizer=test_dict_vectorizer)
-    output_path = join(_my_dir, "other", "string_ids_df.jsonlines")
+    output_path = join(_my_dir, "other", "test_string_ids_df.jsonlines")
     test_writer = NDJWriter(output_path, fs_test)
     test_writer.write()
 


### PR DESCRIPTION
The `_write_line()` method in `NDJWriter` assumes that we will always get numpy datatypes (e.g., `np.int64`) and hence uses `np.asscalar()` to convey them into scalar types before calling `json.dumps()` since numpy datatypes are not supported by JSON. However, this does not handle the edge case where a scalar datatype might show up, e.g., through the use of `pandas`. This PR fixes this and adds support for this edge case. It also adds new tests - based on the example shown in the related issue (#416). 

@bwriordan since you filed the issue, it'd be great if you can test this out. Thanks!