### PR TITLE
Replace Travis CI references with Gitlab CI.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ following rules before submitting a pull request:
 -  All methods and functions should have informative docstrings.
 
 -  All existing tests should pass when everything is rebuilt from scratch. You
-   should be able to see this by running ``nosetests`` locally, or looking at the Travis CI build status after you create your pull request.
+   should be able to see this by running ``nosetests`` locally, or looking at the Gitlab CI build status after you create your pull request.
 
 -  All new functionality must be covered by unit tests.
 

--- a/DistributeTests.ps1
+++ b/DistributeTests.ps1
@@ -6,7 +6,7 @@
     It is adapted from the script in this repository:
     https://github.com/PBoraMSFT/ParallelTestingSample-Python/blob/master/DistributeTests.ps1
 
-    The distribution is basically identical to the way we do it in .travis.yaml
+    The distribution is basically identical to the way we do it in .gitlab-ci.yaml
 #>
 
 $tests = Get-ChildItem .\tests\ -Filter "test*.py" # search for test files with specific pattern.


### PR DESCRIPTION
This PR closes #677.

- Change "Travis CI" to "Gitlab CI" in CONTRIBUTING.md.
- Change ".travis.yaml" to ".gitlab-ci.yaml" in DistributeTests.ps1.

**Note:** In the issue (and in other parts of the repository), it's spelled "Gitlab," which I defaulted to in order to keep things consistent. However, it's officially spelled "GitLab," [with a capitalized L](https://en.wikipedia.org/wiki/GitLab). We should open another issue to fix this.