### PR TITLE
Make `model_params` and `print_model_weights` work with hashed features

### DIFF
--- a/skll/learner.py
+++ b/skll/learner.py
@@ -1113,9 +1113,14 @@ class Learner(object):
             coef = self.model.coef_
             intercept = {'_intercept_': self.model.intercept_}
 
-            # convert SVR coefficient format (1 x matrix) to array
+            # convert SVR coefficient from a matrix to a 1D array
+            # and convert from sparse to dense also if necessary.
+            # However, this last bit may not be necessary
+            # if we did feature scaling and coef is already dense.
             if isinstance(self._model, SVR):
-                coef = coef.toarray()[0]
+                if sp.issparse(coef):
+                    coef = coef.toarray()
+                coef = coef[0]
 
             # inverse transform to get indices for before feature selection
             coef = coef.reshape(1, -1)

--- a/skll/learner.py
+++ b/skll/learner.py
@@ -14,13 +14,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import inspect
-import math
 import logging
 import os
 import sys
 from collections import Counter, defaultdict
 from functools import wraps
 from importlib import import_module
+from math import floor, log10
 from itertools import combinations
 from multiprocessing import cpu_count
 
@@ -1075,7 +1075,7 @@ class Learner(object):
             if isinstance(self.feat_vectorizer, FeatureHasher):
                 self.logger.warning("No feature names are available since this model was trained on hashed features.")
                 num_features = len(coef)
-                index_width_in_feature_name = math.floor(math.log10(num_features)) + 1
+                index_width_in_feature_name = int(floor(log10(num_features))) + 1
                 for idx in range(num_features):
                     if coef[idx]:
                         index_str = str(idx + 1).zfill(index_width_in_feature_name)
@@ -1104,7 +1104,7 @@ class Learner(object):
                 coef = self.feat_selector.inverse_transform(coef)[0]
                 if isinstance(self.feat_vectorizer, FeatureHasher):
                     num_features = len(coef)
-                    index_width_in_feature_name = math.floor(math.log10(num_features)) + 1
+                    index_width_in_feature_name = int(floor(log10(num_features))) + 1
                     for idx in range(num_features):
                         if coef[idx]:
                             index_str = str(idx + 1).zfill(index_width_in_feature_name)
@@ -1142,7 +1142,7 @@ class Learner(object):
                 class2 = self.label_list[class_pair[1]]
                 if isinstance(self.feat_vectorizer, FeatureHasher):
                     num_features = len(coef)
-                    index_width_in_feature_name = math.floor(math.log10(num_features)) + 1
+                    index_width_in_feature_name = int(floor(log10(num_features))) + 1
                     for idx in range(num_features):
                         if coef[idx]:
                             index_str = str(idx + 1).zfill(index_width_in_feature_name)

--- a/skll/utilities/print_model_weights.py
+++ b/skll/utilities/print_model_weights.py
@@ -78,11 +78,7 @@ def main(argv=None):
                 intercept_is_array = False
 
             # now print out the intercepts
-            if intercept_is_array:
-                    intercept_list = ["%.12f" % i for i in model_intercepts]
-                    print("intercept = {}".format(intercept_list))
-            else:
-                print("intercept = {:.12f}".format(model_intercepts))
+            print("intercept = {:.12f}".format(model_intercepts))
         else:
             print("== intercept values ==")
             for (label, val) in intercept.items():

--- a/skll/utilities/print_model_weights.py
+++ b/skll/utilities/print_model_weights.py
@@ -67,12 +67,22 @@ def main(argv=None):
     if intercept is not None:
         # subclass of LinearModel
         if '_intercept_' in intercept:
-            # Some learners (e.g. LinearSVR) may return a list of intercepts
-            if isinstance(intercept['_intercept_'], np.ndarray):
-                intercept_list = ["%.12f" % i for i in intercept['_intercept_']]
-                print("intercept = {}".format(intercept_list))
+            # Some learners (e.g. LinearSVR) may return an array of intercepts but
+            # sometimes that array is of length 1 so we don't need to print that
+            # as an array/list. First, let's normalize these cases.
+            model_intercepts = intercept['_intercept_']
+            intercept_is_array = isinstance(model_intercepts, np.ndarray)
+            num_intercepts = len(model_intercepts) if intercept_is_array else 1
+            if intercept_is_array and num_intercepts == 1:
+                model_intercepts = model_intercepts[0]
+                intercept_is_array = False
+
+            # now print out the intercepts
+            if intercept_is_array:
+                    intercept_list = ["%.12f" % i for i in model_intercepts]
+                    print("intercept = {}".format(intercept_list))
             else:
-                print("intercept = {:.12f}".format(intercept['_intercept_']))
+                print("intercept = {:.12f}".format(model_intercepts))
         else:
             print("== intercept values ==")
             for (label, val) in intercept.items():

--- a/skll/utilities/print_model_weights.py
+++ b/skll/utilities/print_model_weights.py
@@ -4,6 +4,7 @@
 Simple script for printing out model weights.
 
 :author: Michael Heilman (mheilman@ets.org)
+:author: Nitin Madnani (nmadnani@ets.org)
 :organization: ETS
 """
 

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -194,8 +194,10 @@ def test_ablation_cv_feature_hasher_all_combos():
     run_configuration(config_path, quiet=True, ablation=None)
 
     # read in the summary file and make sure it has
-    # 10 ablated featuresets * (10 folds + 1 average line) * 2 learners = 220
-    # lines
+    #    10 ablated featuresets
+    #      * (10 folds + 1 average line)
+    #      * 2 learners
+    #    = 220 lines in total
     with open(join(_my_dir,
                    'output',
                    'ablation_cv_feature_hasher_all_combos_summary.tsv')) as f:
@@ -206,8 +208,8 @@ def test_ablation_cv_feature_hasher_all_combos():
     # make sure there are 10 ablated featuresets * 2 learners = 20 results
     # files
     num_result_files = len(glob(join(_my_dir,
-                                    'output',
-                                    'ablation_cv_feature_hasher_all_combos*.results')))
+                                     'output',
+                                     'ablation_cv_feature_hasher_all_combos*.results')))
     eq_(num_result_files, 20)
 
 
@@ -233,8 +235,8 @@ def test_ablation_cv_sampler():
 
     # make sure there are 6 ablated featuresets * 2 learners = 12 results files
     num_result_files = len(glob(join(_my_dir,
-                                    'output',
-                                    'ablation_cv_sampler*.results')))
+                                     'output',
+                                     'ablation_cv_sampler*.results')))
     eq_(num_result_files, 14)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,10 +5,10 @@ Utilities functions to make SKLL testing simpler
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import math
 import re
 
 from collections import OrderedDict
+from math import floor, log10
 from os.path import abspath, dirname, exists, join
 
 import numpy as np
@@ -341,7 +341,7 @@ def make_regression_data(num_examples=100,
     ids = ['EXAMPLE_{}'.format(n) for n in range(1, num_examples + 1)]
 
     # create a list of dictionaries as the features
-    index_width_for_feature_name = math.floor(math.log10(num_features)) + 1
+    index_width_for_feature_name = int(floor(log10(num_features))) + 1
     feature_names = []
     for n in range(start_feature_num, start_feature_num + num_features):
         index_str = str(n).zfill(index_width_for_feature_name)
@@ -369,7 +369,7 @@ def make_regression_data(num_examples=100,
     # that would be output by `model_params()` instead of the
     # original names since that's what we would get from SKLL
     if use_feature_hashing:
-        index_width_for_feature_name = math.floor(math.log10(feature_bins)) + 1
+        index_width_for_feature_name = int(floor(log10(feature_bins))) + 1
         hashed_feature_names = []
         for i in range(feature_bins):
             index_str = str(i + 1).zfill(index_width_for_feature_name)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -324,7 +324,7 @@ def make_regression_data(num_examples=100,
 
     # if we are doing feature hashing and we have asked for more
     # feature bins than number of total features, we need to
-    # handle that because `mqke_regression()` doesn't know
+    # handle that because `make_regression()` doesn't know
     # about hashing
     if use_feature_hashing and num_features < feature_bins:
         num_features = feature_bins
@@ -349,15 +349,15 @@ def make_regression_data(num_examples=100,
         feature_names.append(feature_name)
     features = [dict(zip(feature_names, row)) for row in X]
 
-    # At this point the weights are learned from unhashed features
+    # At this point the labels are generated using unhashed features
     # even if we want to do feature hashing. `make_regression()` from
     # sklearn doesn't know anything about feature hashing, so we need
-    # a hack here to compute the correct expected weights ourselves
+    # a hack here to compute the updated labels ourselves
     # using the same command that sklearn uses inside `make_regression()`
     # which is to generate the X and the weights and then compute the
     # y as the dot product of the two. This y will then be used as our
-    # labels instead of the original y we got from `make_regression()`
-    # note that we only want to use the number of weights that are
+    # labels instead of the original y we got from `make_regression()`.
+    # Note that we only want to use the number of weights that are
     # equal to the number of feature bins for the hashing
     if use_feature_hashing:
         feature_hasher = FeatureHasher(n_features=feature_bins)


### PR DESCRIPTION
- Modify `model_params` to work with hashed features. Since we lose the original feature names after hashing, we make up names in the format `hashed_feature_xx` in the output. 
- Tweak`print_model_weights` utility to print intercepts more clearly. For example, if the intercept list contains a single item, do not print it as a list.
- Update the utility function `make_regression_data()` to properly produce hashed feature data. This particular SKLL function relies on the sklearn function `make_regression()` which doesn’t know anything about hashed features. `make_regression()` works by generating random feature values, adding noise to them, generating weights randomly, and then computing the labels by taking dot product of the feature values and the weights. `make_regression_data()` then uses this data and creates train and test feature sets that are then used by tests. Previously when feature hashing was used, the learners in the tests were using the same labels as generated by `make_regresssion()` which doesn’t know anything about hashing. This meant that learners were using hashed versions of the feature values but the same labels so the linear relationship was not as strong. This meant lower correlation values in the tests. I now changed `make_regression_data()` to modify the labels based on the hashed versions of the features. This means that that the correlation values in the tests should now be > 0.9 range just like for unhashed features. 
- Update tests to deal with changes to `make_regression_data()`.
- Update regression and utility tests to cover the `model_params` and `print_model_weights` changes.