### PR TITLE
SKLL Release 2.1

### DIFF
--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,7 +1,7 @@
 How to create and test conda package.
 
 1. To create the SKLL conda package run:
-   `conda build -c defaults -c conda-forge --numpy=1.17 skll`
+   `conda build -c defaults -c conda-forge --numpy=1.17 .`
 2. Upload the package to anaconda.org using `anaconda upload --user ets <path>`.
 3. Test the package:
-   `conda create -n foobar -c conda-forge -c ets skll=2.0`
+   `conda create -n foobar -c conda-forge -c ets skll=2.1`

--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: skll
-  version: 2.0
+  version: 2.1
 
 source:
   path: ../../../skll
@@ -48,7 +48,7 @@ requirements:
     - pandas
     - python >=3.6
     - ruamel.yaml
-    - scikit-learn ==0.21.3
+    - scikit-learn ==0.22.2.post1
     - scipy
     - seaborn
     - setuptools
@@ -61,7 +61,7 @@ requirements:
     - pandas
     - python >=3.6
     - ruamel.yaml
-    - scikit-learn ==0.21.3
+    - scikit-learn ==0.22.2.post1
     - seaborn
     - scipy
     - tabulate

--- a/doc/internal/release.rst
+++ b/doc/internal/release.rst
@@ -35,18 +35,20 @@ This document is only meant for the project administrators, not users and develo
 
 9. Then run some SKLL examples or tests from a SKLL working copy. If the TestPyPI package works, then move on to the next step. If it doesn't, figure out why and rebuild and re-upload the package.
 
-10. Upload the source and wheel packages to main PyPI using ``python setup.py sdist upload`` and ``python setup.py bdist_wheel upload``
+10. Create pull requests on the `skll-conda-tester <https://github.com/EducationalTestingService/skll-conda-tester/>`_ and `skll-pip-tester <https://github.com/EducationalTestingService/skll-pip-tester/>`_ repositories to test the conda and TestPyPI packages on Linux and Windows.
 
-11. Draft a release on GitHub.
+11. Draft a release on GitHub while the Linux and Windows package tester builds are running.
 
-12. Make a pull request with the release branch to be merged into ``master`` and request code review.
+12. Once both builds have passed, make a pull request with the release branch to be merged into ``master`` and request code review.
 
-13. Once the Travis (Linux) and Azure (Windows) builds for the PR pass and the reviewers approve, merge the release branch into ``master``.
+13. Once the build for the PR passes and the reviewers approve, merge the release branch into ``master``.
 
-14. Make sure that the ReadTheDocs build for ``master`` passes.
+14. Upload source and wheel packages to PyPI using ``python setup.py sdist upload`` and ``python setup.py bdist_wheel upload``
 
-15. Tag the latest commit in ``master`` with the appropriate release tag and publish the release on GitHub.
+15. Make sure that the ReadTheDocs build for ``master`` passes.
 
-16. Send an email around at ETS announcing the release and the changes.
+16. Tag the latest commit in ``master`` with the appropriate release tag and publish the release on GitHub.
 
-17. Post release announcement on Twitter/LinkedIn.
+17. Send an email around at ETS announcing the release and the changes.
+
+18. Post release announcement on Twitter/LinkedIn.

--- a/doc/internal/release.rst
+++ b/doc/internal/release.rst
@@ -17,9 +17,9 @@ This document is only meant for the project administrators, not users and develo
 
    e. update the README and this release documentation, if necessary.
 
-3. Build the new conda package using the following command::
+3. Run the following command in the ``conda-recipe`` directory to build the conda package::
 
-    conda build -c conda-forge --numpy=1.17 skll
+    conda build -c conda-forge --numpy=1.17 .
 
 4. Upload the package to anaconda.org using ``anaconda upload --user ets <package tarball>``. You will need to have the appropriate permissions for the ``ets`` organization. 
 
@@ -35,13 +35,13 @@ This document is only meant for the project administrators, not users and develo
 
 9. Then run some SKLL examples or tests from a SKLL working copy. If the TestPyPI package works, then move on to the next step. If it doesn't, figure out why and rebuild and re-upload the package.
 
-10. Upload source package to main PyPI using ``python setup.py sdist upload``.
+10. Upload the source and wheel packages to main PyPI using ``python setup.py sdist upload`` and ``python setup.py bdist_wheel upload``
 
 11. Draft a release on GitHub.
 
 12. Make a pull request with the release branch to be merged into ``master`` and request code review.
 
-13. Once the Travis (Linux) and Appveyor (Windows) builds for the PR pass and the reviewers approve, merge the release branch into ``master``.
+13. Once the Travis (Linux) and Azure (Windows) builds for the PR pass and the reviewers approve, merge the release branch into ``master``.
 
 14. Make sure that the ReadTheDocs build for ``master`` passes.
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -178,7 +178,7 @@ types of files:
 An example of a human-readable results file for our Titanic experiment is::
 
     Experiment Name: Titanic_Evaluate_Tuned
-    SKLL Version: 2.0
+    SKLL Version: 2.1
     Training Set: train
     Training Set Size: 569
     Test Set: dev

--- a/skll/version.py
+++ b/skll/version.py
@@ -7,5 +7,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :organization: ETS
 """
 
-__version__ = '2.0'
+__version__ = '2.1'
 VERSION = tuple(int(x) for x in __version__.split('.'))


### PR DESCRIPTION
This PR: 
- Updates version number in `version.py`.
- Updates conda recipe and README.
- Updates release process document to include the conda and testpypi tester steps.
- Updates version number in tutorial output in documentation.

To review:

1. Review the changes in the PR.
2. Create a conda environment and test out the conda package with some of your SKLL experiments.
3. Let me know if I missed updating anything in the documentation.

**NOTE**: The pre-release test builds for both [Conda](https://github.com/EducationalTestingService/skll-conda-tester/pull/1) and [TestPyPI](https://github.com/EducationalTestingService/skll-pip-tester/pull/1) pass successfully 🎉.

