### PR TITLE
Upgrade scikit-learn to v1.0.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - test
 
 variables:
-  PYVERSION: "3.7"
+  PYVERSION: "3.8"
   BINDIR: "/root/sklldev/bin"
   MPLBACKEND: "Agg"
   NOSE_WITH_COV: "1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,11 +14,11 @@ repos:
     -   id: check-json
     -   id: debug-statements
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 4.0.1
     hooks:
     - id: flake8
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
     -   id: isort
 -   repo: https://github.com/ikamensh/flynt/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@
 
 variables:
   MPLBACKEND: Agg
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.9
 
 trigger:
   branches:

--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: skll
-  version: 2.5
+  version: 3.0
 
 source:
   path: ../../../skll
@@ -40,7 +40,7 @@ requirements:
     - numpy {{ numpy }}
     - pandas
     - ruamel.yaml
-    - scikit-learn >=0.24.1,<=0.24.2
+    - scikit-learn >=1.0.1,<=1.0.2
     - scipy
     - seaborn
     - tabulate
@@ -52,7 +52,7 @@ requirements:
     - numpy
     - pandas
     - ruamel.yaml
-    - scikit-learn >=0.24.1,<=0.24.2
+    - scikit-learn >=1.0.1,<=1.0.2
     - scipy
     - seaborn
     - tabulate

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -5,7 +5,7 @@ nose-cov
 pandas
 pre-commit
 ruamel.yaml
-scikit-learn>=0.24.1,<=0.24.2
+scikit-learn>=1.0.1,<=1.0.2
 scipy
 seaborn
 tabulate

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -636,7 +636,7 @@ RandomForestClassifier and RandomForestRegressor
 RANSACRegressor
     .. code-block:: python
 
-       {'loss': 'squared_loss', 'random_state': 123456789}
+       {'loss': 'squared_error', 'random_state': 123456789}
 
 Ridge and RidgeClassifier
     .. code-block:: python

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ joblib
 numpy
 pandas
 ruamel.yaml
-scikit-learn>=0.24.1,<=0.24.2
+scikit-learn>=1.0.1,<=1.0.2
 scipy
 seaborn
 tabulate

--- a/skll/data/writers.py
+++ b/skll/data/writers.py
@@ -329,7 +329,7 @@ class Writer(object):
         # then, select only the columns that we want,
         # and give the columns their correct names
         if issparse(feature_set.features):
-            df_features = pd.DataFrame(feature_set.features.todense())
+            df_features = pd.DataFrame(feature_set.features.toarray())
         else:
             df_features = pd.DataFrame(feature_set.features)
         df_features = df_features.iloc[:, column_idxs].copy()

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -264,7 +264,7 @@ class Learner(object):
             self._model_kwargs['max_iter'] = 1000
             self._model_kwargs['tol'] = 1e-3
         elif issubclass(self._model_type, RANSACRegressor):
-            self._model_kwargs['loss'] = 'squared_loss'
+            self._model_kwargs['loss'] = 'squared_error'
         elif issubclass(self._model_type, (MLPClassifier, MLPRegressor)):
             self._model_kwargs['learning_rate'] = 'invscaling'
             self._model_kwargs['max_iter'] = 500

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -886,7 +886,7 @@ class Learner(object):
         # Convert to dense if necessary
         if self._use_dense_features:
             try:
-                xtrain = xtrain.todense()
+                xtrain = xtrain.toarray()
             except MemoryError:
                 if issubclass(self._model_type, _REQUIRES_DENSE):
                     reason = (f'{self._model_type.__name__} does not support '
@@ -922,7 +922,7 @@ class Learner(object):
             if isinstance(self.sampler, SkewedChi2Sampler):
                 self.logger.warning('SkewedChi2Sampler uses a dense matrix')
                 if sp.issparse(xtrain):
-                    xtrain = xtrain.todense()
+                    xtrain = xtrain.toarray()
             xtrain = self.sampler.fit_transform(xtrain)
 
         # use label dict transformed version of examples.labels if doing
@@ -1332,7 +1332,7 @@ class Learner(object):
         # Convert to dense if necessary
         if self._use_dense_features and not isinstance(xtest, np.ndarray):
             try:
-                xtest = xtest.todense()
+                xtest = xtest.toarray()
             except MemoryError:
                 if issubclass(self._model_type, _REQUIRES_DENSE):
                     reason = (f'{self._model_type.__name__} does not support '
@@ -1354,7 +1354,7 @@ class Learner(object):
             if isinstance(self.sampler, SkewedChi2Sampler):
                 self.logger.warning('SkewedChi2Sampler uses a dense matrix')
                 if sp.issparse(xtest):
-                    xtest = xtest.todense()
+                    xtest = xtest.toarray()
             xtest = self.sampler.transform(xtest)
 
         # get the various prediction from this learner on these features

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -273,6 +273,23 @@ class Learner(object):
             self._model_kwargs['solver'] = 'liblinear'
             self._model_kwargs['multi_class'] = 'auto'
 
+        #############################################
+        # FIXME when upgrading to scikit-learn v1.2 #
+        #############################################
+        # scikit-learn v1.0 will be deprecating the `normalize`
+        # attribute for linear models; this attribute
+        # is set to False by default in most scikit-learn
+        # linear models anyway and so no warnings are surfaced
+        # in SKLL. However, for `Lars`, the default value of
+        # `normalize` is still set to True and so we need to
+        # force it to False to avoid deprecation warnings. This
+        # code will actually lead to an execption in the
+        # `_create_estimator()` method when the `normalize`
+        # attribute  doesn't exist, so that will be the perfect
+        # reminder to excise this if block entirely.
+        if issubclass(self._model_type, Lars):
+            self._model_kwargs["normalize"] = False
+
         if issubclass(self._model_type,
                       (AdaBoostClassifier, AdaBoostRegressor,
                        DecisionTreeClassifier, DecisionTreeRegressor,

--- a/skll/learner/utils.py
+++ b/skll/learner/utils.py
@@ -63,7 +63,7 @@ class Densifier(BaseEstimator, TransformerMixin):
         return self
 
     def transform(self, X):
-        return X.todense()
+        return X.toarray()
 
 
 class FilteredLeaveOneGroupOut(LeaveOneGroupOut):

--- a/tests/test_commandline_utils.py
+++ b/tests/test_commandline_utils.py
@@ -777,8 +777,8 @@ def check_skll_convert(from_suffix, to_suffix, id_type):
     # explicit zeros that are in files (e.g., in CSVs and TSVs). There's an issue
     # open on scikit-learn: https://github.com/scikit-learn/scikit-learn/issues/14718
 
-    orig_fs.features = sp.sparse.csr_matrix(orig_fs.features.todense())
-    converted_fs.features = sp.sparse.csr_matrix(converted_fs.features.todense())
+    orig_fs.features = sp.sparse.csr_matrix(orig_fs.features.toarray())
+    converted_fs.features = sp.sparse.csr_matrix(converted_fs.features.toarray())
 
     eq_(orig_fs, converted_fs)
 

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -564,7 +564,7 @@ def check_filter_features(inverse=False):
                                      train_test_ratio=1.0)
 
     # store the features in a separate matrix before filtering
-    X = fs.features.todense()
+    X = fs.features.toarray()
 
     # filter features f1 and f4 or their inverse
     fs.filter(features=['f01', 'f04'], inverse=inverse)
@@ -582,7 +582,7 @@ def check_filter_features(inverse=False):
     else:
         feature_columns = X[:, [0, 3]]
 
-    assert (fs.features.todense() == feature_columns).all()
+    assert (fs.features.toarray() == feature_columns).all()
 
     # make sure that the feature names that we kept are also correct
     feature_names = ['f02', 'f03', 'f05'] if inverse else ['f01', 'f04']
@@ -665,14 +665,14 @@ def test_feature_merging_order_invariance():
     assert_array_equal(merged_fs.ids, train_fs2.ids)
     assert_array_equal(merged_fs.ids, merged_fs_shuf.ids)
 
-    assert_array_equal(merged_fs.features[:, 0:2].todense(),
-                       train_fs1.features.todense())
-    assert_array_equal(merged_fs.features[:, 2:4].todense(),
-                       train_fs2.features.todense())
-    assert_array_equal(merged_fs.features.todense(),
-                       merged_fs_shuf.features.todense())
+    assert_array_equal(merged_fs.features[:, 0:2].toarray(),
+                       train_fs1.features.toarray())
+    assert_array_equal(merged_fs.features[:, 2:4].toarray(),
+                       train_fs2.features.toarray())
+    assert_array_equal(merged_fs.features.toarray(),
+                       merged_fs_shuf.features.toarray())
 
-    assert not np.all(merged_fs.features[:, 0:2].todense() == merged_fs.features[:, 2:4].todense())
+    assert not np.all(merged_fs.features[:, 0:2].toarray() == merged_fs.features[:, 2:4].toarray())
 
 
 # Tests related to loading featuresets and merging them

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -73,7 +73,7 @@ def test_SelectByMinCount():
                          [0.0101, -200.0, 0.0]])
     assert_array_equal(feat_selector.fit_transform(np.array(m2)), expected)
     assert_array_equal(feat_selector.fit_transform(
-        sp.csr_matrix(m2)).todense(),
+        sp.csr_matrix(m2)).toarray(),
         expected)
 
     # keep features that happen 2+ times
@@ -84,7 +84,7 @@ def test_SelectByMinCount():
                          [0.0101, -200.0]])
     assert_array_equal(feat_selector.fit_transform(np.array(m2)), expected)
     assert_array_equal(
-        feat_selector.fit_transform(sp.csr_matrix(m2)).todense(),
+        feat_selector.fit_transform(sp.csr_matrix(m2)).toarray(),
         expected)
 
     # keep features that happen 3+ times
@@ -92,7 +92,7 @@ def test_SelectByMinCount():
     expected = np.array([[0.001], [0.00001], [0.001], [0.0101]])
     assert_array_equal(feat_selector.fit_transform(np.array(m2)), expected)
     assert_array_equal(
-        feat_selector.fit_transform(sp.csr_matrix(m2)).todense(),
+        feat_selector.fit_transform(sp.csr_matrix(m2)).toarray(),
         expected)
 
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -774,6 +774,6 @@ def test_non_negative_regression():
     # just for good measure, train a non-negative learner directly
     # in sklearn space and check that it has the same weights
     sklearn_estimator = LinearRegression(positive=True)
-    X, y = train_fs.features.todense(), train_fs.labels
+    X, y = train_fs.features.toarray(), train_fs.labels
     _ = sklearn_estimator.fit(X, y)
     assert_array_equal(skll_estimator2.model.coef_, sklearn_estimator.coef_)


### PR DESCRIPTION
This PR closes #699. 

This change is pretty straightforward but it’s definitely backwards incompatible which we will reflect in the release version when we put together the release.

The change specifically motivated by the upgrade are:
- Update `requirements.txt` and `conda_requirements.txt` to point to the latest scikit-learn (v1.0.1) and allow up to v1.0.2. 
- Use `squared_error` as the default value of the `loss` parameter for `RANSACRegressor`. 
- Use `toarray()` for converting sparse numpy arrays to dense instead of `todense()` since the latter returns an `np.matrix` instead of an `np.ndarray`. Scikit-learn is planning to drop support for `np.matrix` inputs and is already displaying `FutureWarning`s.
- Force normalize to False for Lars models
  -  Scikit-learn v1.0 will be deprecating the `normalize` attribute for linear models
  - This attribute is set to `False` by default in most scikit-learn linear models anyway and so no warnings are surfaced in SKLL.
  - However, for `Lars`, the default value of `normalize` is still set to `True` and so we need to force it to False to avoid `FutureWarning` instances.
  - The `if` statement added will actually lead to an execption in the `_create_estimator()` method when the `normalize` attribute  doesn't exist, so that will be the perfect reminder to excise it entirely when the time comes.

Other changes include:
- Update Python versions in CI builds (3.9 for Windows/Azure and 3.9 for Linux/Gitlab)
- Update pre-commit and pre-commit hooks to their latest versions 