### PR TITLE
Allow saving models in current directory without specifying `./`

### DIFF
--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -598,6 +598,8 @@ class Learner(object):
         """
         # create the directory if it doesn't exist
         learner_dir = os.path.dirname(learner_path)
+        if not learner_dir:
+            learner_dir = os.getcwd()
         if not os.path.exists(learner_dir):
             os.makedirs(learner_dir)
         # write out the learner to disk

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -10,7 +10,6 @@ Tests related to output from run_experiment
 import csv
 import json
 import os
-import platform
 import re
 import warnings
 


### PR DESCRIPTION
This PR closes #572. 

- `Learner.save()` now uses the current working directory if only a filename is specified. 
- Added a test.
