### PR TITLE
Make `save_cv_folds` true by default.

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -1328,7 +1328,7 @@ save_cv_folds *(Optional)*
 """"""""""""""""""""""""""
 
 Whether to save the :ref:`folds file <output_folds_file>` containing the folds for a cross-validation experiment.
-Defaults to ``False``.
+Defaults to ``True``.
 
 .. _save_cv_models:
 

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -85,7 +85,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                     'results': '',
                     'sampler': '',
                     'sampler_parameters': '[]',
-                    'save_cv_folds': 'False',
+                    'save_cv_folds': 'True',
                     'save_cv_models': 'False',
                     'shuffle': 'False',
                     'suffix': '',

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -1411,7 +1411,7 @@ class Learner(object):
                        prediction_prefix=None,
                        param_grid=None,
                        shuffle=False,
-                       save_cv_folds=False,
+                       save_cv_folds=True,
                        save_cv_models=False,
                        use_custom_folds_for_grid_search=True):
         """
@@ -1466,7 +1466,7 @@ class Learner(object):
             Defaults to ``False``.
         save_cv_folds : bool, optional
              Whether to save the cv fold ids or not?
-             Defaults to ``False``.
+             Defaults to ``True``.
         save_cv_models : bool, optional
             Whether to save the cv models or not?
             Defaults to ``False``.

--- a/skll/learner/voting.py
+++ b/skll/learner/voting.py
@@ -625,7 +625,7 @@ class VotingLearner(object):
                        prediction_prefix=None,
                        param_grid_list=None,
                        shuffle=False,
-                       save_cv_folds=False,
+                       save_cv_folds=True,
                        save_cv_models=False,
                        individual_predictions=False,
                        use_custom_folds_for_grid_search=True):
@@ -693,7 +693,7 @@ class VotingLearner(object):
             Defaults to ``False``.
         save_cv_folds : bool, optional
              Whether to save the cv fold ids or not?
-             Defaults to ``False``.
+             Defaults to ``True``.
         save_cv_models : bool, optional
             Whether to save the cv models or not?
             Defaults to ``False``.

--- a/tests/configs/test_folds_file.template.cfg
+++ b/tests/configs/test_folds_file.template.cfg
@@ -12,4 +12,5 @@ folds_file = ../train/folds_file_test.csv
 grid_search=False
 
 [Output]
+save_cv_folds=False
 results=output

--- a/tests/configs/test_folds_file_grid.template.cfg
+++ b/tests/configs/test_folds_file_grid.template.cfg
@@ -15,4 +15,5 @@ grid_search_folds=3
 use_folds_file_for_grid_search=False
 
 [Output]
+save_cv_folds=False
 results=output

--- a/tests/configs/test_save_cv_folds.template.cfg
+++ b/tests/configs/test_save_cv_folds.template.cfg
@@ -11,5 +11,4 @@ suffix=.jsonlines
 grid_search=False
 
 [Output]
-save_cv_folds=True
 results=output

--- a/tests/configs/test_save_cv_models.template.cfg
+++ b/tests/configs/test_save_cv_models.template.cfg
@@ -11,7 +11,6 @@ suffix=.jsonlines
 grid_search=False
 
 [Output]
-save_cv_folds=True
 save_cv_models=True
 models=output
 results=output

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -156,7 +156,8 @@ def test_specified_cv_folds():
             learner.cross_validate(cv_fs,
                                    cv_folds=folds,
                                    grid_search=True,
-                                   grid_objective='f1_score_micro')
+                                   grid_objective='f1_score_micro',
+                                   save_cv_folds=False)
         fold_test_scores = [t[-2] for t in grid_scores]
 
         overall_score = np.mean(fold_test_scores)
@@ -238,8 +239,7 @@ def test_retrieve_cv_folds():
                                                        cv_folds=num_folds,
                                                        grid_search=True,
                                                        grid_objective='f1_score_micro',
-                                                       shuffle=False,
-                                                       save_cv_folds=True)
+                                                       shuffle=False)
     eq_(skll_fold_ids, expected_fold_ids)
 
     # Test 2: if we pass in custom fold ids, those are also preserved.
@@ -248,8 +248,7 @@ def test_retrieve_cv_folds():
                                                        cv_folds=custom_cv_folds,
                                                        grid_search=True,
                                                        grid_objective='f1_score_micro',
-                                                       shuffle=False,
-                                                       save_cv_folds=True)
+                                                       shuffle=False)
     eq_(skll_fold_ids, custom_cv_folds)
 
     # Test 3: when learner.cross_validate() makes the folds but stratified=False
@@ -268,8 +267,7 @@ def test_retrieve_cv_folds():
                                                        stratified=False,
                                                        cv_folds=num_folds,
                                                        grid_search=False,
-                                                       shuffle=False,
-                                                       save_cv_folds=True)
+                                                       shuffle=False)
     eq_(skll_fold_ids, custom_cv_folds)
 
 

--- a/tests/test_voting_learners_api_5.py
+++ b/tests/test_voting_learners_api_5.py
@@ -94,7 +94,6 @@ def check_cross_validate_with_grid_search(learner_type,
                                            cv_folds=3,
                                            prediction_prefix=prediction_prefix,
                                            output_metrics=[extra_metric],
-                                           save_cv_folds=True,
                                            save_cv_models=True,
                                            individual_predictions=with_individual_predictions)
 

--- a/tests/test_voting_learners_expts_4.py
+++ b/tests/test_voting_learners_expts_4.py
@@ -152,7 +152,7 @@ def check_xval_task(learner_type, options_dict):
                                 "stratified": True,
                                 "cv_folds": num_cv_folds,
                                 "output_metrics": output_metrics,
-                                "save_cv_folds": options_dict["with_save_cv_folds"],
+                                "save_cv_folds": not options_dict["without_save_cv_folds"],
                                 "save_cv_models": options_dict["with_save_cv_models"],
                                 "individual_predictions": options_dict["with_individual_predictions"]}
 
@@ -219,7 +219,7 @@ def test_xval_task():
                     "with_gs_folds",
                     "with_cv_folds",
                     "with_output_metrics",
-                    "with_save_cv_folds",
+                    "without_save_cv_folds",
                     "with_save_cv_models",
                     "with_individual_predictions"]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -378,8 +378,8 @@ def fill_in_config_options_for_voting_learners(learner_type,  # noqa: C901
         num_cv_folds = 6
         values_to_fill_dict["num_cv_folds"] = str(num_cv_folds)
 
-    if options_dict["with_save_cv_folds"]:
-        values_to_fill_dict["save_cv_folds"] = "true"
+    if options_dict["without_save_cv_folds"]:
+        values_to_fill_dict["save_cv_folds"] = "false"
 
     if options_dict["with_save_cv_models"]:
         values_to_fill_dict["save_cv_models"] = "true"


### PR DESCRIPTION
This PR closes #528. 

- Change default keyword argument values in `Learner.cross_validate()` and `VotingLearner.cross_validate()`.
- Change default value in configuration parser.
- Update tests and test templates to not specify `save_cv_folds` as `True` explicitly but do specify it as `False`.
- Update documentation for this field.