### PR TITLE
Set default value of `grid_search` in config files to be `True`. 

### DIFF
--- a/skll/config.py
+++ b/skll/config.py
@@ -58,7 +58,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                     'featuresets': '[]',
                     'featureset_names': '[]',
                     'fixed_parameters': '[]',
-                    'grid_search': 'False',
+                    'grid_search': 'True',
                     'grid_search_folds': '3',
                     'grid_search_jobs': '0',
                     'hasher_features': '0',
@@ -752,6 +752,13 @@ def _parse_config_file(config_path, log_level=logging.INFO):
                                                   'objectives',
                                                   logger=logger)
 
+    # if we are doing learning curves , we don't care about
+    # grid search
+    if task == 'learning_curve' and do_grid_search:
+        do_grid_search = False
+        logger.warning("Grid search is not supported during "
+                       "learning curve generation. Ignoring.")
+
     # Check if `param_grids` is specified, but `do_grid_search` is False
     if param_grid_list and not do_grid_search:
         logger.warning('Since "grid_search" is set to False, the specified'
@@ -790,7 +797,9 @@ def _parse_config_file(config_path, log_level=logging.INFO):
                          'predict.')
     if task in ['cross_validate', 'evaluate', 'train']:
         if do_grid_search and len(grid_objectives) == 0:
-            raise ValueError('You must specify a list of objectives if doing grid search.')
+            raise ValueError('Grid search is on. Either specify a list of tuning '
+                             'objectives or set `grid_search` to `false` in the '
+                             'Tuning section.')
         if not do_grid_search and len(grid_objectives) > 0:
             logger.warning('Since "grid_search" is set to False, any specified'
                            ' "objectives" will be ignored.')

--- a/skll/config.py
+++ b/skll/config.py
@@ -757,7 +757,7 @@ def _parse_config_file(config_path, log_level=logging.INFO):
     if task == 'learning_curve' and do_grid_search:
         do_grid_search = False
         logger.warning("Grid search is not supported during "
-                       "learning curve generation. Ignoring.")
+                       "learning curve generation. Disabling.")
 
     # Check if `param_grids` is specified, but `do_grid_search` is False
     if param_grid_list and not do_grid_search:

--- a/skll/experiments.py
+++ b/skll/experiments.py
@@ -1048,10 +1048,6 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',
 
     # No grid search or ablation for learning curve generation
     if task == 'learning_curve':
-        if do_grid_search:
-            do_grid_search = False
-            logger.warning("Grid search is not supported during "
-                           "learning curve generation. Ignoring.")
         if ablation is None or ablation > 0:
             ablation = 0
             logger.warning("Ablating features is not supported during "

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -1946,7 +1946,7 @@ class Learner(object):
                        examples,
                        stratified=True,
                        cv_folds=10,
-                       grid_search=False,
+                       grid_search=True,
                        grid_search_folds=3,
                        grid_jobs=None,
                        grid_objective=None,
@@ -2048,6 +2048,15 @@ class Learner(object):
         if (self.model_type._estimator_type == 'classifier' and
                 type_of_target(examples.labels) not in ['binary', 'multiclass']):
             raise ValueError("Floating point labels must be encoded as strings for cross-validation.")
+
+        # check that we have an objective since grid search is on by default
+        # Note that `train()` would raise this error anyway later but it's
+        # better to raise this early on so rather than after a whole bunch of
+        # stuff has happened
+        if grid_search:
+            if not grid_objective:
+                raise ValueError("Grid search is on by default. You must either "
+                                 "specify a grid objective or turn off grid search.")
 
         # Shuffle so that the folds are random for the inner grid search CV.
         # If grid search is True but shuffle isn't, shuffle anyway.

--- a/tests/configs/test_int_labels_cv.template.cfg
+++ b/tests/configs/test_int_labels_cv.template.cfg
@@ -9,3 +9,4 @@ suffix=.jsonlines
 [Output]
 
 [Tuning]
+grid_search=false

--- a/tests/configs/test_single_file_saved_subset.template.cfg
+++ b/tests/configs/test_single_file_saved_subset.template.cfg
@@ -6,6 +6,7 @@ task=evaluate
 learners=["RandomForestClassifier"]
 
 [Tuning]
+grid_search=false
 
 [Output]
 probability=false

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -712,7 +712,7 @@ def test_train_and_score_function():
 
 
 @raises(ValueError)
-def test_learner_api_grid_search_no_objective():
+def check_learner_api_grid_search_no_objective(task='train'):
 
     (train_fs,
      test_fs) = make_classification_data(num_examples=500,
@@ -721,7 +721,15 @@ def test_learner_api_grid_search_no_objective():
                                          use_feature_hashing=False,
                                          non_negative=True)
     learner = Learner('LogisticRegression')
-    _ = learner.train(train_fs)
+    if task == 'train':
+        _ = learner.train(train_fs)
+    else:
+        _ = learner.cross_validate(train_fs)
+
+
+def test_learner_api_grid_search_no_objective():
+    yield check_learner_api_grid_search_no_objective, 'train'
+    yield check_learner_api_grid_search_no_objective, 'cross_validate'
 
 
 def test_learner_api_load_into_existing_instance():

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -585,9 +585,9 @@ def test_new_labels_in_test_set_change_order():
     train_fs, test_fs = make_classification_data(num_labels=3,
                                                  train_test_ratio=0.8)
     # change train labels to create a gap
-    train_fs.labels = train_fs.labels*10
+    train_fs.labels = train_fs.labels * 10
     # add new test labels
-    test_fs.labels = test_fs.labels*10
+    test_fs.labels = test_fs.labels * 10
     test_fs.labels[-3:] = 15
 
     learner = Learner('SVC')
@@ -604,7 +604,7 @@ def test_all_new_labels_in_test():
     train_fs, test_fs = make_classification_data(num_labels=3,
                                                  train_test_ratio=0.8)
     # change all test labels
-    test_fs.labels = test_fs.labels+3
+    test_fs.labels = test_fs.labels + 3
 
     learner = Learner('SVC')
     learner.train(train_fs, grid_search=False)
@@ -644,6 +644,7 @@ def test_xval_float_classes_as_strings():
     prediction_prefix = join(_my_dir, 'output', 'float_class')
     learner = Learner('LogisticRegression')
     learner.cross_validate(float_class_fs,
+                           grid_search=True,
                            grid_objective='accuracy',
                            prediction_prefix=prediction_prefix)
 
@@ -663,6 +664,7 @@ def check_bad_xval_float_classes(do_stratified_xval):
     learner = Learner('LogisticRegression')
     learner.cross_validate(float_class_fs,
                            stratified=do_stratified_xval,
+                           grid_search=True,
                            grid_objective='accuracy',
                            prediction_prefix=prediction_prefix)
 

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -278,7 +278,6 @@ def test_retrieve_cv_folds():
                                                  stratified=False,
                                                  cv_folds=num_folds,
                                                  grid_search=False,
-                                                 grid_objective='f1_score_micro',
                                                  shuffle=False,
                                                  save_cv_folds=True)
     assert_equal(skll_fold_ids, custom_cv_folds)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1051,7 +1051,7 @@ def test_config_parsing_no_grid_objectives_needed_for_learning_curve():
      class_map, custom_learner_path, learning_curve_cv_folds_list,
      learning_curve_train_sizes, output_metrics) = _parse_config_file(config_path)
 
-    eq_(do_grid_search, True)
+    eq_(do_grid_search, False)
     eq_(grid_objectives, [])
     eq_(output_metrics, ['neg_mean_squared_error'])
 
@@ -1060,7 +1060,7 @@ def test_config_parsing_relative_input_path():
 
     train_dir = join('..', 'train')
     output_dir = join(_my_dir, 'output')
-    
+
     # make a simple config file that has relative paths
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'cross_validate',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1204,8 +1204,9 @@ def check_config_parsing_metrics_and_objectives_overlap(task,
         values_to_fill_dict['test_directory'] = test_dir
 
     if objectives:
-        values_to_fill_dict['grid_search'] = 'true'
         values_to_fill_dict['objectives'] = str(objectives)
+    else:
+        values_to_fill_dict['grid_search'] = 'false'
 
     config_template_path = join(_my_dir, 'configs',
                                 'test_config_parsing.template.cfg')
@@ -1355,7 +1356,7 @@ def check_cv_folds_and_grid_search_folds(task,
                            'featuresets': "[['f1', 'f2', 'f3']]",
                            'learners': "['LogisticRegression']",
                            'log': output_dir,
-                           'objectives': "['f1_score_mcro']"}
+                           'objectives': "['f1_score_macro']"}
 
     # we need the models field when training but the results field
     # when cross-validating

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -281,7 +281,7 @@ def test_config_parsing_bad_learner():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has bas learner specifications
+    # make a simple config file that has bad learner specifications
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -316,7 +316,7 @@ def test_config_parsing_bad_sampler():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad sampling information
+    # make a simple config file that has bad sampling information
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -524,7 +524,7 @@ def test_config_parsing_bad_test():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has bad test paths
+    # make a simple config file that has bad test path
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -225,8 +225,7 @@ def test_config_parsing_no_name():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has no experiment name
     values_to_fill_dict = {'train_directory': train_dir,
                            'test_directory': test_dir,
                            'task': 'evaluate',
@@ -282,8 +281,7 @@ def test_config_parsing_bad_learner():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bas learner specifications
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -318,8 +316,7 @@ def test_config_parsing_bad_sampler():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has a bad sampling information
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -348,8 +345,7 @@ def test_config_parsing_bad_hashing():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bad feature hashing information
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -377,8 +373,7 @@ def test_config_parsing_bad_featuresets():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bad feature sets
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -410,8 +405,7 @@ def test_config_parsing_bad_featurenames():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bad feature names
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -446,8 +440,7 @@ def test_config_parsing_bad_scaling():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bad scaling information
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -481,8 +474,7 @@ def test_config_parsing_bad_train():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has a bad train paths
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'test_directory': test_dir,
@@ -532,8 +524,7 @@ def test_config_parsing_bad_test():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bad test paths
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -583,12 +574,10 @@ def test_config_parsing_grid_search_but_no_objectives():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has grid search turned on but no objectives
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
-                           'grid_search': 'true',
                            'test_directory': test_dir,
                            'featuresets': "[['f1', 'f2', 'f3']]",
                            'learners': "['LogisticRegression']",
@@ -613,8 +602,7 @@ def test_config_parsing_bad_objective():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has an invalid objective value
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -623,6 +611,7 @@ def test_config_parsing_bad_objective():
                            'learners': "['LogisticRegression']",
                            'log': output_dir,
                            'results': output_dir,
+                           'grid_search': 'true',
                            'objectives': "['foobar']"}
 
     config_template_path = join(_my_dir, 'configs',
@@ -643,9 +632,7 @@ def test_config_parsing_bad_objectives():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
-
+    # make a simple config file that has a mistyped objective value
     config_template_path = join(_my_dir, 'configs',
                                 'test_config_parsing.template.cfg')
     values_to_fill_dict = {'experiment_name': 'config_parsing',
@@ -656,6 +643,7 @@ def test_config_parsing_bad_objectives():
                            'learners': "['LogisticRegression']",
                            'log': output_dir,
                            'results': output_dir,
+                           'grid_search': 'true',
                            'objectives': "accuracy"}
     config_path = fill_in_config_options(config_template_path,
                                          values_to_fill_dict,
@@ -672,8 +660,7 @@ def test_config_parsing_bad_metric():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bad metrics
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -702,8 +689,7 @@ def test_config_parsing_bad_metric_2():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has bad metrics
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -732,8 +718,6 @@ def test_config_parsing_log_loss_no_probability():
     test_dir = join(_my_dir, 'test')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'evaluate',
                            'train_directory': train_dir,
@@ -755,8 +739,9 @@ def test_config_parsing_log_loss_no_probability():
 
 
 def test_config_parsing_bad_task_paths():
+
     # Test to ensure config file parsing raises an error with various
-    # incorrectly set path
+    # incorrectly set paths
 
     train_dir = join(_my_dir, 'train')
     test_dir = join(_my_dir, 'test')
@@ -968,7 +953,7 @@ def test_config_parsing_mislocated_input_path():
     train_dir = 'train'
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has an invalid option
+    # make a simple config file that has a mislocated path
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'cross_validate',
                            'train_directory': train_dir,
@@ -989,6 +974,9 @@ def test_config_parsing_mislocated_input_path():
 
 
 def test_config_parsing_mse_to_neg_mse():
+    """
+    Check that `mean_squared_error` gets normalized properly
+    """
 
     train_dir = join('..', 'train')
     output_dir = join(_my_dir, 'output')
@@ -1027,11 +1015,13 @@ def test_config_parsing_mse_to_neg_mse():
 
 
 def test_config_parsing_no_grid_objectives_needed_for_learning_curve():
+    """
+    Check that tuning objectives are not needed for learning curve task
+    """
 
     train_dir = join('..', 'train')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has an invalid option
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'learning_curve',
                            'train_directory': train_dir,
@@ -1070,8 +1060,8 @@ def test_config_parsing_relative_input_path():
 
     train_dir = join('..', 'train')
     output_dir = join(_my_dir, 'output')
-
-    # make a simple config file that has an invalid option
+    
+    # make a simple config file that has relative paths
     values_to_fill_dict = {'experiment_name': 'config_parsing',
                            'task': 'cross_validate',
                            'train_directory': train_dir,
@@ -1365,7 +1355,7 @@ def check_cv_folds_and_grid_search_folds(task,
                            'featuresets': "[['f1', 'f2', 'f3']]",
                            'learners': "['LogisticRegression']",
                            'log': output_dir,
-                           'objectives': "['f1_score_macro']"}
+                           'objectives': "['f1_score_mcro']"}
 
     # we need the models field when training but the results field
     # when cross-validating
@@ -1837,8 +1827,7 @@ def test_config_parsing_param_grids_no_grid_search():
     train_dir = join(_my_dir, 'train')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that turns off grid search but specifies param grids
     values_to_fill_dict = {'experiment_name': 'config_parsing_param_grids_no_grid_search',
                            'task': 'train',
                            'train_directory': train_dir,
@@ -1846,7 +1835,7 @@ def test_config_parsing_param_grids_no_grid_search():
                            'learners': "['LinearSVC']",
                            'log': output_dir,
                            'models': output_dir,
-                           'objectives': "['f1_score_macro']",
+                           'grid_search': 'false',
                            'param_grids': "[{'C': [1e-6, 0.001, 1, 10, 100, 1e5]}]"}
 
     config_template_path = join(_my_dir, 'configs',
@@ -1873,8 +1862,7 @@ def test_config_parsing_no_grid_search_but_objectives_specified():
     train_dir = join(_my_dir, 'train')
     output_dir = join(_my_dir, 'output')
 
-    # make a simple config file that has a bad task
-    # but everything else is correct
+    # make a simple config file that has grid search off but still specifies objectives
     values_to_fill_dict = {'experiment_name': 'config_parsing_objectives_no_grid_search',
                            'task': 'train',
                            'train_directory': train_dir,
@@ -1882,6 +1870,7 @@ def test_config_parsing_no_grid_search_but_objectives_specified():
                            'learners': "['LinearSVC']",
                            'log': output_dir,
                            'models': output_dir,
+                           'grid_search': 'false',
                            'objectives': "['f1_score_macro', 'accuracy']"}
 
     config_template_path = join(_my_dir, 'configs',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1026,7 +1026,6 @@ def test_config_parsing_no_grid_objectives_needed_for_learning_curve():
                            'task': 'learning_curve',
                            'train_directory': train_dir,
                            'featuresets': "[['f1', 'f2', 'f3']]",
-                           'grid_search': 'true',
                            'learners': "['LogisticRegression']",
                            'log': output_dir,
                            'metrics': "['neg_mean_squared_error']",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,7 +18,6 @@ from os.path import abspath, dirname, exists, join
 from nose.tools import raises
 from numpy.testing import assert_almost_equal
 
-from skll.data import FeatureSet
 from skll.learner import Learner
 from skll.learner import _DEFAULT_PARAM_GRIDS
 from skll.metrics import kappa

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -154,14 +154,14 @@ def check_summary_score(use_feature_hashing,
 
     if use_feature_hashing:
         cfgfile = ('test_summary_feature_hasher_with_metrics.template.cfg' if
-                    use_additional_metrics else 'test_summary_feature_hasher.template.cfg')
+                   use_additional_metrics else 'test_summary_feature_hasher.template.cfg')
         outprefix = ('test_summary_feature_hasher_with_metrics_test_summary' if
                      use_additional_metrics else 'test_summary_feature_hasher_test_summary')
         summprefix = ('test_summary_feature_hasher_with_metrics' if
                       use_additional_metrics else 'test_summary_feature_hasher')
     else:
         cfgfile = ('test_summary_with_metrics.template.cfg' if
-                    use_additional_metrics else 'test_summary.template.cfg')
+                   use_additional_metrics else 'test_summary.template.cfg')
         outprefix = ('test_summary_with_metrics_test_summary' if
                      use_additional_metrics else 'test_summary_test_summary')
         summprefix = ('test_summary_with_metrics' if
@@ -258,7 +258,7 @@ def check_summary_score(use_feature_hashing,
 
     if not use_feature_hashing:
         test_tuples.append((naivebayes_result_score,
-                             naivebayes_summary_score,
+                            naivebayes_summary_score,
                             'MultinomialNB'))
         if use_additional_metrics:
             test_tuples.extend([(nb_result_additional_metric1,
@@ -606,6 +606,7 @@ def test_learning_curve_plots_with_objectives():
         ok_(exists(join(_my_dir,
                         'output',
                         '{}_{}.png'.format(outprefix, featureset_name))))
+
 
 @attr('have_pandas_and_seaborn')
 def test_learning_curve_ylimits():

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -100,8 +100,8 @@ def check_rescaling(name, grid_search=False):
     # train both the regular regressor and the rescaled regressor
     # with and without using grid search
     if grid_search:
-        learner.train(train_fs, grid_objective='pearson')
-        rescaled_learner.train(train_fs, grid_objective='pearson')
+        learner.train(train_fs, grid_search=True, grid_objective='pearson')
+        rescaled_learner.train(train_fs, grid_search=True, grid_objective='pearson')
     else:
         learner.train(train_fs, grid_search=False)
         rescaled_learner.train(train_fs, grid_search=False)
@@ -180,7 +180,7 @@ def check_linear_models(name,
 
     # train it with the training feature set we created
     # make sure to set the grid objective to pearson
-    learner.train(train_fs, grid_objective='pearson')
+    learner.train(train_fs, grid_search=True, grid_objective='pearson')
 
     # make sure that the weights are close to the weights
     # that we got from make_regression_data. Take the
@@ -258,7 +258,7 @@ def check_non_linear_models(name,
 
     # train it with the training feature set we created
     # make sure to set the grid objective to pearson
-    learner.train(train_fs, grid_objective='pearson')
+    learner.train(train_fs, grid_search=True, grid_objective='pearson')
 
     # Note that we cannot check the feature weights here
     # since `model_params()` is not defined for non-linear
@@ -315,7 +315,7 @@ def check_tree_models(name,
 
     # train it with the training feature set we created
     # make sure to set the grid objective to pearson
-    learner.train(train_fs, grid_objective='pearson')
+    learner.train(train_fs, grid_search=True, grid_objective='pearson')
 
     # make sure that the feature importances are as expected.
     if name.endswith('DecisionTreeRegressor'):
@@ -391,7 +391,7 @@ def check_ensemble_models(name,
 
     # train it with the training feature set we created
     # make sure to set the grid objective to pearson
-    learner.train(train_fs, grid_objective='pearson')
+    learner.train(train_fs, grid_search=True, grid_objective='pearson')
 
     # make sure that the feature importances are as expected.
     if name.endswith('AdaBoostRegressor'):
@@ -478,7 +478,7 @@ def test_additional_metrics():
 
     # train a regression model using the train feature set
     learner = Learner('LinearRegression')
-    learner.train(train_fs, grid_objective='pearson')
+    learner.train(train_fs, grid_search=True, grid_objective='pearson')
 
     # evaluate the trained model using the test feature set
     results = learner.evaluate(test_fs, output_metrics=['spearman',
@@ -499,7 +499,7 @@ def test_fancy_output():
 
     # train a regression model using the train feature set
     learner = Learner('LinearRegression')
-    learner.train(train_fs, grid_objective='pearson')
+    learner.train(train_fs, grid_search=True, grid_objective='pearson')
 
     # evaluate the trained model using the test feature set
     resultdict = learner.evaluate(test_fs)


### PR DESCRIPTION
In order to be consistent with the API, it makes sense to set `grid_search` to be `True` by default in the config files. 

- Set default value of `grid_search` to be `True` in the config parser.
-  Update error message when no objectives are provided  to be more informative in light of this similar to the API error message.
- Move the grid search + learning curve check to config parsing instead of in `experiments.py` since it belongs here. And update the warning message to be more accurate.
- Update all tests and templates
    - If we were not previously specifiying grid search, we wanted it to be false so we need to be explicit about that now.
    - Explicitly specify grid search in API everywhere
- Fix some comments and docstrings in tests.
- Minor flake8 fixes.