### PR TITLE
Add missing logger attribute to `FilteredLeaveOneGroupOut`

### DIFF
--- a/skll/learner.py
+++ b/skll/learner.py
@@ -236,11 +236,12 @@ class FilteredLeaveOneGroupOut(LeaveOneGroupOut):
         A list of example IDs.
     """
 
-    def __init__(self, keep, example_ids):
+    def __init__(self, keep, example_ids, logger=None):
         super(FilteredLeaveOneGroupOut, self).__init__()
         self.keep = keep
         self.example_ids = example_ids
         self._warned = False
+        self.logger = logger if logger else logging.getLogger(__name__)
 
     def split(self, X, y, groups):
         """
@@ -1631,7 +1632,9 @@ class Learner(object):
                 dummy_label = next(iter(grid_search_folds.values()))
                 fold_groups = [grid_search_folds.get(curr_id, dummy_label) for
                                curr_id in examples.ids]
-                kfold = FilteredLeaveOneGroupOut(grid_search_folds, examples.ids)
+                kfold = FilteredLeaveOneGroupOut(grid_search_folds,
+                                                 examples.ids,
+                                                 logger=self.logger)
                 folds = kfold.split(examples.features, examples.labels, fold_groups)
 
             # If we're using a correlation metric for doing binary
@@ -2271,7 +2274,9 @@ class Learner(object):
             dummy_label = next(iter(cv_folds.values()))
             fold_groups = [cv_folds.get(curr_id, dummy_label) for curr_id in examples.ids]
             # Only retain IDs within folds if they're in cv_folds
-            kfold = FilteredLeaveOneGroupOut(cv_folds, examples.ids)
+            kfold = FilteredLeaveOneGroupOut(cv_folds,
+                                             examples.ids,
+                                             logger=self.logger)
             cv_groups = fold_groups
 
             # If we are planning to do grid search, set the grid search folds

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -65,6 +65,7 @@ def tearDown():
     if exists(fold_file_path):
         os.unlink(fold_file_path)
 
+    train_dir = join(_my_dir, "train")
     output_dir = join(_my_dir, 'output')
     config_dir = join(_my_dir, 'configs')
 
@@ -85,6 +86,9 @@ def tearDown():
                         glob(join(output_dir,
                                   'test_folds_file*'))):
         os.unlink(output_file)
+
+    for i in range(6):
+        os.unlink(join(train_dir, "f{}.jsonlines".format(i)))
 
 
 def make_cv_folds_data(num_examples_per_fold=100,
@@ -325,7 +329,7 @@ def test_folds_file_with_fewer_ids_than_featureset():
     """
     # Run experiment with a special featureset that has extra IDs
     suffix = '.jsonlines'
-    train_path = join(_my_dir, 'train', 'f0_extra{}'.format(suffix))
+    train_path = join(_my_dir, 'train', 'f5{}'.format(suffix))
 
     config_path = fill_in_config_paths_for_single_file(join(_my_dir,
                                                             "configs",
@@ -338,7 +342,7 @@ def test_folds_file_with_fewer_ids_than_featureset():
     # Check job log output
     with open(join(_my_dir,
                    'output',
-                   'test_folds_file_logging_train_f0_extra.'
+                   'test_folds_file_logging_train_f5.'
                    'jsonlines_LogisticRegression.log')) as f:
         cv_file_pattern = re.compile('Feature set contains IDs that are not in folds dictionary. Skipping those IDs.')
         matches = re.findall(cv_file_pattern, f.read())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -211,7 +211,7 @@ def create_jsonlines_feature_files(path):
 
     # we only need to create the feature files if they
     # don't already exist under the given path
-    feature_files_to_create = [join(path, 'f{}.jsonlines'.format(i)) for i in range(5)]
+    feature_files_to_create = [join(path, 'f{}.jsonlines'.format(i)) for i in range(6)]
     if all([exists(ff) for ff in feature_files_to_create]):
         return
     else:
@@ -226,13 +226,18 @@ def create_jsonlines_feature_files(path):
             y = "dog" if j % 2 == 0 else "cat"
             ex_id = "{}{}".format(y, j)
             x = {"f{}".format(feat_num): np.random.randint(0, 4) for feat_num in
-                 range(5)}
+                 range(6)}
             x = OrderedDict(sorted(x.items(), key=lambda t: t[0]))
             ids.append(ex_id)
             labels.append(y)
             features.append(x)
+            # one of the files needs to have 2 more instances
+            # than the other files
+            extra_ids = ids + ['cat{}'.format(num_examples),
+                               'dog{}'.format(num_examples + 1)]
+            extra_labels = labels + ['cat', 'dog']
 
-        for i in range(5):
+        for i in range(6):
             file_path = join(path, 'f{}.jsonlines'.format(i))
             sub_features = []
             for example_num in range(num_examples):
@@ -240,7 +245,12 @@ def create_jsonlines_feature_files(path):
                 x = {"f{}".format(feat_num):
                      features[example_num]["f{}".format(feat_num)]}
                 sub_features.append(x)
-            fs = FeatureSet('ablation_cv', ids, features=sub_features, labels=labels)
+            # the first 5 files have the same 1000 instances
+            if i <= 4:
+                fs = FeatureSet('ablation_cv', ids, features=sub_features, labels=labels)
+            # the last file has two extra instances
+            else:
+                fs = FeatureSet('ablation_cv', extra_ids, features=sub_features + [{}, {}], labels=extra_labels)
             writer = NDJWriter(file_path, fs)
             writer.write()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -226,18 +226,13 @@ def create_jsonlines_feature_files(path):
             y = "dog" if j % 2 == 0 else "cat"
             ex_id = "{}{}".format(y, j)
             x = {"f{}".format(feat_num): np.random.randint(0, 4) for feat_num in
-                 range(6)}
+                 range(5)}
             x = OrderedDict(sorted(x.items(), key=lambda t: t[0]))
             ids.append(ex_id)
             labels.append(y)
             features.append(x)
-            # one of the files needs to have 2 more instances
-            # than the other files
-            extra_ids = ids + ['cat{}'.format(num_examples),
-                               'dog{}'.format(num_examples + 1)]
-            extra_labels = labels + ['cat', 'dog']
 
-        for i in range(6):
+        for i in range(5):
             file_path = join(path, 'f{}.jsonlines'.format(i))
             sub_features = []
             for example_num in range(num_examples):
@@ -245,14 +240,22 @@ def create_jsonlines_feature_files(path):
                 x = {"f{}".format(feat_num):
                      features[example_num]["f{}".format(feat_num)]}
                 sub_features.append(x)
-            # the first 5 files have the same 1000 instances
-            if i <= 4:
-                fs = FeatureSet('ablation_cv', ids, features=sub_features, labels=labels)
-            # the last file has two extra instances
-            else:
-                fs = FeatureSet('ablation_cv', extra_ids, features=sub_features + [{}, {}], labels=extra_labels)
+            fs = FeatureSet('ablation_cv', ids, features=sub_features, labels=labels)
+
             writer = NDJWriter(file_path, fs)
             writer.write()
+
+        # now write out the last file which is basically
+        # identical to the last featureset we wrote
+        # except that it has two extra instances
+        fs = FeatureSet('extra',
+                        ids + ['cat{}'.format(num_examples),
+                               'dog{}'.format(num_examples + 1)],
+                        features=sub_features + [{}, {}],
+                        labels=labels + ['cat', 'dog'])
+        file_path = join(path, 'f5.jsonlines')
+        writer = NDJWriter(file_path, fs)
+        writer.write()
 
 
 def make_classification_data(num_examples=100, train_test_ratio=0.5,


### PR DESCRIPTION
Addresses #541 . 

- Passes the `Learner` logger down to `FilteredLeaveOneGroupOut` which means any warnings logged by the latter will get printed to the job log.
- Add a new test that triggers said warning which was not being tested before.