### PR TITLE
Fix `—drop_blanks` for `filter_features` command line script

### DIFF
--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -364,7 +364,7 @@ class Reader(object):
             # raise an exception here because downstream processing
             # will run into issues
             if df.empty:
-                raise ValueError("No rows/lines left in feature file "
+                raise ValueError("No rows/lines left in the feature file "
                                  "after dropping blank values.")
 
         # if the id column exists,

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -360,6 +360,13 @@ class Reader(object):
             self.logger.info('Rows/lines with any blank values will be dropped.')
             df = df.dropna().reset_index(drop=True)
 
+            # if the dataframe has no rows left after removing blanks,
+            # raise an exception here because downstream processing
+            # will run into issues
+            if df.empty:
+                raise ValueError("No rows/lines left in feature file "
+                                 "after dropping blank values.")
+
         # if the id column exists,
         # get them from the data frame and
         # delete the column; otherwise, just

--- a/skll/utils/commandline/filter_features.py
+++ b/skll/utils/commandline/filter_features.py
@@ -75,13 +75,15 @@ def main(argv=None):
                         default='y')
     parser.add_argument('-rb', '--replace_blanks_with',
                         help='Specifies a new value with which to replace '
-                             'blank values in all columns in the file. To '
+                             'blank values in all columns in a CSV/TSV file. To '
                              'replace blanks differently in each column, use '
                              'the SKLL Reader API directly.',
                         default=None)
     parser.add_argument('-db', '--drop_blanks',
                         action='store_true',
-                        help='Drop all lines/rows that have any blank values.',
+                        help='Drop all lines/rows in a CSV/TSV file that '
+                             'contain any blank values. If each row of the file '
+                             'contains a blank value, an exception will be raised.',
                         default=False)
     parser.add_argument('-q', '--quiet',
                         help='Suppress printing of "Loading..." messages.',

--- a/tests/test_commandline_utils.py
+++ b/tests/test_commandline_utils.py
@@ -1836,9 +1836,9 @@ def test_filter_features_with_drop_blanks():
 
 
 @raises(ValueError)
-def test_filter_features_with_drop_blanks_all_blanks():
+def test_filter_features_with_drop_blanks_all_blanks_csv():
     """
-    Test filter features with CSV and TSV readers
+    Test filter features with CSV readers
     using `drop_blanks` and blanks in each row
     """
     df = pd.DataFrame({'A': [1, 2, np.nan, 4, 5, 6],
@@ -1847,21 +1847,37 @@ def test_filter_features_with_drop_blanks_all_blanks():
                        'L': [1, np.nan, 1, 2, 1, np.nan]})
 
     csv_infile = join(other_dir, 'features', 'features_drop_blanks_all_blanks.csv')
-    tsv_infile = join(other_dir, 'features', 'features_drop_blanks_all_blanks.tsv')
 
     df.to_csv(csv_infile, index=False)
-    df.to_csv(tsv_infile, index=False, sep='\t')
 
     filter_features_csv_cmd = ['-i', csv_infile,
                                '-o', 'blah.csv',
                                '-l', 'L',
                                '--drop_blanks']
+
+    ff.main(filter_features_csv_cmd)
+
+
+@raises(ValueError)
+def test_filter_features_with_drop_blanks_all_blanks_tsv():
+    """
+    Test filter features with TSV readers
+    using `drop_blanks` and blanks in each row
+    """
+    df = pd.DataFrame({'A': [1, 2, np.nan, 4, 5, 6],
+                       'B': [5, 9, 7, 2, np.nan, 1],
+                       'C': [np.nan, 1.0, 1.0, np.nan, 1.0, 1.1],
+                       'L': [1, np.nan, 1, 2, 1, np.nan]})
+
+    tsv_infile = join(other_dir, 'features', 'features_drop_blanks_all_blanks.tsv')
+
+    df.to_csv(tsv_infile, index=False, sep='\t')
+
     filter_features_tsv_cmd = ['-i', tsv_infile,
                                '-o', 'blah.tsv',
                                '-l', 'L',
                                '--drop_blanks']
 
-    ff.main(filter_features_csv_cmd)
     ff.main(filter_features_tsv_cmd)
 
 

--- a/tests/test_commandline_utils.py
+++ b/tests/test_commandline_utils.py
@@ -1835,6 +1835,36 @@ def test_filter_features_with_drop_blanks():
     assert_frame_equal(df_tsv_output, df_expected)
 
 
+@raises(ValueError)
+def test_filter_features_with_drop_blanks_all_blanks():
+    """
+    Test filter features with CSV and TSV readers
+    using `drop_blanks` and blanks in each row
+    """
+    df = pd.DataFrame({'A': [1, 2, np.nan, 4, 5, 6],
+                       'B': [5, 9, 7, 2, np.nan, 1],
+                       'C': [np.nan, 1.0, 1.0, np.nan, 1.0, 1.1],
+                       'L': [1, np.nan, 1, 2, 1, np.nan]})
+
+    csv_infile = join(other_dir, 'features', 'features_drop_blanks_all_blanks.csv')
+    tsv_infile = join(other_dir, 'features', 'features_drop_blanks_all_blanks.tsv')
+
+    df.to_csv(csv_infile, index=False)
+    df.to_csv(tsv_infile, index=False, sep='\t')
+
+    filter_features_csv_cmd = ['-i', csv_infile,
+                               '-o', 'blah.csv',
+                               '-l', 'L',
+                               '--drop_blanks']
+    filter_features_tsv_cmd = ['-i', tsv_infile,
+                               '-o', 'blah.tsv',
+                               '-l', 'L',
+                               '--drop_blanks']
+
+    ff.main(filter_features_csv_cmd)
+    ff.main(filter_features_tsv_cmd)
+
+
 def test_filter_features_with_replace_blanks_with():
     """
     Test filter features with CSV and TSV readers


### PR DESCRIPTION
This PR closes #693. 

- Raise an exception if `—drop_blanks` removes all rows in the input file if each of them contains a blank value.
- Add a test for this scenario.
- Update `—help` output for `filter_features` to make it clear that `—drop_blanks` and `—replace_blanks_with` only apply to CSV/TSV files. 