### PR TITLE
Various minor fixes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: doc/requirements.txt
+  system_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_install:
   - ${HOME}/miniconda3/bin/conda update conda --yes
 install:
   - ${HOME}/miniconda3/bin/conda create --name sklldev -c conda-forge --file conda_requirements.txt python=${TRAVIS_PYTHON_VERSION} codecov --yes --quiet
-  - ${HOME}/miniconda3/envs/sklldev/bin/pip install nose-cov
   - ${HOME}/miniconda3/envs/sklldev/bin/pip install -e .
 
 # Run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ How to contribute
 
 3. Create an isolated environment for SKLL development. We recommend using the [conda](https://conda.io/en/latest/) package manager. To create a `conda` environment, run the following command in the root of the working directory:
 
-         $ conda create -n sklldev -c conda-forge nose --file conda_requirements.txt
+         $ conda create -n sklldev -c conda-forge --file conda_requirements.txt
 
 4. Activate the conda environment
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,11 @@ SciKit-Learn Laboratory
 
 .. image:: https://img.shields.io/travis/EducationalTestingService/skll/main.svg
    :alt: Build status
-   :target: https://travis-ci.org/EducationalTestingService/skll
+   :target: https://travis-ci.com/EducationalTestingService/skll
+
+.. image:: https://dev.azure.com/EducationalTestingService/SKLL/_apis/build/status/EducationalTestingService.skll
+   :target: https://dev.azure.com/EducationalTestingService/SKLL/_build?view=runs
+   :alt: Build status
 
 .. image:: https://codecov.io/gh/EducationalTestingService/skll/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/EducationalTestingService/skll
@@ -148,6 +152,10 @@ Talks
 
 -  *Simpler Machine Learning with SKLL 1.0*, Dan Blanchard, PyData NYC 2014 (`video <https://www.youtube.com/watch?v=VEo2shBuOrc&feature=youtu.be&t=1s>`__ | `slides <http://www.slideshare.net/DanielBlanchard2/py-data-nyc-2014>`__)
 -  *Simpler Machine Learning with SKLL*, Dan Blanchard, PyData NYC 2013 (`video <http://vimeo.com/79511496>`__ | `slides <http://www.slideshare.net/DanielBlanchard2/simple-machine-learning-with-skll>`__)
+
+Citing
+~~~~~~
+If you are using SKLL in your work, you can cite it as follows: "We used scikit-learn (Pedragosa et al, 2011) via the SKLL toolkit (https://github.com/EducationalTestingService/skll)."
 
 Books
 ~~~~~

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
     displayName: "Update conda"
 
   - script: |
-      conda create --name sklldev --yes --quiet -c conda-forge -c defaults python=%PYTHON_VERSION% nose --file conda_requirements.txt
+      conda create --name sklldev --yes --quiet -c conda-forge -c defaults python=%PYTHON_VERSION% --file conda_requirements.txt
       conda init cmd.exe
       CALL activate sklldev
       pip install -e .

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,10 +1,11 @@
 beautifulsoup4
-joblib>=0.8
+joblib
 numpy
+nose-cov
 pandas
 pre-commit
 ruamel.yaml
-scikit-learn==0.24.1
+scikit-learn>=0.24.1,<=0.24.2
 scipy
 seaborn
 tabulate

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+scikit-learn>=0.24.1,<=0.24.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,4 @@
+ruamel.yaml
+beautifulsoup4
 numpy
 scikit-learn>=0.24.1,<=0.24.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 ruamel.yaml
 beautifulsoup4
+seaborn
 numpy
 scikit-learn>=0.24.1,<=0.24.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
-ruamel.yaml
 beautifulsoup4
+ruamel.yaml
 seaborn
-numpy
+tabulate
 scikit-learn>=0.24.1,<=0.24.2

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -1301,8 +1301,8 @@ predictions *(Optional)*
 """"""""""""""""""""""""
 
 Directory in which to store :ref:`prediction files <output_prediction_files>`.
-Can be omitted to not store predictions. Must *not* be specified for the
-:ref:`learning_curve <learning_curve>` and :ref:`train <train>` tasks.
+Must *not* be specified for the :ref:`learning_curve <learning_curve>` and
+:ref:`train <train>` tasks. If omitted, the current working directory is used.
 
 .. _probability:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-joblib>=0.8
+joblib
 numpy
 pandas
 ruamel.yaml


### PR DESCRIPTION

This PR closes #527, closes #599, closes #608, closes #664, and closes #668. 

- Added `nose-cov` to `conda_requirements.txt` and remove explicit installation of that package from the CI configuration files. Updated `CONTRIBUTING.md`. (#527). 
- Add a new "Citing" section to the README (#599). 
- Use travis.com badge in README instead of travis.org and add new badge for Azure Pipelines (#608). 
- Make it clear that predictions are written out to the current directory if `predictions` is omitted in the Output section of the configuration file (#664). 
- Add a `.readthedocs.yml` file and separate documentation requirements (`doc/requirements.txt`) to streamline the documentation builds (#668)