### PR TITLE
Add `ignore_blanks` and `replace_blanks_with` arguments

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -57,7 +57,16 @@ A simple comma or tab-delimited format with the following restrictions:
 *   If the data has instance IDs, there should be a column with the name
     specified by :ref:`id_col <id_col>` in the :ref:`Input` section of the configuration file you create for your experiment. This defaults to ``id``.  If there is no such column, IDs will be generated automatically.
 *   All other columns contain feature values, and every feature value
-    must be specified (making this a poor choice for sparse data).
+    must be specified (making this a poor choice for sparse data). 
+    
+.. warning:: 
+ 
+    SKLL will raise an error if there are blank values in *any* of the
+    columns. You must either drop all rows with blank values in any column
+    or replace the blanks with a value you specify. To drop or replace via
+    the command line, use the :ref:`filter_features <filter_features>` script.
+    You can also drop/replace via the SKLL Reader API, specifically :py:mod:`skll.data.readers.CSVReader` and :py:mod:`skll.data.readers.TSVReader`.
+
 
 .. _ndj:
 

--- a/doc/utilities.rst
+++ b/doc/utilities.rst
@@ -76,17 +76,33 @@ Optional Arguments
 
     Instead of keeping features and/or examples in lists, remove them.
 
+.. option:: --id_col <id_col>
+
+    Name of the column which contains the instance IDs in ARFF, CSV, or TSV files.
+    (default: ``id``)
+
 .. option:: -L <label <label ...>>, --label <label <label ...>>
 
     A label in the feature file you would like to keep. If unspecified, no
     instances are removed based on their labels.
 
-.. option:: -l label_col, --label_col label_col
+.. option:: -l <label_col>, --label_col <label_col>
 
     Name of the column which contains the class labels in ARFF, CSV, or TSV
     files. For ARFF files, this must be the final column to count as the label.
     (default: ``y``)
 
+.. option:: -db, --drop-blanks
+    
+    Drop all lines/rows that have any blank values.
+    (default: ``False``)
+
+.. option:: -rb <replacement>, --replace-blanks-with <replacement>
+
+    Specifies a new value with which to replace blank values in all columns in the
+    file. To replace blanks differently in each column, use the SKLL Reader API directly.
+    (default: ``None``)
+      
 .. option:: -q, --quiet
 
     Suppress printing of ``"Loading..."`` messages.

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -347,10 +347,13 @@ class Reader(object):
 
         # should we replace blank values with something?
         if replace_blanks_with is not None:
+            self.logger.info('Values that are blank will replaced with the '
+                             'user-specified value(s).')
             df = df.fillna(replace_blanks_with)
 
         # should we remove lines that have any NaNs?
         if ignore_blanks:
+            self.logger.info('Rows/lines with any blank values will be ignored.')
             df = df.dropna().reset_index(drop=True)
 
         # if the id column exists,

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -793,8 +793,8 @@ class CSVReader(Reader):
         Options are ::
 
             -  value = A (numeric) value with which to replace blank values.
-            -  ``dict`` = A dictionary specifying the replacement value for each column.
-            -  ``None`` = Blank values will be left as blanks, and not replaced.
+            -  dict = A dictionary specifying the replacement value for each column.
+            -  None = Blank values will be left as blanks, and not replaced.
 
         The replacement occurs after the data set is read into a `pd.DataFrame`.
         Defaults to ``None``.
@@ -867,8 +867,8 @@ class TSVReader(CSVReader):
         Options are ::
 
             -  value = A (numeric) value with which to replace blank values.
-            -  ``dict`` = A dictionary specifying the replacement value for each column.
-            -  ``None`` = Blank values will be left as blanks, and not replaced.
+            -  dict = A dictionary specifying the replacement value for each column.
+            -  None = Blank values will be left as blanks, and not replaced.
 
         The replacement occurs after the data set is read into a `pd.DataFrame`.
         Defaults to ``None``.

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -318,7 +318,7 @@ class Reader(object):
             Options are ::
 
                 -  value = A (numeric) value with which to replace blank values.
-                -  ``dict`` = A dictionary specifying the replacement value for each row/line.
+                -  ``dict`` = A dictionary specifying the replacement value for each column.
                 -  ``None`` = Blank values will be left as blanks, and not replaced.
 
             Defaults to ``None``.
@@ -793,7 +793,7 @@ class CSVReader(Reader):
         Options are ::
 
             -  value = A (numeric) value with which to replace blank values.
-            -  ``dict`` = A dictionary specifying the replacement value for each row/line.
+            -  ``dict`` = A dictionary specifying the replacement value for each column.
             -  ``None`` = Blank values will be left as blanks, and not replaced.
 
         The replacement occurs after the data set is read into a `pd.DataFrame`.
@@ -867,7 +867,7 @@ class TSVReader(CSVReader):
         Options are ::
 
             -  value = A (numeric) value with which to replace blank values.
-            -  ``dict`` = A dictionary specifying the replacement value for each row/line.
+            -  ``dict`` = A dictionary specifying the replacement value for each column.
             -  ``None`` = Blank values will be left as blanks, and not replaced.
 
         The replacement occurs after the data set is read into a `pd.DataFrame`.

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -296,7 +296,7 @@ class Reader(object):
                          id_col,
                          label_col,
                          replace_blanks_with=None,
-                         ignore_blanks=False):
+                         drop_blanks=False):
         """
         Parse the data frame into ids, labels, and features.
         For `Reader` objects that rely on `pandas`, this function
@@ -322,7 +322,7 @@ class Reader(object):
                 -  ``None`` = Blank values will be left as blanks, and not replaced.
 
             Defaults to ``None``.
-        ignore_blanks : bool, optional
+        drop_blanks : bool, optional
             If ``True``, remove lines/rows that have any blank
             values.
             Defaults to ``False``.
@@ -340,20 +340,20 @@ class Reader(object):
             raise ValueError("No features found in possibly "
                              "empty file '{}'.".format(self.path_or_list))
 
-        if ignore_blanks and replace_blanks_with is not None:
-            raise ValueError("You have set `ignore_blanks=True`, but 'replace_blanks_with' "
-                             "is not `None`; 'replace_blanks_with' can only have a value "
-                             "when 'ignore_blanks' is set to `False`.")
+        if drop_blanks and replace_blanks_with is not None:
+            raise ValueError("You cannot both drop blanks and replace them. "
+                             "'replace_blanks_with' can only have a value when "
+                             "'drop_blanks' is `False`.")
 
         # should we replace blank values with something?
         if replace_blanks_with is not None:
-            self.logger.info('Values that are blank will be replaced with '
+            self.logger.info('Blank values in all rows/lines will be replaced with '
                              'user-specified value(s).')
             df = df.fillna(replace_blanks_with)
 
         # should we remove lines that have any NaNs?
-        if ignore_blanks:
-            self.logger.info('Rows/lines with any blank values will be ignored.')
+        if drop_blanks:
+            self.logger.info('Rows/lines with any blank values will be dropped.')
             df = df.dropna().reset_index(drop=True)
 
         # if the id column exists,
@@ -798,7 +798,7 @@ class CSVReader(Reader):
 
         The replacement occurs after the data set is read into a `pd.DataFrame`.
         Defaults to ``None``.
-    ignore_blanks : bool, optional
+    drop_blanks : bool, optional
         If ``True``, remove lines/rows that have any blank
         values. These lines/rows are removed after the
         the data set is read into a `pd.DataFrame`.
@@ -814,12 +814,12 @@ class CSVReader(Reader):
     def __init__(self,
                  path_or_list,
                  replace_blanks_with=None,
-                 ignore_blanks=False,
+                 drop_blanks=False,
                  pandas_kwargs=None,
                  **kwargs):
         super(CSVReader, self).__init__(path_or_list, **kwargs)
         self._replace_blanks_with = replace_blanks_with
-        self._ignore_blanks = ignore_blanks
+        self._drop_blanks = drop_blanks
         self._pandas_kwargs = {} if pandas_kwargs is None else pandas_kwargs
         self._sep = self._pandas_kwargs.pop('sep', str(','))
         self._engine = self._pandas_kwargs.pop('engine', 'c')
@@ -846,7 +846,7 @@ class CSVReader(Reader):
                                      self.id_col,
                                      self.label_col,
                                      replace_blanks_with=self._replace_blanks_with,
-                                     ignore_blanks=self._ignore_blanks)
+                                     drop_blanks=self._drop_blanks)
 
 
 class TSVReader(CSVReader):
@@ -872,7 +872,7 @@ class TSVReader(CSVReader):
 
         The replacement occurs after the data set is read into a `pd.DataFrame`.
         Defaults to ``None``.
-    ignore_blanks : bool, optional
+    drop_blanks : bool, optional
         If ``True``, remove lines/rows that have any blank
         values. These lines/rows are removed after the
         the data set is read into a `pd.DataFrame`.
@@ -888,12 +888,12 @@ class TSVReader(CSVReader):
     def __init__(self,
                  path_or_list,
                  replace_blanks_with=None,
-                 ignore_blanks=False,
+                 drop_blanks=False,
                  pandas_kwargs=None,
                  **kwargs):
         super(TSVReader, self).__init__(path_or_list,
                                         replace_blanks_with=replace_blanks_with,
-                                        ignore_blanks=ignore_blanks,
+                                        drop_blanks=drop_blanks,
                                         pandas_kwargs=pandas_kwargs,
                                         **kwargs)
         self._sep = str('\t')

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -347,7 +347,7 @@ class Reader(object):
 
         # should we replace blank values with something?
         if replace_blanks_with is not None:
-            self.logger.info('Values that are blank will replaced with the '
+            self.logger.info('Values that are blank will be replaced with '
                              'user-specified value(s).')
             df = df.fillna(replace_blanks_with)
 

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -326,7 +326,7 @@ class Reader(object):
             raise ValueError("No features found in possibly "
                              "empty file '{}'.".format(self.path_or_list))
 
-        # should we remove lines that are all NaN?
+        # should we remove lines that have any NaNs?
         if ignore_blanks:
             df = df.dropna().reset_index(drop=True)
 

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -309,9 +309,9 @@ class Reader(object):
         label_col : str or None
             The label column.
         ignore_blanks : bool, optional
-            If True, remove lines that have any NaN
+            If ``True``, remove lines/rows that have any blank
             values.
-            Defaults to False.
+            Defaults to ``False``.
 
         Returns
         -------
@@ -763,10 +763,10 @@ class CSVReader(Reader):
     path_or_list : str
         The path to a comma-delimited file.
     ignore_blanks : bool, optional
-        If True, remove lines that have any NaN
-        values. These lines are removed after the
+        If ``True``, remove lines/rows that have any blank
+        values. These lines/rows are removed after the
         the data set is read into a `pd.DataFrame`.
-        Defaults to False.
+        Defaults to ``False``.
     pandas_kwargs : dict or None, optional
         Arguments that will be passed directly
         to the `pandas` I/O reader.
@@ -800,7 +800,8 @@ class CSVReader(Reader):
             The features for the features set.
         """
         df = pd.read_csv(file, sep=self._sep, engine=self._engine, **self._pandas_kwargs)
-        return self._parse_dataframe(df, self.id_col, self.label_col, self._ignore_blanks)
+        return self._parse_dataframe(df, self.id_col, self.label_col,
+                                     ignore_blanks=self._ignore_blanks)
 
 
 class TSVReader(CSVReader):
@@ -817,10 +818,10 @@ class TSVReader(CSVReader):
     path_or_list : str
         The path to a comma-delimited file.
     ignore_blanks : bool, optional
-        If True, remove lines that have any NaN
-        values. These lines are removed after the
+        If ``True``, remove lines/rows that have any blank
+        values. These lines/rows are removed after the
         the data set is read into a `pd.DataFrame`.
-        Defaults to False.
+        Defaults to ``False``.
     pandas_kwargs : dict or None, optional
         Arguments that will be passed directly
         to the `pandas` I/O reader.
@@ -830,7 +831,10 @@ class TSVReader(CSVReader):
     """
 
     def __init__(self, path_or_list, ignore_blanks=False, pandas_kwargs=None, **kwargs):
-        super(TSVReader, self).__init__(path_or_list, ignore_blanks, pandas_kwargs, **kwargs)
+        super(TSVReader, self).__init__(path_or_list, 
+                                        ignore_blanks=ignore_blanks,
+                                        pandas_kwargs=pandas_kwargs,
+                                        **kwargs)
         self._sep = str('\t')
 
 

--- a/skll/utilities/filter_features.py
+++ b/skll/utilities/filter_features.py
@@ -13,7 +13,7 @@ import logging
 import os
 import sys
 
-from skll.data.readers import EXT_TO_READER
+from skll.data.readers import EXT_TO_READER, safe_float
 from skll.data.writers import ARFFWriter, CSVWriter, TSVWriter, EXT_TO_WRITER
 from skll.version import __version__
 
@@ -31,43 +31,50 @@ def main(argv=None):
 
     # Get command line arguments
     parser = argparse.ArgumentParser(
-        description="Takes an input feature file and removes any instances or\
-                     features that do not match the specified patterns.",
+        description="Takes an input feature file and removes any instances or "
+                    "features that do not match the specified patterns.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('infile',
-                        help='input feature file (ends in .arff, .csv, \
-                              .jsonlines, .megam, .ndj, or .tsv)')
+                        help='input feature file (ends in .arff, .csv, '
+                             '.jsonlines, .megam, .ndj, or .tsv)')
     parser.add_argument('outfile',
-                        help='output feature file (must have same extension as\
-                              input file)')
+                        help='output feature file (must have same extension as '
+                             'input file)')
     parser.add_argument('-f', '--feature',
-                        help='A feature in the feature file you would like to \
-                              keep.  If unspecified, no features are removed.',
+                        help='A feature in the feature file you would like to '
+                             'keep.  If unspecified, no features are removed.',
                         nargs='*')
     parser.add_argument('-I', '--id',
-                        help='An instance ID in the feature file you would \
-                              like to keep.  If unspecified, no instances are \
-                              removed based on their IDs.',
+                        help='An instance ID in the feature file you would '
+                             'like to keep.  If unspecified, no instances are '
+                             'removed based on their IDs.',
                         nargs='*')
     parser.add_argument('--id_col',
-                        help='Name of the column which contains the instance \
-                              IDs in ARFF, CSV, or TSV files.',
+                        help='Name of the column which contains the instance '
+                             'IDs in ARFF, CSV, or TSV files.',
                         default='id')
     parser.add_argument('-i', '--inverse',
-                        help='Instead of keeping features and/or examples in \
-                              lists, remove them.',
+                        help='Instead of keeping features and/or examples in '
+                             'lists, remove them.',
                         action='store_true')
     parser.add_argument('-L', '--label',
-                        help='A label in the feature file you would like to \
-                              keep.  If unspecified, no instances are removed \
-                              based on their labels.',
+                        help='A label in the feature file you would like to '
+                             'keep.  If unspecified, no instances are removed '
+                             'based on their labels.',
                         nargs='*')
     parser.add_argument('-l', '--label_col',
-                        help='Name of the column which contains the class \
-                              labels in ARFF, CSV, or TSV files. For ARFF \
-                              files, this must be the final column to count as\
-                              the label.',
+                        help='Name of the column which contains the class '
+                             'labels in ARFF, CSV, or TSV files. For ARFF '
+                             'files, this must be the final column to count as '
+                             'the label.',
                         default='y')
+    parser.add_argument('-r', '--replace_blanks_with',
+                        help='Specifies a new value with which to replace blank values.',
+                        default=None)
+    parser.add_argument('-d', '--ignore_blanks',
+                        action='store_true',
+                        help='Delete/ignore all lines/rows that have any blank values.',
+                        default=False)
     parser.add_argument('-q', '--quiet',
                         help='Suppress printing of "Loading..." messages.',
                         action='store_true')
@@ -104,10 +111,25 @@ def main(argv=None):
                       'file.  You specified: {}').format(output_extension))
         sys.exit(1)
 
+    if input_extension == '.csv' or input_extension == '.tsv':
+        replace_blanks_with = args.replace_blanks_with
+        ignore_blanks = args.ignore_blanks
+        if ignore_blanks and replace_blanks_with is not None:
+            raise ValueError("You cannot pass a value for 'replace_blanks_with' "
+                             "and set 'ignore_blanks' to True.")
+        replace_blanks_with = (None if replace_blanks_with is None
+                               else safe_float(replace_blanks_with))
+        kwargs = {'replace_blanks_with': replace_blanks_with,
+                  'ignore_blanks': ignore_blanks}
+    else:
+        kwargs = {}
+
     # Read input file
-    reader = EXT_TO_READER[input_extension](args.infile, quiet=args.quiet,
+    reader = EXT_TO_READER[input_extension](args.infile,
+                                            quiet=args.quiet,
                                             label_col=args.label_col,
-                                            id_col=args.id_col)
+                                            id_col=args.id_col,
+                                            **kwargs)
     feature_set = reader.read()
 
     # Do the actual filtering

--- a/skll/utilities/filter_features.py
+++ b/skll/utilities/filter_features.py
@@ -69,7 +69,9 @@ def main(argv=None):
                              'the label.',
                         default='y')
     parser.add_argument('-rb', '--replace_blanks_with',
-                        help='Specifies a new value with which to replace blank values.',
+                        help='Specifies a new value with which to replace blank values '
+                             'in all columns in the file. To replace blanks differently '
+                             'in each column, use the SKLL Reader API directly.',
                         default=None)
     parser.add_argument('-db', '--drop_blanks',
                         action='store_true',

--- a/skll/utilities/filter_features.py
+++ b/skll/utilities/filter_features.py
@@ -68,12 +68,12 @@ def main(argv=None):
                              'files, this must be the final column to count as '
                              'the label.',
                         default='y')
-    parser.add_argument('-r', '--replace_blanks_with',
+    parser.add_argument('-rb', '--replace_blanks_with',
                         help='Specifies a new value with which to replace blank values.',
                         default=None)
-    parser.add_argument('-d', '--ignore_blanks',
+    parser.add_argument('-db', '--drop_blanks',
                         action='store_true',
-                        help='Delete/ignore all lines/rows that have any blank values.',
+                        help='Drop all lines/rows that have any blank values.',
                         default=False)
     parser.add_argument('-q', '--quiet',
                         help='Suppress printing of "Loading..." messages.',
@@ -113,14 +113,15 @@ def main(argv=None):
 
     if input_extension == '.csv' or input_extension == '.tsv':
         replace_blanks_with = args.replace_blanks_with
-        ignore_blanks = args.ignore_blanks
-        if ignore_blanks and replace_blanks_with is not None:
-            raise ValueError("You cannot pass a value for 'replace_blanks_with' "
-                             "and set 'ignore_blanks' to True.")
+        drop_blanks = args.drop_blanks
+        if drop_blanks and replace_blanks_with is not None:
+            raise ValueError("You cannot both drop blanks and replace them. "
+                             "'replace_blanks_with' can only have a value when "
+                             "'drop_blanks' is `False`.")
         replace_blanks_with = (None if replace_blanks_with is None
                                else safe_float(replace_blanks_with))
         kwargs = {'replace_blanks_with': replace_blanks_with,
-                  'ignore_blanks': ignore_blanks}
+                  'drop_blanks': drop_blanks}
     else:
         kwargs = {}
 

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -1166,3 +1166,10 @@ def test_reading_csv_and_tsv_with_fill_blanks():
 
     eq_(fs_csv, fs_expected)
     eq_(fs_tsv, fs_expected)
+
+
+@raises(ValueError)
+def test_ignore_blanks_and_replace_blanks_with_raises_error():
+
+    test_csv = '1,1,6\n2,,2\n3,9,3\n,,\n,5,\n,,\n2,7,7'
+    CSVReader(StringIO(test_csv), replace_blanks_with=4.5, ignore_blanks=True).read()

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -1168,6 +1168,35 @@ def test_reading_csv_and_tsv_with_fill_blanks():
     eq_(fs_tsv, fs_expected)
 
 
+def test_reading_csv_and_tsv_with_fill_blanks_with_dictionary():
+
+    # create CSV and TSV strings with blanks
+    test_csv = '1,1,6\n2,,2\n3,9,3\n,,\n,5,\n,,\n2,7,7'
+    test_tsv = test_csv.replace(',', '\t')
+
+    # specify pandas_kwargs for CSV and TSV readers
+    kwargs = {'header': None, 'names': ['A', 'B', 'C']}
+
+    expected = pd.DataFrame({'A': [1, 2, 3, 4.5, 4.5, 4.5, 2],
+                             'B': [1, 2.5, 9, 2.5, 5, 2.5, 7],
+                             'C': [6, 2, 3, 1, 1, 1, 7],
+                             'L': [None, None, None, None, None, None, None]},
+                            index=['EXAMPLE_0', 'EXAMPLE_1', 'EXAMPLE_2',
+                                   'EXAMPLE_3', 'EXAMPLE_4', 'EXAMPLE_5', 'EXAMPLE_6'])
+
+    fs_expected = FeatureSet.from_data_frame(expected, 'test', labels_column='L')
+
+    replacement_dict = {'A': 4.5, 'B': 2.5, 'C': 1}
+    fs_csv = CSVReader(StringIO(test_csv), replace_blanks_with=replacement_dict, pandas_kwargs=kwargs).read()
+    fs_csv.name = 'test'
+
+    fs_tsv = TSVReader(StringIO(test_tsv), replace_blanks_with=replacement_dict, pandas_kwargs=kwargs).read()
+    fs_tsv.name = 'test'
+
+    eq_(fs_csv, fs_expected)
+    eq_(fs_tsv, fs_expected)
+
+
 @raises(ValueError)
 def test_drop_blanks_and_replace_blanks_with_raises_error():
 

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -1138,3 +1138,31 @@ def test_reading_csv_and_tsv_with_ignore_blanks():
 
     eq_(fs_csv, fs_expected)
     eq_(fs_tsv, fs_expected)
+
+
+def test_reading_csv_and_tsv_with_fill_blanks():
+
+    # create CSV and TSV strings with blanks
+    test_csv = '1,1,6\n2,,2\n3,9,3\n,,\n,5,\n,,\n2,7,7'
+    test_tsv = test_csv.replace(',', '\t')
+
+    # specify pandas_kwargs for CSV and TSV readers
+    kwargs = {'header': None, 'names': ['A', 'B', 'C']}
+
+    expected = pd.DataFrame({'A': [1, 2, 3, 4.5, 4.5, 4.5, 2],
+                             'B': [1, 4.5, 9, 4.5, 5, 4.5, 7],
+                             'C': [6, 2, 3, 4.5, 4.5, 4.5, 7],
+                             'L': [None, None, None, None, None, None, None]},
+                            index=['EXAMPLE_0', 'EXAMPLE_1', 'EXAMPLE_2',
+                                   'EXAMPLE_3', 'EXAMPLE_4', 'EXAMPLE_5', 'EXAMPLE_6'])
+
+    fs_expected = FeatureSet.from_data_frame(expected, 'test', labels_column='L')
+
+    fs_csv = CSVReader(StringIO(test_csv), replace_blanks_with=4.5, pandas_kwargs=kwargs).read()
+    fs_csv.name = 'test'
+
+    fs_tsv = TSVReader(StringIO(test_tsv), replace_blanks_with=4.5, pandas_kwargs=kwargs).read()
+    fs_tsv.name = 'test'
+
+    eq_(fs_csv, fs_expected)
+    eq_(fs_tsv, fs_expected)

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -12,6 +12,7 @@ the future.
 import itertools
 import os
 from collections import OrderedDict
+from io import StringIO
 from os.path import abspath, dirname, exists, join
 
 import numpy as np
@@ -22,7 +23,8 @@ from sklearn.feature_extraction import DictVectorizer, FeatureHasher
 from sklearn.datasets.samples_generator import make_classification
 
 import skll
-from skll.data import FeatureSet, Writer, Reader, NDJReader, NDJWriter
+from skll.data import (FeatureSet, Writer, Reader,
+                       CSVReader, TSVReader, NDJReader, NDJWriter)
 from skll.data.readers import DictListReader
 from skll.experiments import _load_featureset
 from skll.learner import _DEFAULT_PARAM_GRIDS
@@ -1111,3 +1113,28 @@ def test_featureset_creation_from_dataframe_with_string_labels():
     fs_test2 = NDJReader.for_path(output_path, ids_to_floats=True).read()
 
     assert fs_test == fs_test2
+
+
+def test_reading_csv_and_tsv_with_ignore_blanks():
+
+    # create CSV and TSV strings with blanks
+    test_csv = '1,1,6\n2,,2\n3,9,3\n,,\n,5,\n,,\n2,7,7'
+    test_tsv = test_csv.replace(',', '\t')
+
+    # specify pandas_kwargs for CSV and TSV readers
+    kwargs = {'header': None, 'names': ['A', 'B', 'C']}
+
+    expected = pd.DataFrame({'A': [1, 3, 2], 'B': [1, 9, 7],
+                             'C': [6, 3, 7], 'L': [None, None, None]},
+                            index=['EXAMPLE_0', 'EXAMPLE_1', 'EXAMPLE_2'])
+
+    fs_expected = FeatureSet.from_data_frame(expected, 'test', labels_column='L')
+
+    fs_csv = CSVReader(StringIO(test_csv), ignore_blanks=True, pandas_kwargs=kwargs).read()
+    fs_csv.name = 'test'
+
+    fs_tsv = TSVReader(StringIO(test_tsv), ignore_blanks=True, pandas_kwargs=kwargs).read()
+    fs_tsv.name = 'test'
+
+    eq_(fs_csv, fs_expected)
+    eq_(fs_tsv, fs_expected)

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -1115,7 +1115,7 @@ def test_featureset_creation_from_dataframe_with_string_labels():
     assert fs_test == fs_test2
 
 
-def test_reading_csv_and_tsv_with_ignore_blanks():
+def test_reading_csv_and_tsv_with_drop_blanks():
 
     # create CSV and TSV strings with blanks
     test_csv = '1,1,6\n2,,2\n3,9,3\n,,\n,5,\n,,\n2,7,7'
@@ -1130,10 +1130,10 @@ def test_reading_csv_and_tsv_with_ignore_blanks():
 
     fs_expected = FeatureSet.from_data_frame(expected, 'test', labels_column='L')
 
-    fs_csv = CSVReader(StringIO(test_csv), ignore_blanks=True, pandas_kwargs=kwargs).read()
+    fs_csv = CSVReader(StringIO(test_csv), drop_blanks=True, pandas_kwargs=kwargs).read()
     fs_csv.name = 'test'
 
-    fs_tsv = TSVReader(StringIO(test_tsv), ignore_blanks=True, pandas_kwargs=kwargs).read()
+    fs_tsv = TSVReader(StringIO(test_tsv), drop_blanks=True, pandas_kwargs=kwargs).read()
     fs_tsv.name = 'test'
 
     eq_(fs_csv, fs_expected)
@@ -1169,7 +1169,7 @@ def test_reading_csv_and_tsv_with_fill_blanks():
 
 
 @raises(ValueError)
-def test_ignore_blanks_and_replace_blanks_with_raises_error():
+def test_drop_blanks_and_replace_blanks_with_raises_error():
 
     test_csv = '1,1,6\n2,,2\n3,9,3\n,,\n,5,\n,,\n2,7,7'
-    CSVReader(StringIO(test_csv), replace_blanks_with=4.5, ignore_blanks=True).read()
+    CSVReader(StringIO(test_csv), replace_blanks_with=4.5, drop_blanks=True).read()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1847,10 +1847,10 @@ def test_join_features_unmatched_output_format():
         yield check_join_features_raises_system_exit, jf_cmd_args
 
 
-def test_filter_features_with_ignore_blanks():
+def test_filter_features_with_drop_blanks():
     """
     Test filter features with CSV and TSV readers
-    using the ignore_blanks option
+    using the `drop_blanks` option
     """
     df = pd.DataFrame({'A': [1, 2, 3, np.nan, 5, 6],
                        'B': [5, 9, np.nan, 2, 9, 1],
@@ -1871,8 +1871,8 @@ def test_filter_features_with_ignore_blanks():
     df.to_csv(csv_infile, index=False)
     df.to_csv(tsv_infile, index=False, sep='\t')
 
-    filter_features_csv_cmd = [csv_infile, csv_outfile, '-l', 'L', '--ignore_blanks']
-    filter_features_tsv_cmd = [tsv_infile, tsv_outfile, '-l', 'L', '--ignore_blanks']
+    filter_features_csv_cmd = [csv_infile, csv_outfile, '-l', 'L', '--drop_blanks']
+    filter_features_tsv_cmd = [tsv_infile, tsv_outfile, '-l', 'L', '--drop_blanks']
 
     ff.main(filter_features_csv_cmd)
     ff.main(filter_features_tsv_cmd)
@@ -1886,7 +1886,7 @@ def test_filter_features_with_ignore_blanks():
 def test_filter_features_with_replace_blanks_with():
     """
     Test filter features with CSV and TSV readers
-    using the replace_blanks_with option
+    using the `replace_blanks_with` option
     """
     df = pd.DataFrame({'A': [1, 2, 3, np.nan, 5, 6],
                        'B': [5, 9, np.nan, 2, 9, 1],
@@ -1918,3 +1918,21 @@ def test_filter_features_with_replace_blanks_with():
 
     assert_frame_equal(df_csv_output, df_expected)
     assert_frame_equal(df_tsv_output, df_expected)
+
+
+@raises(ValueError)
+def test_filter_features_with_replace_blanks_with_and_drop_blanks_raises_error():
+
+
+    df = pd.DataFrame(np.random.randn(5, 10))
+
+    csv_infile = join(_my_dir, 'other', 'features', 'features_drop_and_replace_error.csv')
+    csv_outfile = join(_my_dir, 'other', 'features', 'features_drop_and_replace_error_out.csv')
+
+    df.to_csv(csv_infile, index=False)
+
+    filter_features_csv_cmd = [csv_infile, csv_outfile,
+                               '--drop_blanks',
+                               '--replace_blanks_with', '4.5']
+
+    ff.main(filter_features_csv_cmd)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1862,11 +1862,11 @@ def test_filter_features_with_drop_blanks():
     df_expected['id'] = ['EXAMPLE_{}'.format(i) for i in range(4)]
     df_expected = df_expected[['A', 'B', 'C', 'id', 'L']]
 
-    csv_infile = join(_my_dir, 'other', 'features', 'features_ignore_blanks.csv')
-    tsv_infile = join(_my_dir, 'other', 'features', 'features_ignore_blanks.tsv')
+    csv_infile = join(_my_dir, 'other', 'features', 'features_drop_blanks.csv')
+    tsv_infile = join(_my_dir, 'other', 'features', 'features_drop_blanks.tsv')
 
-    csv_outfile = join(_my_dir, 'other', 'features', 'features_ignore_blanks_out.csv')
-    tsv_outfile = join(_my_dir, 'other', 'features', 'features_ignore_blanks_out.tsv')
+    csv_outfile = join(_my_dir, 'other', 'features', 'features_drop_blanks_out.csv')
+    tsv_outfile = join(_my_dir, 'other', 'features', 'features_drop_blanks_out.tsv')
 
     df.to_csv(csv_infile, index=False)
     df.to_csv(tsv_infile, index=False, sep='\t')

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1883,6 +1883,7 @@ def test_filter_features_with_drop_blanks():
     assert_frame_equal(df_csv_output, df_expected)
     assert_frame_equal(df_tsv_output, df_expected)
 
+
 def test_filter_features_with_replace_blanks_with():
     """
     Test filter features with CSV and TSV readers
@@ -1922,7 +1923,6 @@ def test_filter_features_with_replace_blanks_with():
 
 @raises(ValueError)
 def test_filter_features_with_replace_blanks_with_and_drop_blanks_raises_error():
-
 
     df = pd.DataFrame(np.random.randn(5, 10))
 


### PR DESCRIPTION
This PR addresses issue #540. It includes the following updates:

- Modified `CSVReader` and `TSVReader` classes to include an `ignore_blanks` argument, which removes lines that have any `NaN` values, after the `DataFrame` is created. This argument defaults to `False`.
- Modified `CSVReader` and `TSVReader` classes to include a `replace_blanks_with` argument, which replaces any `NaN` values with a new specified value, after the `DataFrame` is created. This argument defaults to `None` (i.e. no replacement). Users can pass either a value or a dictionary of values (if they want to use a difference value for each column).
- Updated the `filter_features.py` utility script to allow users to add the `ignore_blanks` and  `replace_blanks_with` arguments to `CSVReader` and `TSVReader` readers. (Note that the command line version does not work with dictionaries.)
- Added a test to make sure new the arguments were working for both classes, as well as in the `filter_features.py` utility script.
- Removed an unnecessary argument from `_parse_dataframe()`.
- Updates to documentation.