### PR TITLE
py36-compatible V2.0 branch

### DIFF
--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -44,9 +44,9 @@ requirements:
   build:
     - beautifulsoup4
     - joblib
-    - numpy ==1.19.5
-    - pandas ==1.2.0
-    - python ==3.8.6
+    - numpy
+    - pandas
+    - python
     - ruamel.yaml
     - scikit-learn ==0.21.1
     - scipy
@@ -57,9 +57,9 @@ requirements:
   run:
     - beautifulsoup4
     - joblib
-    - numpy ==1.19.5
-    - pandas ==1.2.0
-    - python ==3.8.6
+    - numpy
+    - pandas
+    - python
     - ruamel.yaml
     - scikit-learn ==0.21.1
     - scipy

--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: skll
-  version: 2.0
+  version: 2.0.1
 
 source:
   path: ../../../skll
 
 build:
-  number: 0
+  number: 2
   noarch: python
   script:
     - cd $SRC_DIR
@@ -43,12 +43,12 @@ build:
 requirements:
   build:
     - beautifulsoup4
-    - joblib >=0.8
-    - numpy
-    - pandas
-    - python >=3.6
+    - joblib
+    - numpy ==1.19.5
+    - pandas ==1.2.0
+    - python ==3.8.6
     - ruamel.yaml
-    - scikit-learn ==0.21.3
+    - scikit-learn ==0.21.1
     - scipy
     - seaborn
     - setuptools
@@ -56,14 +56,14 @@ requirements:
 
   run:
     - beautifulsoup4
-    - joblib >=0.8
-    - numpy
-    - pandas
-    - python >=3.6
+    - joblib
+    - numpy ==1.19.5
+    - pandas ==1.2.0
+    - python ==3.8.6
     - ruamel.yaml
-    - scikit-learn ==0.21.3
-    - seaborn
+    - scikit-learn ==0.21.1
     - scipy
+    - seaborn
     - tabulate
 
 test:


### PR DESCRIPTION
This is mostly for record-keeping. I built skll=2.0.1 conda package for py38 and placed in ETS internal channel 