### PR TITLE
Fix Tests using DictVectorizer by Converting to Dense Matrices

### DIFF
--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -1050,7 +1050,8 @@ def test_featureset_creation_from_dataframe_without_labels_with_vectorizer():
 
 def test_writing_ndj_featureset_with_string_ids():
     test_dict_vectorizer = DictVectorizer()
-    test_feat_dict_list = [{'a': 1.0, 'b': 1.0}, {'b': 1.0, 'c': 1.0}]
+    test_feat_dict_list = [{'a': 1.0, 'b': 1.0, 'c': 0.0},
+                           {'a': 0.0, 'b': 1.0, 'c': 1.0}]
     Xtest = test_dict_vectorizer.fit_transform(test_feat_dict_list)
     fs_test = FeatureSet('test',
                          ids=['1', '2'],
@@ -1075,7 +1076,8 @@ def test_featureset_creation_from_dataframe_with_string_ids():
                            "score": [1, 2],
                            "text": ["a b", "b c"]})
     dftest.set_index("id", inplace=True)
-    test_feat_dict_list = [{'a': 1.0, 'b': 1.0}, {'b': 1.0, 'c': 1.0}]
+    test_feat_dict_list = [{'a': 1.0, 'b': 1.0, 'c': 0.0},
+                           {'a': 0.0, 'b': 1.0, 'c': 1.0}]
     test_dict_vectorizer = DictVectorizer()
     Xtest = test_dict_vectorizer.fit_transform(test_feat_dict_list)
     fs_test = FeatureSet('test',
@@ -1101,7 +1103,8 @@ def test_featureset_creation_from_dataframe_with_string_labels():
                            "score": ['yes', 'no'],
                            "text": ["a b", "b c"]})
     dftest.set_index("id", inplace=True)
-    test_feat_dict_list = [{'a': 1.0, 'b': 1.0}, {'b': 1.0, 'c': 1.0}]
+    test_feat_dict_list = [{'a': 1.0, 'b': 1.0, 'c': 0.0},
+                           {'a': 0.0, 'b': 1.0, 'c': 1.0}]
     test_dict_vectorizer = DictVectorizer()
     Xtest = test_dict_vectorizer.fit_transform(test_feat_dict_list)
     fs_test = FeatureSet('test',
@@ -1109,6 +1112,7 @@ def test_featureset_creation_from_dataframe_with_string_labels():
                          labels=dftest['score'].values,
                          features=Xtest,
                          vectorizer=test_dict_vectorizer)
+
     output_path = join(_my_dir, "other", "test_string_labels_df.jsonlines")
     test_writer = NDJWriter(output_path, fs_test)
     test_writer.write()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -14,6 +14,7 @@ import csv
 import itertools
 import os
 import sys
+import scipy as sp
 
 from collections import defaultdict
 from glob import glob
@@ -770,8 +771,12 @@ def check_skll_convert(from_suffix, to_suffix):
     reader = EXT_TO_READER[to_suffix](to_suffix_file, quiet=True)
     converted_fs = reader.read()
 
-    # ensure that the original and the converted feature sets
-    # are the same
+    # TODO : For now, we are converting these to dense, and then back to sparse.
+    # The reason for this is that DictVectorizers now retain any explicit zeros,
+    # but we convert these to dense when we write them out. This will be fixed.
+    orig_fs.features = sp.sparse.csr_matrix(orig_fs.features.todense())
+    converted_fs.features = sp.sparse.csr_matrix(converted_fs.features.todense())
+
     eq_(orig_fs, converted_fs)
 
 


### PR DESCRIPTION
This PR addresses the following issues:

- Issue #493: 
  - Update several tests in `test_featureset` to add explicit zeros to the`test_feat_dict_list`.
  - Update the `check_skll_convert()` function in `test_utilities` to convert features to dense before comparing.
- Issue #497. Remove Python 2.7 from build.
 