### PR TITLE
Document the internal conversion of string labels to ints/floats and possible edge cases

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -406,6 +406,26 @@ example, if you wanted to collapse the labels ``beagle`` and ``dachsund`` into a
 
 Any labels not included in the dictionary will be left untouched.
 
+One other use case for ``class_map`` is to deal with classification labels that
+would be converted to ``float``s improperly. All ``Reader`` sub-classes use the
+``safe_float`` function internally to read labels. This function tries to
+convert a single label first to ``int``, then to ``float``. If neither
+conversion is possible, the label remains a ``str``. Thus, care must be taken
+to ensure that labels do not get converted in unexpected ways. For example,
+consider the situation where there are classification labels that are a mixture
+of ``int``-converting ``float``-converting labels:
+
+.. code-block:: python
+    import numpy as np
+    from skll.data.readers import safe_float
+    np.array([safe_float(x) for x in ["2", "2.2", "2.21"]]) # array([2.  , 2.2 , 2.21])
+
+The labels will all be converted to floats and any classification model
+generated with this data will predict labels such as ``2.0``, ``2.2``, etc.,
+not ``str`` values that exactly match the input labels, as might be expected.
+``class_map`` could be used to map the original labels to new values that do
+not have the same characteristics.
+
 .. _num_cv_folds:
 
 num_cv_folds *(Optional)*

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -408,7 +408,7 @@ Any labels not included in the dictionary will be left untouched.
 
 One other use case for ``class_map`` is to deal with classification labels that
 would be converted to ``float`` improperly. All ``Reader`` sub-classes use the
-``safe_float`` function internally to read labels. This function tries to
+:py:mod:`skll.data.readers.safe_float` function internally to read labels. This function tries to
 convert a single label first to ``int``, then to ``float``. If neither
 conversion is possible, the label remains a ``str``. Thus, care must be taken
 to ensure that labels do not get converted in unexpected ways. For example,
@@ -416,6 +416,7 @@ consider the situation where there are classification labels that are a mixture
 of ``int``-converting and ``float``-converting labels:
 
 .. code-block:: python
+
     import numpy as np
     from skll.data.readers import safe_float
     np.array([safe_float(x) for x in ["2", "2.2", "2.21"]]) # array([2.  , 2.2 , 2.21])

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -407,13 +407,13 @@ example, if you wanted to collapse the labels ``beagle`` and ``dachsund`` into a
 Any labels not included in the dictionary will be left untouched.
 
 One other use case for ``class_map`` is to deal with classification labels that
-would be converted to ``float``s improperly. All ``Reader`` sub-classes use the
+would be converted to ``float`` improperly. All ``Reader`` sub-classes use the
 ``safe_float`` function internally to read labels. This function tries to
 convert a single label first to ``int``, then to ``float``. If neither
 conversion is possible, the label remains a ``str``. Thus, care must be taken
 to ensure that labels do not get converted in unexpected ways. For example,
 consider the situation where there are classification labels that are a mixture
-of ``int``-converting ``float``-converting labels:
+of ``int``-converting and ``float``-converting labels:
 
 .. code-block:: python
     import numpy as np

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -1,6 +1,32 @@
 # License: BSD 3 clause
 """
-Handles loading data from various types of data files.
+This module handles loading data from various types of data files. A
+base ``Reader`` class is provided that is sub-classed for each data
+file type that is supported, e.g. ``CSVReader``.
+
+Notes about Label Conversion
+----------------------------
+
+All ``Reader`` sub-classes use the ``safe_float`` function internally
+to read in labels. This function tries to convert a single label
+first to ``int``, then to ``float``. If neither conversion is
+possible, the label remains a ``str``. It should be noted that, if
+classification is being done with a feature set that is read in with
+one of the ``Reader`` sub-classes, care must be taken to ensure that
+labels do not get converted in unexpected ways. For example,
+classification labels should not be a mixture of ``int``-converting
+and ``float``-converting labels. Consider the situation below:
+
+>>> import numpy as np
+>>> from skll.data.readers import safe_float
+>>> np.array([safe_float(x) for x in ["2", "2.2", "2.21"]]) # array([2.  , 2.2 , 2.21])
+
+The labels will all be converted to floats and any classification
+model generated with this data will predict labels such as ``2.0``,
+``2.2``, etc., not ``str`` values that exactly match the input
+labels, as might be expected. Be aware that it may be best to make
+use of the ``class_map`` keyword argument in such cases to map
+original labels to labels that convert only to ``str``.
 
 :author: Dan Blanchard (dblanchard@ets.org)
 :author: Michael Heilman (mheilman@ets.org)


### PR DESCRIPTION
I'm a bit unsure where this documentation should go. It would seem to be out of place and obtrusive almost anywhere except for in the `skll.readers` module itself. I tried to keep it brief and I hope that it can serve a purpose. Let me know if you think that it doesn't work here or should be written differently, etc.