### PR TITLE
Bugfix/gen preds

### DIFF
--- a/skll/utilities/generate_predictions.py
+++ b/skll/utilities/generate_predictions.py
@@ -143,14 +143,22 @@ def main(argv=None):
                              'this must be the final column to count as the '
                              'label.',
                         default='y')
-    parser.add_argument('-p', '--positive_label_index',
-                        help="If the model is only being used to predict the "
-                             "probability of a particular label, this "
-                             "specifies the index of the label we're "
-                             "predicting. 1 = second label, which is default "
-                             "for binary classification. Keep in mind that "
-                             "labels are sorted lexicographically.",
-                        default=1, type=int)
+
+    pos_label_idx_group = parser.add_mutually_exclusive_group()
+    pos_label_idx_help_mssg = ("If the model is only being used to predict "
+                               "the probability of a particular label, this "
+                               "specifies the index of the label we're "
+                               "predicting. 1 = second label, which is "
+                               "default for binary classification. Keep in "
+                               "mind that labels are sorted "
+                               "lexicographically.")
+    pos_label_idx_group.add_argument('--positive_label',
+                                     help=pos_label_idx_help_mssg,
+                                     type=int)
+    pos_label_idx_group.add_argument('-p', '--positive_label_index',
+                                     help=pos_label_idx_help_mssg,
+                                     default=1, type=int)
+
     parser.add_argument('-q', '--quiet',
                         help='Suppress printing of "Loading..." messages.',
                         action='store_true')
@@ -181,9 +189,16 @@ def main(argv=None):
                                 '%(message)s'))
     logger = logging.getLogger(__name__)
 
+    if args.positive_label:
+        logger.warning("The `positive_label` argument is deprecated. Use "
+                       "`positive_label_index` instead.")
+        positive_label_index = args.positive_label
+    else:
+        positive_label_index = args.positive_label_index
+
     # Create the classifier and load the model
     predictor = Predictor(args.model_file,
-                          positive_label_index=args.positive_label_index,
+                          positive_label_index=positive_label_index,
                           threshold=args.threshold,
                           all_labels=args.all_probabilities,
                           logger=logger)

--- a/skll/utilities/generate_predictions.py
+++ b/skll/utilities/generate_predictions.py
@@ -27,7 +27,7 @@ class Predictor(object):
     predictions for feature strings.
     """
 
-    def __init__(self, model_path, threshold=None, positive_label=1,
+    def __init__(self, model_path, threshold=None, positive_label_index=1,
                  all_labels=False, logger=None):
         """
         Initialize the predictor.
@@ -41,7 +41,7 @@ class Predictor(object):
             of the positive label, return 1 if it meets/exceeds
             the given threshold and 0 otherwise.
             Defaults to ``None``.
-        positive_label : int, optional
+        positive_label_index : int, optional
             If the model is only being used to predict the
             probability of a particular class, this
             specifies the index of the class we're
@@ -62,7 +62,7 @@ class Predictor(object):
                              "exclusive. They can not both be set to True.")
 
         self._learner = Learner.from_file(model_path)
-        self._pos_index = positive_label
+        self._pos_index = positive_label_index
         self.threshold = threshold
         self.all_labels = all_labels
         self.output_file_header = None
@@ -91,7 +91,7 @@ class Predictor(object):
             if self.all_labels:
                 self.output_file_header = ["id"] + [str(x) for x in labels]
             elif self.threshold is None:
-                label = self._learner.label_dict[self._pos_index]
+                label = self._learner.label_list[self._pos_index]
                 self.output_file_header = ["id",
                                            "Probability of '{}'".format(label)]
                 preds = [pred[self._pos_index] for pred in preds]
@@ -143,7 +143,7 @@ def main(argv=None):
                              'this must be the final column to count as the '
                              'label.',
                         default='y')
-    parser.add_argument('-p', '--positive_label',
+    parser.add_argument('-p', '--positive_label_index',
                         help="If the model is only being used to predict the "
                              "probability of a particular label, this "
                              "specifies the index of the label we're "
@@ -183,7 +183,7 @@ def main(argv=None):
 
     # Create the classifier and load the model
     predictor = Predictor(args.model_file,
-                          positive_label=args.positive_label,
+                          positive_label_index=args.positive_label_index,
                           threshold=args.threshold,
                           all_labels=args.all_probabilities,
                           logger=logger)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -304,6 +304,7 @@ def check_generate_predictions(use_feature_hashing=False,
                                test_on_subset=False,
                                use_all_labels=False,
                                string_labels=False):
+
     # create some simple classification feature sets for training and testing
     string_label_list = ['a', 'b'] if string_labels else None
 
@@ -312,7 +313,9 @@ def check_generate_predictions(use_feature_hashing=False,
                                                  use_feature_hashing=use_feature_hashing,
                                                  feature_bins=4,
                                                  string_label_list=string_label_list)
-    enable_probability = use_threshold or use_all_labels
+
+    enable_probability = any([use_threshold, use_all_labels])
+
     # create a learner that uses an SGD classifier
     learner = Learner('SGDClassifier', probability=enable_probability)
 
@@ -325,7 +328,7 @@ def check_generate_predictions(use_feature_hashing=False,
     if test_on_subset and not use_feature_hashing:
         test_fs.filter(features=['f01', 'f02', 'f03', 'f04'])
 
-    # There are two cases where we don't want translate the predictions to
+    # There are two cases where we don't want to translate the predictions to
     # class labels:
     #   1) If `use_all_labels` is True, a prediction will be a list of
     #      probabilities.
@@ -370,11 +373,17 @@ def check_generate_predictions_file_headers(use_threshold=False,
                                             string_labels=False):
 
     string_label_list = ['a', 'b'] if string_labels else None
+
     # create some simple classification feature sets for training and testing
     train_fs, test_fs = make_classification_data(num_examples=1000,
                                                  num_features=5,
                                                  feature_bins=4,
                                                  string_label_list=string_label_list)
+
+    # Unlike in other generate_predictions tests, for the headers test we
+    # want to enable probability when labels are strings in order to verify
+    # that the output header includes the correct label name(s) ("Probability
+    # of <label>", or "id, <label1>, <label2>").
     enable_probability = any([use_threshold, use_all_labels, string_labels])
 
     # create a learner that uses an SGD classifier
@@ -427,8 +436,9 @@ def test_generate_predictions_conflicting_params():
 
 def test_generate_predictions():
     for (use_feature_hashing, use_threshold, test_on_subset, all_probabilities,
-         string_labels) in product(*[[True, False]] * 5):
-
+         string_labels) in product(*[[True, False], [True, False],
+                                     [True, False], [True, False],
+                                     [True, False]]):
         if use_threshold and all_probabilities:
             continue
         yield (check_generate_predictions, use_feature_hashing,
@@ -437,8 +447,8 @@ def test_generate_predictions():
 
 
 def test_generate_predictions_file_header():
-
-    for (use_threshold, all_probabilities, string_labels) in product(*[[True, False]] * 3):
+    for (use_threshold, all_probabilities, string_labels) in \
+            product(*[[True, False], [True, False], [True, False]]):
         if use_threshold and all_probabilities:
             continue
         yield (check_generate_predictions_file_headers,
@@ -517,6 +527,54 @@ def check_generate_predictions_console(use_threshold=False, all_labels=False):
         sys.stdout = old_stdout
         sys.stderr = old_stderr
         print(err)
+
+
+def test_generate_predictions_kw_arg_deprecation_warning():
+    lc = LogCapture()
+    lc.begin()
+
+    # create some simple classification data without feature hashing
+    train_fs, test_fs = make_classification_data(num_examples=1000,
+                                                 num_features=5)
+    # save the test feature set to an NDJ file
+    input_file = join(_my_dir, 'test',
+                      'test_generate_predictions.jsonlines')
+    writer = NDJWriter(input_file, test_fs)
+    writer.write()
+
+    # create a learner that uses an SGD classifier
+    learner = Learner('SGDClassifier')
+    # train the learner with grid search
+    learner.train(train_fs, grid_search=True, grid_objective='f1_score_micro')
+    # get the predictions on the test featureset
+    _ = learner.predict(test_fs)
+    # save the learner to a file
+    model_file = join(_my_dir, 'output',
+                      'test_generate_predictions_console.model')
+    learner.save(model_file)
+
+    # now call main() from generate_predictions.py
+    generate_cmd = [model_file, input_file, "--positive_label", "1"]
+
+    # we need to capture stdout since that's what main() writes to
+    err = ''
+    try:
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = mystdout = StringIO()
+        sys.stderr = mystderr = StringIO()
+        gp.main(generate_cmd)
+        _ = mystdout.getvalue()
+        err = mystderr.getvalue()
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        print(err)
+
+    expected_log_mssg = ("skll.utilities.generate_predictions: WARNING: The "
+                         "`positive_label` argument is deprecated. Use "
+                         "`positive_label_index` instead.")
+    assert expected_log_mssg in lc.handler.buffer
 
 
 def test_generate_predictions_console_bad_input_ext():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -306,13 +306,13 @@ def check_generate_predictions(use_feature_hashing=False,
                                string_labels=False):
 
     # create some simple classification feature sets for training and testing
-    if string_labels:
-        string_label_list = ['a', 'b']
+    string_label_list = ['a', 'b'] if string_labels else None
+
     train_fs, test_fs = make_classification_data(num_examples=1000,
                                                  num_features=5,
                                                  use_feature_hashing=use_feature_hashing,
                                                  feature_bins=4,
-                                                 string_labels=string_label_list)
+                                                 string_label_list=string_label_list)
     enable_probability = use_threshold or use_all_labels
     # create a learner that uses an SGD classifier
     learner = Learner('SGDClassifier', probability=enable_probability)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -244,7 +244,8 @@ def create_jsonlines_feature_files(path):
 def make_classification_data(num_examples=100, train_test_ratio=0.5,
                              num_features=10, use_feature_hashing=False,
                              feature_bins=4, num_labels=2,
-                             empty_labels=False, feature_prefix='f',
+                             empty_labels=False, string_label_list=None,
+                             feature_prefix='f',
                              class_weights=None, non_negative=False,
                              one_string_feature=False, num_string_values=4,
                              random_state=1234567890):
@@ -258,6 +259,11 @@ def make_classification_data(num_examples=100, train_test_ratio=0.5,
                                n_redundant=0, n_classes=num_labels,
                                weights=class_weights,
                                random_state=random_state)
+
+    if string_label_list:
+        assert(len(string_label_list) == num_labels)
+        label_to_string = np.vectorize(lambda n: string_label_list[n])
+        y = label_to_string(y)
 
     # if we were told to only generate non-negative features, then
     # we can simply take the absolute values of the generated features


### PR DESCRIPTION
This PR addresses #484 fixing the bug in `generate_predictions.py` when there are string labels, by replacing `label = self._learner.label_dict[self._pos_index]` with 
`label = self._learner.label_list[self._pos_index]`. 

The `test_generate_predictions` test was also updated to iterate once more using string labels (by way of an update in `utils:make_classification_data`). 

Finally, in looking through this code, I found the default param name `positive_label` to be misleading, particularly when the labels are strings, since it actually refers to the index of the positive label. I've updated it to be called `positive_label_index`.  NOTE This may break scripts currently calling `generate_predictions` using `positive_label` as the name.