### PR TITLE
SKLL Release 1.5.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,17 +124,17 @@ Requirements
 
 -  Python 2.7+
 -  `scikit-learn <http://scikit-learn.org/stable/>`__
--  `six <https://warehouse.python.org/project/six>`__
--  `PrettyTable <https://warehouse.python.org/project/PrettyTable>`__
+-  `six <https://pypi.org/project/six/>`__
+-  `PrettyTable <https://pypi.org/project/PrettyTable/>`__
 -  `BeautifulSoup 4 <http://www.crummy.com/software/BeautifulSoup/>`__
--  `Grid Map <https://warehouse.python.org/project/gridmap>`__ (only required if you plan
+-  `Grid Map <https://pypi.org/project/gridmap/>`__ (only required if you plan
    to run things in parallel on a DRMAA-compatible cluster)
--  `joblib <https://warehouse.python.org/project/joblib>`__
+-  `joblib <https://pypi.org/project/joblib/>`__
 -  `ruamel.yaml <http://yaml.readthedocs.io/en/latest/overview.html>`__
--  `configparser <https://warehouse.python.org/project/configparser>`__ (only required for
+-  `configparser <https://pypi.org/project/configparser/>`__ (only required for
    Python 2.7)
--  `logutils <https://warehouse.python.org/project/logutils>`__ (only required for Python 2.7)
--  `mock <https://warehouse.python.org/project/mock>`__ (only required for Python 2.7)
+-  `logutils <https://pypi.org/project/logutils/>`__ (only required for Python 2.7)
+-  `mock <https://pypi.org/project/mock/>`__ (only required for Python 2.7)
 
 The following packages can be optionally installed for additional features
 but are not required:

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,7 +1,7 @@
 How to create and test conda package.
 
 1. To create the SKLL conda package run:
-   `conda build -c defaults -c conda-forge --python=3.6 --numpy=1.13 skll`
+   `conda build -c defaults -c conda-forge --python=3.6 --numpy=1.14 skll`
 2. Upload the package to anaconda.org using `anaconda upload <path>`.
 3. Test the package:
    `conda create -n foobar -c defaults -c conda-forge -c desilinguist python=3.6 skll=1.5`

--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: skll
-  version: 1.5.2
+  version: 1.5.3
 
 source:
   path: ../../../skll

--- a/doc/internal/release.rst
+++ b/doc/internal/release.rst
@@ -27,7 +27,7 @@ This document is only meant for the project administrators, not users and develo
 
 5. Upload each of the packages to anaconda.org using ``anaconda upload <package tarball>``.
 
-6. Upload source and wheel packages to PyPI using ``python setup.py sdist upload`` and ``python setup.py bdist_wheel upload``.
+6. Upload source package to PyPI using ``python setup.py sdist upload``.
 
 7. Draft a release on GitHub.
 

--- a/doc/internal/release.rst
+++ b/doc/internal/release.rst
@@ -17,17 +17,17 @@ This document is only meant for the project administrators, not users and develo
 
    e. update the README.
 
-3. Build the new conda package locally on your mac using the following command::
+3. Build the new conda package locally on your mac using the following command  (*Note*: you may have to replace the contents of the ``requirements()`` function in ``setup.py`` with a ``pass`` statement to get ``conda build`` to work)::
 
-    conda build -c defaults -c conda-forge --python=3.6 skll
+    conda build -c defaults -c conda-forge --python=3.6 --numpy=1.14 skll
 
 4. Convert the package for both linux and windows::
 
     conda convert -p win-64 -p linux-64 <mac package tarball>
 
-5. Upload all packages to anaconda.org using ``anaconda upload``.
+5. Upload each of the packages to anaconda.org using ``anaconda upload <package tarball>``.
 
-6. Upload source package to PyPI using ``python setup.py sdist upload``.
+6. Upload source and wheel packages to PyPI using ``python setup.py sdist upload`` and ``python setup.py bdist_wheel upload``.
 
 7. Draft a release on GitHub.
 

--- a/skll/version.py
+++ b/skll/version.py
@@ -7,5 +7,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :organization: ETS
 """
 
-__version__ = '1.5.2'
+__version__ = '1.5.3'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
- Update version numbers.
- Update links in README.
- Update release process documentation.

I have already built and uploaded the conda and PyPI packages and tested them locally on my Mac. They work fine. Feel free to test on other platforms 👍.