### PR TITLE
words have meaning: renames master branch to main and updates references to master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ How to contribute
 
           $ git checkout -b feature/my-new-addition
 
-   and start making changes. **Never work in the ``master`` branch!**
+   and start making changes. **Never work in the ``main`` branch!**
 
 6. During development, you can stage and commit your changes in git as follows: 
 
@@ -69,7 +69,7 @@ following rules before submitting a pull request:
    your PR after you submit it. The *same* comment will update after you make make any further commits so refer to it after every commit. You may want to install a linter in your development environment so that you can fix any PEP8 issues while you write your code. We generally ignore E501 messages about lines longer than 100 characters. 
 
 - You may need to add new tests if the code coverage after merging your branch 
-  will be lower than the current `master`. This will be reported by the `codecov` bot once you submit your PR.
+  will be lower than the current `main`. This will be reported by the `codecov` bot once you submit your PR.
 
 After submitting a pull request, it is recommended to add at least 2-3 reviewers to 
 review it. See [Requesting a pull request review](https://help.github.com/en/articles/requesting-a-pull-request-review) for more details. 

--- a/README.rst
+++ b/README.rst
@@ -163,4 +163,4 @@ See `GitHub releases <https://github.com/EducationalTestingService/skll/releases
 Contribute
 ~~~~~~~~~~
 
-Thank you for your interest in contributing to SKLL! See `CONTRIBUTING.md <https://github.com/EducationalTestingService/skll/blob/master/CONTRIBUTING.md>`__ for instructions on how to get started.
+Thank you for your interest in contributing to SKLL! See `CONTRIBUTING.md <https://github.com/EducationalTestingService/skll/blob/main/CONTRIBUTING.md>`__ for instructions on how to get started.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -10,7 +10,7 @@ Guidelines
 ----------
 
 The SKLL contribution guidelines can be found in our Github repository
-`here <https://github.com/EducationalTestingService/skll/blob/master/CONTRIBUTING.md>`__. Please try to follow them as much as possible.
+`here <https://github.com/EducationalTestingService/skll/blob/main/CONTRIBUTING.md>`__. Please try to follow them as much as possible.
 
 SKLL Code Overview
 ------------------
@@ -24,61 +24,61 @@ Organization
 
 The main Python code for the SKLL package lives inside the ``skll`` sub-directory of the repository. It contains the following files and sub-directories:
 
--  `__init__.py <https://github.com/EducationalTestingService/skll/blob/master/skll/__init__.py>`__ : Code used to initialize the ``skll`` Python
+-  `__init__.py <https://github.com/EducationalTestingService/skll/blob/main/skll/__init__.py>`__ : Code used to initialize the ``skll`` Python
    package.
--  `config.py <https://github.com/EducationalTestingService/skll/blob/master/skll/config.py>`__ : Code to parse SKLL experiment configuration files.
--  `experiments.py <https://github.com/EducationalTestingService/skll/blob/master/skll/experiments.py>`__ : Code that is related to creating and running
+-  `config.py <https://github.com/EducationalTestingService/skll/blob/main/skll/config.py>`__ : Code to parse SKLL experiment configuration files.
+-  `experiments.py <https://github.com/EducationalTestingService/skll/blob/main/skll/experiments.py>`__ : Code that is related to creating and running
    SKLL experiments. It also contains code that collects the various
    evaluation metrics and predictions for each SKLL experiment and
    writes them out to disk.
--  `learner.py <https://github.com/EducationalTestingService/skll/blob/master/skll/learner.py>`__ : Code for the ``Learner`` class. This class is
+-  `learner.py <https://github.com/EducationalTestingService/skll/blob/main/skll/learner.py>`__ : Code for the ``Learner`` class. This class is
    instantiated for every learner name specified in the experiment
    configuration file.
--  `metrics.py <https://github.com/EducationalTestingService/skll/blob/master/skll/metrics.py>`__ : Code for any custom metrics that are not in
+-  `metrics.py <https://github.com/EducationalTestingService/skll/blob/main/skll/metrics.py>`__ : Code for any custom metrics that are not in
    ``sklearn.metrics``, e.g., ``kappa``, ``kendall_tau``,
    ``spearman``, etc.
--  `logutils.py <https://github.com/EducationalTestingService/skll/blob/master/skll/logutils.py>`__ : Code for a custom logging solution that allows
+-  `logutils.py <https://github.com/EducationalTestingService/skll/blob/main/skll/logutils.py>`__ : Code for a custom logging solution that allows
    capturing any information logged to STDOUT/STDERR by SKLL and
    scikit-learn to also be captured into log files that are then
    saved on disk.
--  `version.py <https://github.com/EducationalTestingService/skll/blob/master/skll/version.py>`__ : Code to define the SKLL version. Only changed for
+-  `version.py <https://github.com/EducationalTestingService/skll/blob/main/skll/version.py>`__ : Code to define the SKLL version. Only changed for
    new releases.
--  `data/ <https://github.com/EducationalTestingService/skll/tree/master/skll/data>`__
+-  `data/ <https://github.com/EducationalTestingService/skll/tree/main/skll/data>`__
 
-   -  `__init__.py <https://github.com/EducationalTestingService/skll/blob/master/skll/data/__init__.py>`__ : Code used to initialize the ``skll.data`` Python
+   -  `__init__.py <https://github.com/EducationalTestingService/skll/blob/main/skll/data/__init__.py>`__ : Code used to initialize the ``skll.data`` Python
       package.
-   -  `featureset.py <https://github.com/EducationalTestingService/skll/blob/master/skll/data/featureset.py>`__ : Code for the ``FeatureSet`` class – the main
+   -  `featureset.py <https://github.com/EducationalTestingService/skll/blob/main/skll/data/featureset.py>`__ : Code for the ``FeatureSet`` class – the main
       class that encapsulates all of the features names, values, and
       metadata for a given set of instances.
-   -  `readers.py <https://github.com/EducationalTestingService/skll/blob/master/skll/data/readers.py>`__ : Code for classes that can read various file
+   -  `readers.py <https://github.com/EducationalTestingService/skll/blob/main/skll/data/readers.py>`__ : Code for classes that can read various file
       formats and create ``FeatureSet`` objects from them.
-   -  `writers.py <https://github.com/EducationalTestingService/skll/blob/master/skll/data/writers.py>`__ : Code for classes that can write ``FeatureSet``
+   -  `writers.py <https://github.com/EducationalTestingService/skll/blob/main/skll/data/writers.py>`__ : Code for classes that can write ``FeatureSet``
       objects to files on disk in various formats.
-   -  `dict_vectorizer.py <https://github.com/EducationalTestingService/skll/blob/master/skll/data/dict_vectorizer.py>`__ : Code for a ``DictVectorizer`` class that
+   -  `dict_vectorizer.py <https://github.com/EducationalTestingService/skll/blob/main/skll/data/dict_vectorizer.py>`__ : Code for a ``DictVectorizer`` class that
       subclasses ``sklearn.feature_extraction.DictVectorizer`` to add an
       ``__eq__()`` method that we need for vectorizer equality.
--  `utilities/ <https://github.com/EducationalTestingService/skll/tree/master/skll/utilities>`__
+-  `utilities/ <https://github.com/EducationalTestingService/skll/tree/main/skll/utilities>`__
 
-   -  `compute_eval_from_predictions.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/compute_eval_from_predictions.py>`__ : See
+   -  `compute_eval_from_predictions.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/compute_eval_from_predictions.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#compute-eval-from-predictions>`__.
-   -  `filter_features.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/filter_features.py>`__ : See
+   -  `filter_features.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/filter_features.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#filter-features>`__.
-   -  `generate_predictions.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/generate_predictions.py>`__ : See
+   -  `generate_predictions.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/generate_predictions.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#generate-predictions>`__.
-   -  `join_features.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/join_features.py>`__ : See
+   -  `join_features.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/join_features.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#join-features>`__.
-   -  `plot_learning_curves.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/plot_learning_curves.py>`__ : See
+   -  `plot_learning_curves.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/plot_learning_curves.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#plot-learning-curves>`__.
-   -  `print_model_weights.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/print_model_weights.py>`__ : See
+   -  `print_model_weights.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/print_model_weights.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#print-model-weights>`__.
-   -  `run_experiment.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/run_experiment.py>`__ : See
+   -  `run_experiment.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/run_experiment.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/run_experiment.html#using-run-experiment>`__.
-   -  `skll_convert.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/skll_convert.py>`__ : See
+   -  `skll_convert.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/skll_convert.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#skll-convert>`__.
-   -  `summarize_results.py <https://github.com/EducationalTestingService/skll/blob/master/skll/utilities/summarize_results.py>`__ : See
+   -  `summarize_results.py <https://github.com/EducationalTestingService/skll/blob/main/skll/utilities/summarize_results.py>`__ : See
       `documentation <https://skll.readthedocs.io/en/latest/utilities.html#summarize-results>`__.
 
--  `tests/ <https://github.com/EducationalTestingService/skll/tree/master/tests>`__ 
+-  `tests/ <https://github.com/EducationalTestingService/skll/tree/main/tests>`__
 
    - ``test_*.py`` : These files contain the code for the unit tests and regression tests.
 
@@ -93,12 +93,12 @@ There are three main entry points into the SKLL codebase:
    ``run_experiment <config_file>``, the following happens (at a high level):
 
    -  the configuration file is handed off to the
-      `run_configuration() <https://github.com/EducationalTestingService/skll/blob/master/skll/experiments.py#L989>`__ function in ``experiments.py``.
-   -  a `SKLLConfigParser <https://github.com/EducationalTestingService/skll/blob/master/skll/config.py#L34>`__ object is instantiated from ``config.py``
+      `run_configuration() <https://github.com/EducationalTestingService/skll/blob/main/skll/experiments.py#L989>`__ function in ``experiments.py``.
+   -  a `SKLLConfigParser <https://github.com/EducationalTestingService/skll/blob/main/skll/config.py#L34>`__ object is instantiated from ``config.py``
       that parses all of the relevant fields out of the given
       configuration file.
    -  the configuration fields are then passed to the
-      `_classify_featureset() <https://github.com/EducationalTestingService/skll/blob/master/skll/experiments.py#L449>`__ function in ``experiments.py`` which
+      `_classify_featureset() <https://github.com/EducationalTestingService/skll/blob/main/skll/experiments.py#L449>`__ function in ``experiments.py`` which
       instantiates the learners (using code from ``learner.py``), the
       featuresets (using code from ``reader.py`` & ``featureset.py``),
       and runs the experiments, collects the results, and writes them
@@ -106,7 +106,7 @@ There are three main entry points into the SKLL codebase:
 
 2. **SKLL API**. Another way to interact with SKLL is via the SKLL API
    directly in your Python code rather than using configuration files.
-   For example, you could use the `Learner.from_file() <https://github.com/EducationalTestingService/skll/blob/master/skll/learner.py#L967>`__ method to load a saved model from disk and make predictions on new data. The
+   For example, you could use the `Learner.from_file() <https://github.com/EducationalTestingService/skll/blob/main/skll/learner.py#L967>`__ method to load a saved model from disk and make predictions on new data. The
    documentation for the SKLL API can be found
    `here <https://skll.readthedocs.io/en/latest/api.html>`__.
 

--- a/doc/internal/release.rst
+++ b/doc/internal/release.rst
@@ -39,15 +39,15 @@ This document is only meant for the project administrators, not users and develo
 
 11. Draft a release on GitHub while the Linux and Windows package tester builds are running.
 
-12. Once both builds have passed, make a pull request with the release branch to be merged into ``master`` and request code review.
+12. Once both builds have passed, make a pull request with the release branch to be merged into ``main`` and request code review.
 
-13. Once the build for the PR passes and the reviewers approve, merge the release branch into ``master``.
+13. Once the build for the PR passes and the reviewers approve, merge the release branch into ``main``.
 
 14. Upload source and wheel packages to PyPI using ``python setup.py sdist upload`` and ``python setup.py bdist_wheel upload``
 
-15. Make sure that the ReadTheDocs build for ``master`` passes.
+15. Make sure that the ReadTheDocs build for ``main`` passes.
 
-16. Tag the latest commit in ``master`` with the appropriate release tag and publish the release on GitHub.
+16. Tag the latest commit in ``main`` with the appropriate release tag and publish the release on GitHub.
 
 17. Send an email around at ETS announcing the release and the changes.
 

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -247,7 +247,7 @@ field in each section is provided below, but to summarize:
 *   A :ref:`list of classifiers/regressors <learners>` to try on your feature
     files is required.
 
-Example configuration files are available `here <https://github.com/EducationalTestingService/skll/tree/master/examples/>`__ under the ``boston``, ``iris``, and ``titanic`` sub-directories.
+Example configuration files are available `here <https://github.com/EducationalTestingService/skll/tree/main/examples/>`__ under the ``boston``, ``iris``, and ``titanic`` sub-directories.
 
 .. _general:
 


### PR DESCRIPTION
@desilinguist , 

This is in reference to #625 - thanks for raising a very thoughtful issue!

I've followed the [link you shared above](https://medium.com/faun/git-step-by-step-renaming-a-master-branch-to-main-16390ca7577b) and have completed steps 1-4 along with step 9 of updating references to `master` in the code.

Steps 5-8 and 10 on the same link needs to be done on your end (or whoever has the admin privileges to the repo). 

Let me know if there are any other changes you envisioned as part of the `master` > `main` change.

Thanks! 

