### PR TITLE
Update badges and binder URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 SciKit-Learn Laboratory
 -----------------------
 
-.. image:: https://img.shields.io/travis/EducationalTestingService/skll/master.svg
+.. image:: https://img.shields.io/travis/EducationalTestingService/skll/main.svg
    :alt: Build status
    :target: https://travis-ci.org/EducationalTestingService/skll
 
-.. image:: https://codecov.io/gh/EducationalTestingService/skll/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/EducationalTestingService/skll/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/EducationalTestingService/skll
 
 .. image:: https://img.shields.io/pypi/v/skll.svg
@@ -28,7 +28,7 @@ SciKit-Learn Laboratory
    :alt: DOI for citing SKLL 1.0.0
 
 .. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/EducationalTestingService/skll/master?filepath=examples%2FTutorial.ipynb
+ :target: https://mybinder.org/v2/gh/EducationalTestingService/skll/main?filepath=examples%2FTutorial.ipynb
 
 
 This Python package provides command-line utilities to make it easier to run

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -222,4 +222,4 @@ IRIS Example on Binder
 If you prefer using an interactive Jupyter notebook to learn about SKLL, you can do so by clicking the launch button below. 
 
 .. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/EducationalTestingService/skll/master?filepath=examples%2FTutorial.ipynb
+ :target: https://mybinder.org/v2/gh/EducationalTestingService/skll/main?filepath=examples%2FTutorial.ipynb


### PR DESCRIPTION
One of the last few steps in making `main` the default branch instead of `master`. I have already fixed the integrations in Travis, Azure Pipelines, and ReadTheDocs. Once this is merged, I can delete `master`.