### PR TITLE
Fix Windows log/warnings issue

### DIFF
--- a/tests/configs/test_send_warnings_to_log.template.cfg
+++ b/tests/configs/test_send_warnings_to_log.template.cfg
@@ -11,6 +11,7 @@ num_cv_folds=2
 [Tuning]
 grid_search=True
 grid_search_folds=2
-objectives=["pearson"]
+grid_search_jobs=1
+objectives=["accuracy"]
 
 [Output]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -26,7 +26,6 @@ from numpy.testing import (assert_almost_equal,
                            assert_array_equal,
                            assert_array_almost_equal)
 
-from nose.plugins.skip import SkipTest
 from nose.tools import eq_, ok_, assert_raises
 
 from sklearn.datasets import load_digits
@@ -1085,37 +1084,29 @@ def test_send_warnings_to_log():
     """
     Test that warnings get correctly sent to the logger.
     """
+
     # Run experiment
 
-    if platform.system() == 'Windows':
-        raise SkipTest
-    else:
-        suffix = '.jsonlines'
-        train_path = join(_my_dir, 'train', 'test_send_warnings{}'.format(suffix))
-        config_path = fill_in_config_paths_for_single_file(join(_my_dir,
-                                                                "configs",
-                                                                "test_send_warnings_to_log"
-                                                                ".template.cfg"),
-                                                           train_path,
-                                                           None)
-        run_configuration(config_path, quiet=True, local=True)
+    suffix = '.jsonlines'
+    train_path = join(_my_dir, 'train', 'test_send_warnings{}'.format(suffix))
+    config_path = fill_in_config_paths_for_single_file(join(_my_dir,
+                                                            "configs",
+                                                            "test_send_warnings_to_log"
+                                                            ".template.cfg"),
+                                                       train_path,
+                                                       None)
+    run_configuration(config_path, quiet=True, local=True)
 
-        # Check experiment log output
-        # The experiment log file should contain warnings related
-        # to the use of sklearn
-        with open(join(_my_dir,
-                       'output',
-                       'test_send_warnings_to_log_train_test_send_warnings.'
-                       'jsonlines_LinearSVC.log')) as f:
-            log_content = f.read()
-            undefined_metric_sklearn_warning_re = \
-                re.compile(r"WARNING - [^\n]+sklearn/metrics/classification\.py:\d+:"
-                           r" UndefinedMetricWarning:Precision and F-score are "
-                           r"ill-defined and being set to 0\.0 in labels with no "
-                           r"predicted samples\.")
-            convergence_sklearn_warning_re = \
-                re.compile(r"WARNING - [^\n]+sklearn/svm/base\.py:\d+: "
-                           r"ConvergenceWarning:Liblinear failed to converge, "
-                           r"increase the number of iterations\.")
-            assert undefined_metric_sklearn_warning_re.search(log_content) is not None
-            assert convergence_sklearn_warning_re.search(log_content) is not None
+    # Check experiment log output
+    # The experiment log file should contain warnings related
+    # to the use of sklearn
+    with open(join(_my_dir,
+                   'output',
+                   'test_send_warnings_to_log_train_test_send_warnings.'
+                   'jsonlines_LinearSVC.log')) as f:
+        log_content = f.read()
+        convergence_sklearn_warning_re = \
+            re.compile(r"WARNING - [^\n]+sklearn.svm.base\.py:\d+: "
+                       r"ConvergenceWarning:Liblinear failed to converge, "
+                       r"increase the number of iterations\.")
+        assert convergence_sklearn_warning_re.search(log_content) is not None


### PR DESCRIPTION
Addresses #579.

Because of an issue with the way we were computing correlation, the log/warnings behavior was reacting differently on Windows vs \*nix. So, this PR just makes the test use a different objective that wouldn't issue the same warning. Also, an issue will be made to deal with log/warnings behavior when `grid_search_jobs` is greater than 1 in unit tests.