### PR TITLE
Short PR to address 2 minor documentation issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ How to contribute
 
 10. After making sure all tests pass, you are ready to push your branch/fork to GitHub with:
 
-          $ git push feature/my-new-addition
+          $ git push -u origin feature/my-new-addition
 
 Finally, go to the web page of (your fork of) the SKLL repo,
 and click 'Pull request' to send your changes to the maintainers for

--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -932,7 +932,9 @@ SKLL provides the following metrics but you can also write your own :ref:`custom
     *   **precision_macro**: Macro-averaged |Precision link|_
     *   **precision_micro**: Micro-averaged |Precision link|_
     *   **precision_weighted**: Weighted average |Precision link|_
-    *   **quadratic_weighted_kappa**: `Quadratic weighted kappa <http://www.vassarstats.net/kappaexp.html>`__. (*Contiguous integer labels only*).
+    *   **quadratic_weighted_kappa**: `Quadratic weighted kappa <http://www.vassarstats.net/kappaexp.html>`__. (*Contiguous integer labels only*). If you wish to compute quadratic weighted kappa for continuous
+        values, you may want to use the `implementation provided by RSMTool <https://rsmtool.readthedocs.io/en/stable/evaluation.html#quadratic-weighted-kappa-qwk>`__.
+        To do so, `install the RSMTool Python package <https://rsmtool.readthedocs.io/en/stable/getting_started.html>`__ and create a :ref:`custom metric <custom_metrics>` that wraps ``rsmtool.utils.quadratic_weighted_kappa``.
     *   **qwk_off_by_one**: Same as ``quadratic_weighted_kappa``, but all
         ranking differences are discounted by one. (*Contiguous integer labels only*).
     *   **recall**: |Recall link|_ for binary classification


### PR DESCRIPTION
This PR closes #512 and closes #680. 

- Update `CONTRIBUTING.md` file to fix the `git push` instructions (Issue: #512) 
- Add a link to RSMTool’s QWK implementation from the SKLL documentation. We do this _instead of_  moving RSMTool’s QWK implementation to SKLL because that is no longer necessary now that SKLL supports custom metrics. (Issue: #680)