### PR TITLE
Feature/515 use conda reqs for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export PATH=/home/travis/miniconda3/bin:$PATH
   - conda update --yes conda
 install:
-  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION codecov --file conda_requirements.txt
+  - conda install --yes --channel conda-forge python=$TRAVIS_PYTHON_VERSION codecov --file conda_requirements.txt
   # Have to use pip for nose-cov because its entry points are not supported by conda yet
   - pip install nose-cov
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export PATH=/home/travis/miniconda3/bin:$PATH
   - conda update --yes conda
 install:
-  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy seaborn pandas beautifulsoup4 scikit-learn==0.20.1 joblib tabulate codecov ruamel.yaml
+  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION codecov --file conda_requirements.txt
   # Have to use pip for nose-cov because its entry points are not supported by conda yet
   - pip install nose-cov
   - python setup.py install

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,7 +1,7 @@
 scikit-learn==0.20.1
-PrettyTable
 beautifulsoup4
 tabulate
+intel-openmp==2019.4
 numpy
 scipy
 pandas


### PR DESCRIPTION
Addresses #515 

Use `conda_requirements.txt` in `.travis.yml`. Also, add in `intel-openmp=2019.4` as a requirement until the issue with `joblib` is resolved. Lastly, remove accidentally left-over `PrettyTable` requirement in `conda_requirements.txt` and remove `defaults` channel.