### PR TITLE
Remove top-level imports

### DIFF
--- a/skll/__init__.py
+++ b/skll/__init__.py
@@ -11,12 +11,7 @@ common scikit-learn experiments with pre-generated features.
 
 from sklearn.metrics import SCORERS, f1_score, fbeta_score, make_scorer
 
-from .data import FeatureSet
-from .experiments import run_configuration
-from .learner import Learner
 from .metrics import correlation, f1_score_least_frequent, kappa
-
-__all__ = ["FeatureSet", "Learner", "run_configuration"]
 
 # Add our scorers to the sklearn dictionary here so that they will always be
 # available if you import anything from skll

--- a/skll/utils/commandline/print_model_weights.py
+++ b/skll/utils/commandline/print_model_weights.py
@@ -17,7 +17,7 @@ import numpy as np
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import SVC, LinearSVC
 
-from skll import Learner
+from skll.learner import Learner
 from skll.version import __version__
 
 

--- a/tests/other/custom_metrics.txt
+++ b/tests/other/custom_metrics.txt
@@ -2,7 +2,7 @@ from sklearn.metrics import fbeta_score
 
 
 def f075(y_true, y_pred):
-    return fbeta_score(y_true, y_pred, 0.75)
+    return fbeta_score(y_true, y_pred, beta=0.75)
 
 
 def ratio_of_ones(y_true, y_pred):

--- a/tests/other/custom_metrics2.py
+++ b/tests/other/custom_metrics2.py
@@ -2,4 +2,4 @@ from sklearn.metrics import fbeta_score
 
 
 def f06_micro(y_true, y_pred):
-    return fbeta_score(y_true, y_pred, 0.6, average='micro')
+    return fbeta_score(y_true, y_pred, beta=0.6, average='micro')

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -32,9 +32,9 @@ from sklearn.metrics import (
 )
 from sklearn.utils import shuffle as sk_shuffle
 
-from skll import run_configuration
 from skll.config import parse_config_file
 from skll.data import FeatureSet, NDJReader, NDJWriter
+from skll.experiments import run_configuration
 from skll.learner import Learner
 from skll.learner.utils import (
     FilteredLeaveOneGroupOut,

--- a/tests/test_custom_metrics.py
+++ b/tests/test_custom_metrics.py
@@ -20,8 +20,9 @@ from numpy.testing import (
 from sklearn.metrics import SCORERS, fbeta_score
 
 import skll.metrics
-from skll import Learner, run_configuration
 from skll.data import NDJReader
+from skll.experiments import run_configuration
+from skll.learner import Learner
 from skll.metrics import _CUSTOM_METRICS, register_custom_metric, use_score_func
 from tests import config_dir, other_dir, output_dir
 from tests.utils import (


### PR DESCRIPTION
This PR closes #661. 

In addition, it makes another minor change of passing in the `beta` argument as a keyword argument since scikit-learn raises a warning otherwise.