### PR TITLE
Replace MANIFEST.in with `package_data` in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+include requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include LICENSE.txt
-include *.rst
-include requirements.txt
-recursive-exclude doc *
-recursive-exclude tests *
-recursive-exclude examples *

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,10 @@ setup(name='skll',
       author_email='nmadnani@ets.org',
       license='BSD 3 clause',
       packages=find_packages(exclude=['tests', 'examples']),
+      package_data={'':
+                    ['*.rst', 'LICENSE.txt', 'requirements.txt']},
+      exclude_package_data={'doc': ['*'], 'tests': ['*'], 'examples': ['*']},
+      include_package_data=True,
       entry_points={'console_scripts':
                     ['filter_features = skll.utils.commandline.filter_features:main',
                      'generate_predictions = skll.utils.commandline.generate_predictions:main',

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,6 @@ setup(name='skll',
       author_email='nmadnani@ets.org',
       license='BSD 3 clause',
       packages=find_packages(exclude=['tests', 'examples']),
-      package_data={'':
-                    ['*.rst', 'LICENSE.txt', 'requirements.txt']},
-      exclude_package_data={'doc': ['*'], 'tests': ['*'], 'examples': ['*']},
-      include_package_data=True,
       entry_points={'console_scripts':
                     ['filter_features = skll.utils.commandline.filter_features:main',
                      'generate_predictions = skll.utils.commandline.generate_predictions:main',


### PR DESCRIPTION
This PR closes #674.
- Add package_data, exclude_data, and include_package_data methods to setup.py
- Delete MANIFEST.in

**Note:** Tested by running `python setup.py sdist build` once for each setup and running a diff on the generated folders. They were identical!