### PR TITLE
Fix `Learner._check_input_formatting()` for dense feature sets. 

### DIFF
--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -661,8 +661,14 @@ class Learner(object):
                                     "labels.  Convert them to integers or "
                                     "floats.")
 
-        # make sure that feature values are not strings
-        for val in examples.features.data:
+        # make sure that feature values are not strings; to check this
+        # we need to get a flattened version of the feature array,
+        # whether it is sparse (more likely) or dense
+        if sp.issparse(examples.features):
+            flattened_features = examples.features.data
+        else:
+            flattened_features = examples.features.flat
+        for val in flattened_features:
             if isinstance(val, str):
                 raise TypeError("You have feature values that are strings.  "
                                 "Convert them to floats.")

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1820,3 +1820,12 @@ def test_predict_return_and_write():
     for (learner, class_labels) in product([learner1, learner2],
                                            [False, True]):
         yield check_predict_return_and_write, learner, test_fs, class_labels
+
+
+def test_train_non_sparse_featureset():
+    """Test that we can train a classifier on a non-sparse featureset"""
+    train_file = join(other_dir, 'examples_train.jsonlines')
+    train_fs = NDJReader.for_path(train_file, sparse=False).read()
+    learner = Learner('LogisticRegression')
+    learner.train(train_fs, grid_search=False)
+    ok_(hasattr(learner.model, "coef_"))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -18,14 +18,14 @@ from os.path import join
 from pathlib import Path
 
 import numpy as np
-from nose.tools import assert_almost_equal, assert_greater, assert_less, eq_, raises
+from nose.tools import assert_almost_equal, assert_greater, assert_less, eq_, raises, ok_
 from numpy.testing import assert_allclose
 from scipy.stats import pearsonr
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression
 
 from skll.config import _setup_config_parser
-from skll.data import FeatureSet, NDJWriter
+from skll.data import FeatureSet, NDJWriter, NDJReader
 from skll.experiments import run_configuration
 from skll.learner import Learner
 from skll.learner.utils import rescaled
@@ -727,3 +727,13 @@ def test_train_non_sparse_featureset():
     learner = Learner('LinearRegression')
     learner.train(train_fs, grid_search=False)
     ok_(hasattr(learner.model, "coef_"))
+
+
+@raises(TypeError)
+def test_train_string_labels():
+    """Test that regression on string labels raises TypeError"""
+    train_file = join(other_dir, 'test_int_labels_cv.jsonlines')
+    train_fs = NDJReader.for_path(train_file).read()
+    train_fs.labels = train_fs.labels.astype('str')
+    learner = Learner('LinearRegression')
+    learner.train(train_fs, grid_search=False)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -18,14 +18,21 @@ from os.path import join
 from pathlib import Path
 
 import numpy as np
-from nose.tools import assert_almost_equal, assert_greater, assert_less, eq_, raises, ok_
+from nose.tools import (
+    assert_almost_equal,
+    assert_greater,
+    assert_less,
+    eq_,
+    ok_,
+    raises,
+)
 from numpy.testing import assert_allclose
 from scipy.stats import pearsonr
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression
 
 from skll.config import _setup_config_parser
-from skll.data import FeatureSet, NDJWriter, NDJReader
+from skll.data import FeatureSet, NDJReader, NDJWriter
 from skll.experiments import run_configuration
 from skll.learner import Learner
 from skll.learner.utils import rescaled

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -718,3 +718,12 @@ def test_invalid_regression_metric():
         for metric in CLASSIFICATION_ONLY_METRICS:
             yield check_invalid_regression_metric, learner, metric, True
             yield check_invalid_regression_metric, learner, metric, False
+
+
+def test_train_non_sparse_featureset():
+    """Test that we can train a regressor on a non-sparse featureset"""
+    train_file = join(other_dir, 'test_int_labels_cv.jsonlines')
+    train_fs = NDJReader.for_path(train_file, sparse=False).read()
+    learner = Learner('LinearRegression')
+    learner.train(train_fs, grid_search=False)
+    ok_(hasattr(learner.model, "coef_"))


### PR DESCRIPTION
This PR closes #656. 

- Right now, this method basically assumes that all featuresets will be sparse and, hence, [uses](https://github.com/EducationalTestingService/skll/blob/main/skll/learner/__init__.py#L665) the `.data` attribute to get a flattened version of the feature array. However, this does _not_ work for featuresets with dense feature arrays (see the issue for a detailed description of the problem). 
- To handle dense feature arrays, we can use the `.flat` attribute that returns a 1-dimensional iterator over the dense array. 
- Added three new tests: 
  - 2 tests that train SKLL models -- one regression & one classification -- with a non-sparse featureset (which would not have worked before this PR) 
  - 1 to trigger the other check from this method -- regression with string labels -- which is not something we are testing for currently. 