### PR TITLE
Rename `pos_label_str` to `pos_label` everywhere.

### DIFF
--- a/doc/run_experiment.rst
+++ b/doc/run_experiment.rst
@@ -1146,17 +1146,17 @@ SVR
     experiment and are best left up to the user.
 
 
-.. _pos_label_str:
+.. _pos_label:
 
-pos_label_str *(Optional)*
-""""""""""""""""""""""""""
+pos_label *(Optional)*
+""""""""""""""""""""""
 
 A string denoting the label of the class to be
 treated as the positive class in a binary classification
 setting. If unspecified, the class represented by the label
 that appears second when sorted is chosen as the positive
 class. For example, if the two labels in data are "A" and
-"B" and ``pos_label_str`` is not specified, "B" will be chosen
+"B" and ``pos_label`` is not specified, "B" will be chosen
 as the positive class.
 
 .. _use_folds_file_for_grid_search:
@@ -1550,7 +1550,7 @@ in these files, where N is the number of classes in the training
 data. The header for the column containing IDs is still "id" and the
 labels themselves are the headers for the columns containing their
 respective probabilities. In the special case of binary classification,
-the :ref:`positive class <pos_label_str>` probabilities are always in
+the :ref:`positive class <pos_label>` probabilities are always in
 the last column.
 
 .. _output_summary_file:

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -77,7 +77,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                     'metrics': "[]",
                     'objectives': "[]",
                     'param_grids': '[]',
-                    'pos_label_str': '',
+                    'pos_label': '',
                     'pipeline': 'False',
                     'predictions': '',
                     'probability': 'False',
@@ -121,7 +121,7 @@ class SKLLConfigParser(configparser.ConfigParser):
                                    'num_cv_folds': 'Input',
                                    'objectives': 'Tuning',
                                    'param_grids': 'Tuning',
-                                   'pos_label_str': 'Tuning',
+                                   'pos_label': 'Tuning',
                                    'pipeline': 'Output',
                                    'predictions': 'Output',
                                    'probability': 'Output',
@@ -328,7 +328,7 @@ def parse_config_file(config_path, log_level=logging.INFO):  # noqa: C901
     results_path : str
         Path to store result files in.
 
-    pos_label_str : str
+    pos_label : str
         The string label for the positive class in the binary
         classification setting.
 
@@ -592,10 +592,10 @@ def parse_config_file(config_path, log_level=logging.INFO):  # noqa: C901
     fixed_sampler_parameters = yaml.safe_load(fixed_sampler_parameters)
     param_grid_list = yaml.safe_load(fix_json(config.get("Tuning", "param_grids")))
 
-    # read and normalize the value of `pos_label_str`
-    pos_label_str = safe_float(config.get("Tuning", "pos_label_str"))
-    if pos_label_str == '':
-        pos_label_str = None
+    # read and normalize the value of `pos_label`
+    pos_label = safe_float(config.get("Tuning", "pos_label"))
+    if pos_label == '':
+        pos_label = None
 
     # ensure that feature_scaling is specified only as one of the
     # four available choices
@@ -884,7 +884,7 @@ def parse_config_file(config_path, log_level=logging.INFO):  # noqa: C901
             feature_hasher, hasher_features, id_col, label_col, train_set_name,
             test_set_name, suffix, featuresets, do_shuffle, model_path,
             do_grid_search, grid_objectives, probability, pipeline, results_path,
-            pos_label_str, feature_scaling, min_feature_count, folds_file,
+            pos_label, feature_scaling, min_feature_count, folds_file,
             grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
             save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
             fixed_parameter_list, param_grid_list, featureset_names, learners,

--- a/skll/experiments/__init__.py
+++ b/skll/experiments/__init__.py
@@ -108,7 +108,7 @@ def _classify_featureset(args):  # noqa: C901
     fixed_parameters = args.pop("fixed_parameters")
     sampler_parameters = args.pop("sampler_parameters")
     param_grid = args.pop("param_grid")
-    pos_label_str = args.pop("pos_label_str")
+    pos_label = args.pop("pos_label")
     overwrite = args.pop("overwrite")
     feature_scaling = args.pop("feature_scaling")
     min_feature_count = args.pop("min_feature_count")
@@ -241,7 +241,7 @@ def _classify_featureset(args):  # noqa: C901
             # supported by SKLL (regular and voting)
             common_learner_kwargs = {"custom_learner_path": custom_learner_path,
                                      "feature_scaling": feature_scaling,
-                                     "pos_label_str": pos_label_str,
+                                     "pos_label": pos_label,
                                      "min_feature_count": min_feature_count,
                                      "logger": logger}
 
@@ -630,7 +630,7 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',  
         (experiment_name, task, sampler, fixed_sampler_parameters, feature_hasher,
          hasher_features, id_col, label_col, train_set_name, test_set_name, suffix,
          featuresets, do_shuffle, model_path, do_grid_search, grid_objectives,
-         probability, pipeline, results_path, pos_label_str, feature_scaling,
+         probability, pipeline, results_path, pos_label, feature_scaling,
          min_feature_count, folds_file, grid_search_jobs, grid_search_folds, cv_folds,
          save_cv_folds, save_cv_models, use_folds_file_for_grid_search,
          do_stratified_folds, fixed_parameter_list, param_grid_list, featureset_names,
@@ -811,7 +811,7 @@ def run_configuration(config_file, local=False, overwrite=True, queue='all.q',  
                                                     else dict())
                     job_args["param_grid"] = (param_grid_list[learner_num]
                                               if param_grid_list else None)
-                    job_args["pos_label_str"] = pos_label_str
+                    job_args["pos_label"] = pos_label
                     job_args["overwrite"] = overwrite
                     job_args["feature_scaling"] = feature_scaling
                     job_args["min_feature_count"] = min_feature_count

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -137,13 +137,13 @@ class Learner(object):
         A dictionary of keyword arguments to pass to the
         initializer for the specified model.
         Defaults to ``None``.
-    pos_label_str : str, optional
+    pos_label : str, optional
         A string denoting the label of the class to be
         treated as the positive class in a binary classification
         setting. If ``None``, the class represented by the label
         that appears second when sorted is chosen as the positive
         class. For example, if the two labels in data are "A"
-        and "B" and ``pos_label_str`` is not specified, "B" will
+        and "B" and ``pos_label`` is not specified, "B" will
         be chosen as the positive class.
         Defaults to ``None``.
     min_feature_count : int, optional
@@ -176,7 +176,7 @@ class Learner(object):
                  pipeline=False,
                  feature_scaling='none',
                  model_kwargs=None,
-                 pos_label_str=None,
+                 pos_label=None,
                  min_feature_count=1,
                  sampler=None,
                  sampler_kwargs=None,
@@ -191,7 +191,7 @@ class Learner(object):
         self.scaler = None
         self.label_dict = None
         self.label_list = None
-        self.pos_label_str = safe_float(pos_label_str) if pos_label_str is not None else pos_label_str
+        self.pos_label = safe_float(pos_label) if pos_label is not None else pos_label
         self._model = None
         self._store_pipeline = pipeline
         self._feature_scaling = feature_scaling
@@ -711,14 +711,14 @@ class Learner(object):
         # that it is last in the list; for multi-class classification
         # raise a warning and set it back to None, since it does not
         # make any sense anyway
-        if self.pos_label_str is not None:
+        if self.pos_label is not None:
             if len(self.label_list) != 2:
-                self.logger.warning('Ignoring value of `pos_label_str` for '
+                self.logger.warning('Ignoring value of `pos_label` for '
                                     'multi-class classification.')
-                self.pos_label_str = None
+                self.pos_label = None
             else:
                 self.label_list = sorted(self.label_list,
-                                         key=lambda x: (x == self.pos_label_str,
+                                         key=lambda x: (x == self.pos_label,
                                                         x))
 
         # Given a list of all labels in the dataset and a list of the

--- a/skll/learner/voting.py
+++ b/skll/learner/voting.py
@@ -68,13 +68,13 @@ class VotingLearner(object):
         -  "both": do both scaling as well as centering
         -  "none": do neither scaling nor centering
         Defaults to 'none'.
-    pos_label_str : str, optional
+    pos_label : str, optional
         A string denoting the label of the class to be
         treated as the positive class in a binary classification
         setting, for each estimator. If ``None``, the class represented
         by the label that appears second when sorted is chosen as the
         positive class. For example, if the two labels in data are "A"
-        and "B" and ``pos_label_str`` is not specified, "B" will
+        and "B" and ``pos_label`` is not specified, "B" will
         be chosen as the positive class.
         Defaults to ``None``.
     min_feature_count : int, optional
@@ -112,7 +112,7 @@ class VotingLearner(object):
                  voting="hard",
                  custom_learner_path=None,
                  feature_scaling="none",
-                 pos_label_str=None,
+                 pos_label=None,
                  min_feature_count=1,
                  model_kwargs_list=None,
                  sampler_list=None,
@@ -175,7 +175,7 @@ class VotingLearner(object):
                               min_feature_count=min_feature_count,
                               model_kwargs=model_kwargs,
                               pipeline=True,
-                              pos_label_str=pos_label_str,
+                              pos_label=pos_label,
                               probability=self.voting == "soft",
                               sampler=sampler,
                               sampler_kwargs=sampler_kwargs,
@@ -375,7 +375,7 @@ class VotingLearner(object):
 
         # get the training labels in the right format too
         # NOTE: technically, we could also use a `LabelEncoder` here but
-        # that may not account for passing `pos_label_str` above when
+        # that may not account for passing `pos_label` above when
         # instantiating the learners so we stick with the label dict
         if self.learner_type == "classifier":
             y_train = [self.label_dict[label] for label in examples.labels]

--- a/skll/utils/commandline/generate_predictions.py
+++ b/skll/utils/commandline/generate_predictions.py
@@ -98,18 +98,18 @@ def main(argv=None):
     estimator_type = learner.model_type._estimator_type
 
     # if we are using a binary classification model, get the positive
-    # class label string if from the `pos_label_str` attribute, and if
+    # class label string if from the `pos_label` attribute, and if
     # that is `None`, get it from the learner's label dictionary; also
     # get the string denoting the negative label which is just the other
     # label in the list
     if estimator_type == 'classifier':
         if len(learner.label_list) == 2:
-            if learner.pos_label_str is not None:
-                pos_label_str = learner.pos_label_str
+            if learner.pos_label is not None:
+                pos_label = learner.pos_label
             else:
-                pos_label_str = [label for label in learner.label_dict if learner.label_dict[label] == 1][0]
-            neg_label_str = [label for label in learner.label_list if label != pos_label_str][0]
-            logger.info(f"{pos_label_str} is the label for the positive "
+                pos_label = [label for label in learner.label_dict if learner.label_dict[label] == 1][0]
+            neg_label = [label for label in learner.label_list if label != pos_label][0]
+            logger.info(f"{pos_label} is the label for the positive "
                         "class.")
 
     # if we want to choose labels by thresholding the probabilities,
@@ -180,7 +180,7 @@ def main(argv=None):
             if args.threshold is not None:
                 predictions = []
                 for neg_label_prob, pos_label_prob in original_predictions:
-                    chosen_label = pos_label_str if pos_label_prob >= args.threshold else neg_label_str
+                    chosen_label = pos_label if pos_label_prob >= args.threshold else neg_label
                     predictions.append(chosen_label)
 
             # For everything else, we can just use the original predictions

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -249,20 +249,20 @@ def check_binary_predictions_for_pos_label(label_list,
     """
 
     if label_list == ['B', 'C']:
-        pos_label, other_label_str = 'B', 'C'
+        pos_label, other_label = 'B', 'C'
     elif label_list == [1, 2]:
-        pos_label, other_label_str = 2, 1
+        pos_label, other_label = 2, 1
     else:
-        pos_label, other_label_str = 'FRAG', 'NONE'
+        pos_label, other_label = 'FRAG', 'NONE'
 
     # create the mapping from class indices to class labels
     # manually so that they match our expectations for what
     # is supposed to happen when `pos_label` is specified
     # and when it is not
     if use_pos_label:
-        index_label_dict = {0: other_label_str, 1: pos_label}
+        index_label_dict = {0: other_label, 1: pos_label}
     else:
-        sorted_label_list = sorted([pos_label, other_label_str])
+        sorted_label_list = sorted([pos_label, other_label])
         index_label_dict = dict(enumerate(sorted_label_list))
 
     # initialize a random number generator

--- a/tests/test_commandline_utils.py
+++ b/tests/test_commandline_utils.py
@@ -84,7 +84,7 @@ def tearDown():
 
     for glob_pattern in [join(output_dir, 'test_print_model_weights.model*'),
                          join(output_dir, 'test_generate_predictions.model*'),
-                         join(output_dir, 'pos_label_str_predict*'),
+                         join(output_dir, 'pos_label_predict*'),
                          join(output_dir, 'test_generate_predictions_console.model*'),
                          join(other_dir, 'test_skll_convert*'),
                          join(other_dir, 'test_join_features*'),
@@ -304,7 +304,7 @@ def check_generate_predictions(use_regression=False,  # noqa: C901
                                string_labels=False,
                                num_labels=2,
                                use_probability=False,
-                               use_pos_label_str=False,
+                               use_pos_label=False,
                                test_on_subset=False,
                                use_threshold=False,
                                predict_labels=False,
@@ -319,7 +319,7 @@ def check_generate_predictions(use_regression=False,  # noqa: C901
 
     # generate the train and test featuresets
     if use_regression:
-        pos_label_str = None
+        pos_label = None
         train_fs, test_fs, _ = make_regression_data(num_examples=100,
                                                     num_features=5)
     else:
@@ -331,21 +331,21 @@ def check_generate_predictions(use_regression=False,  # noqa: C901
         # get the sorted list of unique class labels
         class_labels = np.unique(train_fs.labels).tolist()
 
-        # if we are using `pos_label_str`, then randomly pick a label
+        # if we are using `pos_label`, then randomly pick a label
         # as its value even for multi-class since we want to check that
         # it properly gets ignored; we also instantiate variables in the
         # binary case that contain the positive and negative class labels
         # since we need those to process our expected predictions we
         # are matching against
         prng = np.random.RandomState(123456789)
-        if use_pos_label_str:
-            pos_label_str = prng.choice(class_labels, size=1)[0]
+        if use_pos_label:
+            pos_label = prng.choice(class_labels, size=1)[0]
             if num_labels == 2:
-                positive_class_label = pos_label_str
+                positive_class_label = pos_label
                 negative_class_label = [label for label in class_labels if label != positive_class_label][0]
                 class_labels = [negative_class_label, positive_class_label]
         else:
-            pos_label_str = None
+            pos_label = None
             if num_labels == 2:
                 positive_class_label = class_labels[-1]
                 negative_class_label = [label for label in class_labels if label != positive_class_label][0]
@@ -371,7 +371,7 @@ def check_generate_predictions(use_regression=False,  # noqa: C901
     learner_name = 'SGDRegressor' if use_regression else 'SGDClassifier'
     learner = Learner(learner_name,
                       probability=enable_probability,
-                      pos_label_str=pos_label_str)
+                      pos_label=pos_label)
     learner.train(train_fs, grid_search=False)
     model_file = join(output_dir, 'test_generate_predictions.model')
     learner.save(model_file)
@@ -494,7 +494,7 @@ def test_generate_predictions():
          string_labels,
          num_labels,
          use_probability,
-         use_pos_label_str,
+         use_pos_label,
          test_on_subset,
          use_threshold,
          predict_labels,
@@ -520,7 +520,7 @@ def test_generate_predictions():
                string_labels,
                num_labels,
                use_probability,
-               use_pos_label_str,
+               use_pos_label,
                test_on_subset,
                use_threshold,
                predict_labels,

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -978,7 +978,7 @@ def test_config_parsing_no_grid_objectives_needed_for_learning_curve():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1016,7 +1016,7 @@ def test_config_parsing_relative_input_path():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1290,7 +1290,7 @@ def check_cv_folds_and_grid_search_folds(task,
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1328,7 +1328,7 @@ def test_default_number_of_cv_folds():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1365,7 +1365,7 @@ def test_setting_number_of_cv_folds():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1404,7 +1404,7 @@ def test_setting_param_grids():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1447,7 +1447,7 @@ def test_setting_fixed_parameters():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1515,7 +1515,7 @@ def test_default_learning_curve_options():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1552,7 +1552,7 @@ def test_setting_learning_curve_options():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1591,7 +1591,7 @@ def test_learning_curve_metrics_and_objectives_throw_error():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1627,7 +1627,7 @@ def test_learning_curve_metrics_and_no_objectives():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1663,7 +1663,7 @@ def test_learning_curve_metrics():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1701,7 +1701,7 @@ def test_learning_curve_pipeline_option():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1847,7 +1847,7 @@ def test_config_parsing_no_grid_search_but_objectives_specified():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1910,9 +1910,9 @@ def test_config_parsing_param_grids_fixed_parameters_conflict():
         eq_(len(matches), 1)
 
 
-def test_config_parsing_default_pos_label_str_value():
+def test_config_parsing_default_pos_label_value():
     """
-    Check that the default value of `pos_label_str` gets set to `None`
+    Check that the default value of `pos_label` gets set to `None`
     """
 
     values_to_fill_dict = {
@@ -1932,13 +1932,13 @@ def test_config_parsing_default_pos_label_str_value():
 
     config_path = fill_in_config_options(config_template_path,
                                          values_to_fill_dict,
-                                         'default_value_pos_label_str')
+                                         'default_value_pos_label')
 
     (experiment_name, task, sampler, fixed_sampler_parameters,
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -1946,7 +1946,7 @@ def test_config_parsing_default_pos_label_str_value():
      class_map, custom_learner_path, custom_metric_path, learning_curve_cv_folds_list,
      learning_curve_train_sizes, output_metrics, save_votes) = parse_config_file(config_path)
 
-    eq_(pos_label_str, None)
+    eq_(pos_label, None)
 
 
 def test_config_parsing_default_save_votes_value():
@@ -1978,7 +1978,7 @@ def test_config_parsing_default_save_votes_value():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,
@@ -2019,7 +2019,7 @@ def test_config_parsing_set_save_votes_value():
      feature_hasher, hasher_features, id_col, label_col, train_set_name,
      test_set_name, suffix, featuresets, do_shuffle, model_path,
      do_grid_search, grid_objectives, probability, pipeline, results_path,
-     pos_label_str, feature_scaling, min_feature_count, folds_file,
+     pos_label, feature_scaling, min_feature_count, folds_file,
      grid_search_jobs, grid_search_folds, cv_folds, save_cv_folds,
      save_cv_models, use_folds_file_for_grid_search, do_stratified_folds,
      fixed_parameter_list, param_grid_list, featureset_names, learners,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -220,7 +220,7 @@ def check_scaling_features(use_feature_hashing=False, use_scaling=False):
     # create a Linear SVM with the value of scaling as specified
     feature_scaling = 'both' if use_scaling else 'none'
     learner = Learner('SGDClassifier', feature_scaling=feature_scaling,
-                      pos_label_str=1)
+                      pos_label="1")
 
     # train the learner on the training set and test on the testing set
     learner.train(train_fs,

--- a/tests/test_voting_learners_api_1.py
+++ b/tests/test_voting_learners_api_1.py
@@ -49,7 +49,7 @@ def tearDown():
 def check_initialize(learner_type,
                      voting_type,
                      feature_scaling,
-                     pos_label_str,
+                     pos_label,
                      min_feature_count,
                      model_kwargs_list,
                      sampler_list):
@@ -60,8 +60,8 @@ def check_initialize(learner_type,
         kwargs["voting"] = voting_type
     if feature_scaling:
         kwargs["feature_scaling"] = feature_scaling
-    if pos_label_str:
-        kwargs["pos_label_str"] = pos_label_str
+    if pos_label:
+        kwargs["pos_label"] = pos_label
     if min_feature_count:
         kwargs["min_feature_count"] = min_feature_count
     if sampler_list is not None:
@@ -163,7 +163,7 @@ def test_initialize():
     for (learner_type,
          voting_type,
          feature_scaling,
-         pos_label_str,
+         pos_label,
          min_feature_count,
          model_kwargs_list,
          sampler_list) in product(["classifier", "regressor"],
@@ -177,7 +177,7 @@ def test_initialize():
                learner_type,
                voting_type,
                feature_scaling,
-               pos_label_str,
+               pos_label,
                min_feature_count,
                model_kwargs_list,
                sampler_list)

--- a/tests/test_voting_learners_expts_1.py
+++ b/tests/test_voting_learners_expts_1.py
@@ -102,7 +102,7 @@ def check_train_task(learner_type, options_dict):
         expected_init_kwargs = {"voting": "soft" if options_dict["with_soft_voting"] else "hard",
                                 "custom_learner_path": custom_learner,
                                 "feature_scaling": "with_mean" if options_dict["with_centering"] else "none",
-                                "pos_label_str": "dog" if options_dict["with_pos_label_str"] else None,
+                                "pos_label": "dog" if options_dict["with_pos_label"] else None,
                                 "min_feature_count": 2 if options_dict["with_min_feature_count"] else 1,
                                 "model_kwargs_list": model_kwargs_list,
                                 "sampler_list": sampler_list,
@@ -160,7 +160,7 @@ def test_train_task():
                     "with_centering",
                     "with_min_feature_count",
                     "with_custom_learner_path",
-                    "with_pos_label_str",
+                    "with_pos_label",
                     "with_model_kwargs_list",
                     "with_sampler_list",
                     "with_grid_search",
@@ -190,9 +190,9 @@ def test_train_task():
         # a dictionary class that returns `False` for non-existent keys
         options_dict = BoolDict(zip(option_names, option_values[1:]))
 
-        # voting regressors do not support soft voting or `pos_label_str`
+        # voting regressors do not support soft voting or `pos_label`
         if (learner_type == "regressor" and
-                (options_dict["with_soft_voting"] or options_dict["with_pos_label_str"])):
+                (options_dict["with_soft_voting"] or options_dict["with_pos_label"])):
             continue
 
         yield check_train_task, learner_type, options_dict

--- a/tests/test_voting_learners_expts_2.py
+++ b/tests/test_voting_learners_expts_2.py
@@ -133,7 +133,7 @@ def check_evaluate_task(learner_type, options_dict):
         expected_init_kwargs = {"voting": "soft" if options_dict["with_soft_voting"] else "hard",
                                 "custom_learner_path": custom_learner,
                                 "feature_scaling": "none",
-                                "pos_label_str": None,
+                                "pos_label": None,
                                 "min_feature_count": 1,
                                 "model_kwargs_list": model_kwargs_list,
                                 "sampler_list": sampler_list,

--- a/tests/test_voting_learners_expts_3.py
+++ b/tests/test_voting_learners_expts_3.py
@@ -133,7 +133,7 @@ def check_predict_task(learner_type, options_dict):
         expected_init_kwargs = {"voting": "soft" if options_dict["with_soft_voting"] else "hard",
                                 "custom_learner_path": custom_learner,
                                 "feature_scaling": "none",
-                                "pos_label_str": None,
+                                "pos_label": None,
                                 "min_feature_count": 1,
                                 "model_kwargs_list": model_kwargs_list,
                                 "sampler_list": sampler_list,

--- a/tests/test_voting_learners_expts_4.py
+++ b/tests/test_voting_learners_expts_4.py
@@ -129,7 +129,7 @@ def check_xval_task(learner_type, options_dict):
         expected_init_args = (estimator_names,)
         expected_init_kwargs = {"voting": "soft" if options_dict["with_soft_voting"] else "hard",
                                 "feature_scaling": "none",
-                                "pos_label_str": "dog" if options_dict["with_pos_label_str"] else None,
+                                "pos_label": "dog" if options_dict["with_pos_label"] else None,
                                 "model_kwargs_list": model_kwargs_list,
                                 "sampler_list": sampler_list,
                                 "sampler_kwargs_list": None}
@@ -211,7 +211,7 @@ def test_xval_task():
     # not very common or because they are already tested in other voting
     # learner experiment tests
     option_names = ["with_soft_voting",
-                    "with_pos_label_str",
+                    "with_pos_label",
                     "with_model_kwargs_list",
                     "with_grid_search",
                     "with_param_grid_list",
@@ -244,9 +244,9 @@ def test_xval_task():
         # a dictionary class that returns `False` for non-existent keys
         options_dict = BoolDict(zip(option_names, option_values[1:]))
 
-        # voting regressors do not support soft voting or `pos_label_str`
+        # voting regressors do not support soft voting or `pos_label`
         if (learner_type == "regressor" and
-                (options_dict["with_soft_voting"] or options_dict["with_pos_label_str"])):
+                (options_dict["with_soft_voting"] or options_dict["with_pos_label"])):
             continue
 
         yield check_xval_task, learner_type, options_dict

--- a/tests/test_voting_learners_expts_5.py
+++ b/tests/test_voting_learners_expts_5.py
@@ -123,7 +123,7 @@ def check_learning_curve_task(learner_type, options_dict):
         expected_init_kwargs = {"voting": "soft" if options_dict["with_soft_voting"] else "hard",
                                 "custom_learner_path": custom_learner,
                                 "feature_scaling": "none",
-                                "pos_label_str": None,
+                                "pos_label": None,
                                 "min_feature_count": 1,
                                 "model_kwargs_list": model_kwargs_list,
                                 "sampler_list": sampler_list,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -176,7 +176,7 @@ def fill_in_config_options(config_template_path,
                             'suffix'],
                   'Tuning': ['grid_search', 'objective', 'min_feature_count',
                              'use_folds_file_for_grid_search', 'grid_search_folds',
-                             'pos_label_str', 'param_grids', 'objectives',
+                             'pos_label', 'param_grids', 'objectives',
                              'duplicate_option'],
                   'Output': ['results', 'log', 'logs', 'models', 'metrics',
                              'predictions', 'pipeline', 'save_cv_folds',
@@ -362,8 +362,8 @@ def fill_in_config_options_for_voting_learners(learner_type,  # noqa: C901
         custom_learner = join(other_dir, "custom_logistic_wrapper.py")
         values_to_fill_dict["custom_learner_path"] = custom_learner
 
-    if options_dict["with_pos_label_str"]:
-        values_to_fill_dict["pos_label_str"] = "dog"
+    if options_dict["with_pos_label"]:
+        values_to_fill_dict["pos_label"] = "dog"
 
     if options_dict["with_individual_predictions"]:
         values_to_fill_dict["save_votes"] = "true"


### PR DESCRIPTION
This PR closes #569. 

We are only doing part of the issue here (the renaming) but _not_ moving the `pos_label` field into the `Input` section from the `Tuning` section where it currently lives. This is mainly to minimize the amount of changes that someone would need to go through when converting their old code/config files (renaming can be automated). 