### PR TITLE
Revert Intel OpenMP pinning

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,7 +1,6 @@
 scikit-learn==0.20.1
 beautifulsoup4
 tabulate
-intel-openmp==2019.4
 numpy
 scipy
 pandas


### PR DESCRIPTION
Now that intel has pulled the broken `intel-openmp==2019.5` package from anaconda, we should automatically get the last working version and do not need to pin it in our requirements. 