### PR TITLE
Use `pathlib.Path` where possible. 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
     rev: 'v0.0.264'
     hooks:
       - id: ruff
-        args: [--line-length=100]
+        args: [--line-length=100, --select, "D,E,F,I", --ignore, "D212", --per-file-ignores, "tests/test*.py:D103"]

--- a/examples/make_california_example_data.py
+++ b/examples/make_california_example_data.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
 
 """
-This is a simple script to download and transform some example data from
+Create data for California regression example.
+
+A script to download and transform some example data from
 sklearn.datasets.
 
+:author: Nitin Madnani (nmadnani@ets.org)
 :author: Michael Heilman (mheilman@ets.org)
 :author: Aoife Cahill (acahill@ets.org)
-:author: Nitin Madnani (nmadnani@ets.org)
 :organization: ETS
 """
 
 import json
-import os
+from pathlib import Path
 
 import numpy as np
 import sklearn.datasets
@@ -20,7 +22,8 @@ from sklearn.model_selection import train_test_split
 
 def main():
     """
-    Download some example data and split it into training and test data.
+    Download example data and split it into training and test data.
+
     The california data set is meant for regression modeling.
     """
     print("Retrieving california data from servers...", end="")
@@ -44,10 +47,10 @@ def main():
 
     print("Writing training and testing files...", end="")
     for examples, suffix in [(examples_train, "train"), (examples_test, "test")]:
-        california_dir = os.path.join("california", suffix)
-        if not os.path.exists(california_dir):
-            os.makedirs(california_dir)
-        jsonlines_path = os.path.join(california_dir, "example_california_features.jsonlines")
+        california_dir = Path("california") / suffix
+        if not california_dir.exists():
+            california_dir.mkdir(parents=True)
+        jsonlines_path = california_dir / "example_california_features.jsonlines"
         with open(jsonlines_path, "w") as f:
             for ex in examples:
                 f.write(f"{json.dumps(ex)}\n")

--- a/examples/make_iris_example_data.py
+++ b/examples/make_iris_example_data.py
@@ -1,25 +1,26 @@
 #!/usr/bin/env python
 
 """
-This is a simple script to download and transform some example data from
+Create data for IRIS classification example.
+
+A script to download and transform some example data from
 sklearn.datasets.
 
 :author: Michael Heilman (mheilman@ets.org)
+:author: Nitin Madnani (nmadnani@ets.org)
 :organization: ETS
 """
 
 import json
-import os
 import sys
+from pathlib import Path
 
 import sklearn.datasets
 from sklearn.model_selection import train_test_split
 
 
 def main():
-    """
-    Download some example data and split it into training and test data.
-    """
+    """Download some example data and split it into training and test data."""
     print("Retrieving iris data from servers...", end="")
     iris_data = sklearn.datasets.load_iris()
     print("done")
@@ -37,10 +38,10 @@ def main():
 
     print("Writing training and testing files...", end="")
     for examples, suffix in [(examples_train, "train"), (examples_test, "test")]:
-        iris_dir = os.path.join("iris", suffix)
-        if not os.path.exists(iris_dir):
-            os.makedirs(iris_dir)
-        jsonlines_path = os.path.join(iris_dir, "example_iris_features.jsonlines")
+        iris_dir = Path("iris") / suffix
+        if not iris_dir.exists():
+            iris_dir.mkdir(parents=True)
+        jsonlines_path = iris_dir / "example_iris_features.jsonlines"
         with open(jsonlines_path, "w") as f:
             for ex in examples:
                 f.write(f"{json.dumps(ex)}\n")

--- a/examples/make_titanic_example_data.py
+++ b/examples/make_titanic_example_data.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 """
-This is a simple script to split the train.csv and test.csv files from the
-Kaggle "Titanic: Machine Learning from Disaster" competition into the format
-titanic.cfg expects.
+Create data for Titanic classification example.
+
+A script to split the train.csv and test.csv files from the
+Kaggle "Titanic: Machine Learning from Disaster" competition
+into the format `titanic.cfg` expects.
 
 :author: Dan Blanchard (dblanchard@ets.org)
 :organization: ETS
 """
 
 import logging
-import os
 from itertools import chain
+from pathlib import Path
 
 from skll.data import Reader, Writer
 
 
 def main():
-    """
-    Create directories and split CSV files into subsets.
-    """
+    """Create directories and split CSV files into subsets."""
     logging.basicConfig(
         format="%(asctime)s - %(name)s - %(levelname)s - " "%(message)s", level=logging.INFO
     )
@@ -34,18 +34,16 @@ def main():
     features_to_keep = list(chain(*subset_dict.values()))
 
     # Create directories to store files
-    if not os.path.exists("titanic/train"):
-        logger.info("Creating titanic/train directory")
-        os.makedirs("titanic/train")
-    if not os.path.exists("titanic/dev"):
-        logger.info("Creating titanic/dev directory")
-        os.makedirs("titanic/dev")
-    if not os.path.exists("titanic/train+dev"):
-        logger.info("Creating titanic/train+dev directory")
-        os.makedirs("titanic/train+dev")
-    if not os.path.exists("titanic/test"):
-        logger.info("Creating titanic/test directory")
-        os.makedirs("titanic/test")
+    root_path = Path("titanic")
+    train_path = root_path / "train"
+    dev_path = root_path / "dev"
+    train_dev_path = root_path / "train+dev"
+    test_path = root_path / "test"
+
+    for path in [train_path, dev_path, train_dev_path, test_path]:
+        if not path.exists():
+            logger.info(f"Creating {path} directory")
+            path.mkdir(parents=True)
 
     usecols_train = features_to_keep + ["PassengerId", "Survived"]
     usecols_test = features_to_keep + ["PassengerId"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+include = '\.pyi?$'
+line-length = 100
+target-version = ['py38']
+
+[tool.ruff]
+select = ["D", "E", "F", "I"]
+ignore = ["D212"]
+line-length = 100
+target-version = "py38"

--- a/skll/experiments/input.py
+++ b/skll/experiments/input.py
@@ -7,7 +7,7 @@ Functions for reading inputs for SKLL experiments.
 :author: Michael Heilman (mheilman@ets.org)
 """
 
-from os.path import isfile, join
+from pathlib import Path
 
 from skll.data.readers import Reader
 
@@ -30,7 +30,7 @@ def load_featureset(
 
     Parameters
     ----------
-    dir_path : str
+    dir_path : Union[str, Path]
         Path to the directory that contains the feature files.
     feat_files : list of str
         A list of feature file prefixes.
@@ -78,9 +78,12 @@ def load_featureset(
         A ``FeatureSet`` instance containing the specified labels, IDs, features,
         and feature vectorizer.
     """
+    # convert to Path object
+    dir_path = Path(dir_path)
+
     # if the training file is specified via train_file, then dir_path
     # actually contains the entire file name
-    if isfile(dir_path):
+    if dir_path.is_file():
         return Reader.for_path(
             dir_path,
             label_col=label_col,
@@ -100,7 +103,7 @@ def load_featureset(
                 "feature file separately."
             )
         merged_set = None
-        for file_name in sorted(join(dir_path, featfile + suffix) for featfile in feat_files):
+        for file_name in sorted(dir_path / f"{featfile}{suffix}" for featfile in feat_files):
             fs = Reader.for_path(
                 file_name,
                 label_col=label_col,

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -105,8 +105,7 @@ __all__ = ["Learner", "MAX_CONCURRENT_PROCESSES", "load_custom_learner"]
 
 class Learner(object):
     """
-    A simpler learner interface around many scikit-learn classification
-    and regression estimators.
+    A simpler interface around scikit-learn classification and regression estimators.
 
     Parameters
     ----------
@@ -184,9 +183,7 @@ class Learner(object):
         custom_learner_path=None,
         logger=None,
     ):
-        """
-        Initializes a learner object with the specified settings.
-        """
+        """Initialize a learner object with the specified settings."""
         super(Learner, self).__init__()
 
         self.feat_vectorizer = None
@@ -373,7 +370,7 @@ class Learner(object):
 
         Parameters
         ----------
-        learner_path : str
+        learner_path : Union[str, Path]
             The path to a saved ``Learner`` instance file.
         logger : logging object, optional
             A logging object. If ``None`` is passed, get logger from ``__name__``.
@@ -393,23 +390,17 @@ class Learner(object):
 
     @property
     def model_type(self):
-        """
-        The model type (i.e., the class)
-        """
+        """Return the model type (i.e., the class)."""
         return self._model_type
 
     @property
     def model_kwargs(self):
-        """
-        A dictionary of the underlying scikit-learn model's keyword arguments
-        """
+        """Return a dictionary of the underlying scikit-learn model's keyword arguments."""
         return self._model_kwargs
 
     @property
     def model(self):
-        """
-        The underlying scikit-learn model
-        """
+        """Return the underlying scikit-learn model."""
         return self._model
 
     def load(self, learner_path):
@@ -426,7 +417,9 @@ class Learner(object):
 
     def _convert_coef_array_to_feature_names(self, coef, feature_name_prefix=""):
         """
-        A helper method used by `model_params` to convert the model
+        Convert model coefficients array to dictionary.
+
+        Method used by `model_params` to convert the model
         coefficients array into a dictionary with feature names as
         keys and the coefficients as values.
 
@@ -474,8 +467,10 @@ class Learner(object):
     @property
     def model_params(self):
         """
-        Model parameters (i.e., weights) for a ``LinearModel`` (e.g., ``Ridge``)
-        regression and liblinear models. If the model was trained using feature
+        Return model parameters (i.e., weights).
+
+        Return the weights for a ``LinearModel`` (e.g., ``Ridge``),
+        regression, and liblinear models. If the model was trained using feature
         hashing, then names of the form `hashed_feature_XX` are used instead.
 
         Returns
@@ -587,16 +582,17 @@ class Learner(object):
     @property
     def probability(self):
         """
-        Should learner return probabilities of all labels (instead of just
-        label with highest probability)?
+        Return the value of the probability flag.
+
+        The flag indicages whether the learner return probabilities of all
+        labels (instead of just label with highest probability)?
         """
         return self._probability
 
     @probability.setter
     def probability(self, value):
         """
-        Set the probabilities flag (i.e. whether learner
-        should return probabilities of all labels).
+        Set the probability flag.
 
         Parameters
         ----------
@@ -615,8 +611,9 @@ class Learner(object):
 
     def __getstate__(self):
         """
-        Return the attributes that should be pickled. We need this
-        because we cannot pickle loggers.
+        Return attributes that should be pickled.
+
+        We need this because we cannot pickle loggers.
         """
         attribute_dict = dict(self.__dict__)
         if "logger" in attribute_dict:
@@ -629,7 +626,7 @@ class Learner(object):
 
         Parameters
         ----------
-        learner_path : str
+        learner_path : Union[str, Path]
             The path to save the ``Learner`` instance to.
         """
         _save_learner_to_disk(self, learner_path)
@@ -682,7 +679,7 @@ class Learner(object):
 
     def _check_input_formatting(self, examples):
         """
-        check that the examples are properly formatted.
+        Check that the examples are properly formatted.
 
         Parameters
         ----------
@@ -721,7 +718,7 @@ class Learner(object):
 
     def _check_max_feature_value(self, feat_array):
         """
-        Check if the the maximum absolute value of any feature is too large
+        Check if the the maximum absolute value of any feature is too large.
 
         Parameters
         ----------
@@ -739,14 +736,13 @@ class Learner(object):
 
     def _create_label_dict(self, examples):
         """
-        Creates a dictionary of labels for classification problems.
+        Create a dictionary of labels for classification problems.
 
         Parameters
         ----------
         examples : skll.FeatureSet
             The examples to use for training.
         """
-
         # we don't need to do this if we have already done it
         # or for regression models, so simply return.
         if self.label_dict is not None or self.model_type._estimator_type == "regressor":
@@ -818,8 +814,9 @@ class Learner(object):
         shuffle=False,
     ):
         """
-        Train the model underlying the learner and return the grid search
-        score and a dictionary of grid search results.
+        Train model underlying the learner.
+
+        Return the grid search score and a dictionary of grid search results.
 
         Parameters
         ----------
@@ -872,7 +869,6 @@ class Learner(object):
         ValueError
             If FeatureHasher is used with MultinomialNB.
         """
-
         # get the estimator type since we need it in multiple places below
         estimator_type = self.model_type._estimator_type
 
@@ -1158,7 +1154,7 @@ class Learner(object):
         self, examples, prediction_prefix=None, append=False, grid_objective=None, output_metrics=[]
     ):
         """
-        Evaluates a given model on a given dev or test ``FeatureSet``.
+        Evaluate the learner on a given dev or test ``FeatureSet``.
 
         Parameters
         ----------
@@ -1255,11 +1251,11 @@ class Learner(object):
         self, examples, prediction_prefix=None, append=False, class_labels=True  # noqa: C901
     ):
         """
-        Uses a given model to return, and optionally, write out predictions
-        on a given ``FeatureSet`` to a file.
+        Generate predictions for the given examples using the learner model.
 
-        For regressors, the returned and written-out predictions are identical.
-        However, for classifiers:
+        Return, and optionally, write out predictions on a given ``FeatureSet``
+        to a file. For regressors, the returned and written-out predictions are
+        identical. However, for classifiers:
 
         - if ``class_labels`` is ``True``, class labels are returned
           as well as written out.
@@ -1495,7 +1491,7 @@ class Learner(object):
         use_custom_folds_for_grid_search=True,
     ):
         """
-        Cross-validates a given model on the training examples.
+        Cross-validate the learner on the given training examples.
 
         Parameters
         ----------
@@ -1591,7 +1587,6 @@ class Learner(object):
         ValueError
             If ``grid_search`` is ``True`` but ``grid_objective`` is ``None``.
         """
-
         # Seed the random number generator so that randomized
         # algorithms are replicable
         random_state = np.random.RandomState(cv_seed)
@@ -1737,7 +1732,9 @@ class Learner(object):
         override_minimum=False,
     ):
         """
-        Generates learning curves for a given model on the training examples
+        Generate learning curves for the learner using the examples.
+
+        The learning curves arge generated on the training examples
         via cross-validation. Adapted from the scikit-learn code for learning
         curve generation (cf.``sklearn.model_selection.learning_curve``).
 
@@ -1788,7 +1785,6 @@ class Learner(object):
         ValueError
             If the number of examples is less than 500.
         """
-
         # check that the number of training examples is more than the minimum
         # needed for generating a reliable learning curve
         if len(examples) < 500:
@@ -1854,90 +1850,90 @@ class Learner(object):
 
 # Rescaled regressors
 @rescaled
-class RescaledBayesianRidge(BayesianRidge):
+class RescaledBayesianRidge(BayesianRidge):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledAdaBoostRegressor(AdaBoostRegressor):
+class RescaledAdaBoostRegressor(AdaBoostRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledDecisionTreeRegressor(DecisionTreeRegressor):
+class RescaledDecisionTreeRegressor(DecisionTreeRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledElasticNet(ElasticNet):
+class RescaledElasticNet(ElasticNet):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledGradientBoostingRegressor(GradientBoostingRegressor):
+class RescaledGradientBoostingRegressor(GradientBoostingRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledHuberRegressor(HuberRegressor):
+class RescaledHuberRegressor(HuberRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledKNeighborsRegressor(KNeighborsRegressor):
+class RescaledKNeighborsRegressor(KNeighborsRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledLars(Lars):
+class RescaledLars(Lars):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledLasso(Lasso):
+class RescaledLasso(Lasso):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledLinearRegression(LinearRegression):
+class RescaledLinearRegression(LinearRegression):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledLinearSVR(LinearSVR):
+class RescaledLinearSVR(LinearSVR):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledMLPRegressor(MLPRegressor):
+class RescaledMLPRegressor(MLPRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledRandomForestRegressor(RandomForestRegressor):
+class RescaledRandomForestRegressor(RandomForestRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledRANSACRegressor(RANSACRegressor):
+class RescaledRANSACRegressor(RANSACRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledRidge(Ridge):
+class RescaledRidge(Ridge):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledSGDRegressor(SGDRegressor):
+class RescaledSGDRegressor(SGDRegressor):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledSVR(SVR):
+class RescaledSVR(SVR):  # noqa: D101
     pass
 
 
 @rescaled
-class RescaledTheilSenRegressor(TheilSenRegressor):
+class RescaledTheilSenRegressor(TheilSenRegressor):  # noqa: D101
     pass

--- a/skll/learner/voting.py
+++ b/skll/learner/voting.py
@@ -54,7 +54,7 @@ class VotingLearner(object):
         probabilities from each of the underlying learnrs. This parameter
         is only relevant for classification.
         Defaults to "hard".
-    custom_learner_path : str, optional
+    custom_learner_path : Union[str, Path], optional
         Path to a Python file containing the definitions of any custom
         learners. Any and all custom learners in ``estimator_names`` must
         be defined in this file. If the custom learner does not inherit
@@ -121,10 +121,7 @@ class VotingLearner(object):
         sampler_kwargs_list=None,
         logger=None,
     ):
-        """
-        Initializes a ``VotingLearner`` object with the specified settings.
-        """
-
+        """Initialize a ``VotingLearner`` object with the specified settings."""
         # initialize various attributes
         self._model = None
         self.voting = voting
@@ -199,37 +196,30 @@ class VotingLearner(object):
 
     @property
     def learners(self):
-        """
-        Return the underlying list of learners
-        """
+        """Return the underlying list of learners."""
         return self._learners
 
     @property
     def model(self):
-        """
-        The underlying scikit-learn meta-estimator model
-        """
+        """Return underlying scikit-learn meta-estimator model."""
         return self._model
 
     @property
     def model_type(self):
-        """
-        The meta-estimator model type (i.e., the class)
-        """
+        """Return meta-estimator model type (i.e., the class)."""
         return self._model_type
 
     def _setup_underlying_learners(self, examples):
-        """
-        Initial, pre-training set up for learners
-        """
+        """Complete pre-training set up for learners."""
         for learner in self.learners:
             learner._create_label_dict(examples)
             learner._train_setup(examples)
 
     def __getstate__(self):
         """
-        Return the attributes that should be dumped. We need this
-        because we do not want to dump loggers.
+        Return attributes that should be pickled.
+
+        We need this because we do not want to dump loggers.
         """
         attribute_dict = dict(self.__dict__)
         if "logger" in attribute_dict:
@@ -405,7 +395,9 @@ class VotingLearner(object):
         individual_predictions=False,
     ):
         """
-        Generate predictions from the meta-estimator and, optionally, the
+        Generate predictions with meta-estimator.
+
+        Compute the predictions from the meta-estimator and, optionally, the
         underlying estimators on given ``FeatureSet``. The predictions are
         also written to disk if ``prediction_prefix`` is not ``None``.
 
@@ -533,7 +525,7 @@ class VotingLearner(object):
         output_metrics=[],
     ):
         """
-        Evaluates the meta-estimator on a given ``FeatureSet``.
+        Evaluate the meta-estimator on a given ``FeatureSet``.
 
         Parameters
         ----------
@@ -567,7 +559,6 @@ class VotingLearner(object):
             PRFs, the model parameters, the grid search objective
             function score, and the additional evaluation metrics, if any.
         """
-
         # make the prediction on the test data; note that these
         # are either class indices or class probabilities
         yhat, _ = self.predict(
@@ -754,7 +745,6 @@ class VotingLearner(object):
         ValueError
             If ``grid_search`` is ``True`` but ``grid_objective`` is ``None``.
         """
-
         # Seed the random number generator so that randomized algorithms are
         # replicable.
         random_state = np.random.RandomState(cv_seed)
@@ -893,7 +883,9 @@ class VotingLearner(object):
         override_minimum=False,
     ):
         """
-        Generates learning curves for the voting meta-estimator on the training
+        Generate learning curves for the meta-estimator.
+
+        Generate learning curves for the voting meta-estimator on the training
         examples via cross-validation. Adapted from the scikit-learn code for
         learning curve generation (cf.``sklearn.model_selection.learning_curve``).
 

--- a/skll/utils/commandline/filter_features.py
+++ b/skll/utils/commandline/filter_features.py
@@ -10,8 +10,8 @@ Filter a given feature file to remove unwanted features, labels, or IDs.
 
 import argparse
 import logging
-import os
 import sys
+from pathlib import Path
 
 from skll.data.readers import EXT_TO_READER, safe_float
 from skll.data.writers import EXT_TO_WRITER, ARFFWriter, CSVWriter, TSVWriter
@@ -20,7 +20,7 @@ from skll.version import __version__
 
 def main(argv=None):
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and gets things started.
 
     Parameters
     ----------
@@ -28,7 +28,6 @@ def main(argv=None):
         List of arguments, as if specified on the command-line.
         If None, ``sys.argv[1:]`` is used instead.
     """
-
     # Get command line arguments
     parser = argparse.ArgumentParser(
         description="Takes an input feature file and removes any instances or"
@@ -124,8 +123,8 @@ def main(argv=None):
     valid_extensions = {ext for ext in EXT_TO_READER if ext != ".libsvm"}
 
     # make sure the input file extension is one we can process
-    input_extension = os.path.splitext(args.infile)[1].lower()
-    output_extension = os.path.splitext(args.outfile)[1].lower()
+    input_extension = Path(args.infile).suffix.lower()
+    output_extension = Path(args.outfile).suffix.lower()
 
     if input_extension == ".libsvm":
         logger.error(

--- a/skll/utils/commandline/generate_predictions.py
+++ b/skll/utils/commandline/generate_predictions.py
@@ -11,8 +11,8 @@ Loads a trained model and outputs predictions based on input feature files.
 
 import argparse
 import logging
-import os
 import sys
+from pathlib import Path
 
 import numpy as np
 
@@ -23,7 +23,7 @@ from skll.version import __version__
 
 def main(argv=None):
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and gets things started.
 
     Parameters
     ----------
@@ -31,7 +31,6 @@ def main(argv=None):
         List of arguments, as if specified on the command-line.
         If None, ``sys.argv[1:]`` is used instead.
     """
-
     # Get command line arguments
     parser = argparse.ArgumentParser(
         description="Loads a trained model and outputs predictions based "
@@ -158,7 +157,7 @@ def main(argv=None):
     # iterate over all the specified input files
     for i, input_file in enumerate(args.input_files):
         # make sure each file extension is one we can process
-        input_extension = os.path.splitext(input_file)[1].lower()
+        input_extension = Path(input_file).suffix.lower()
         if input_extension not in EXT_TO_READER:
             logger.error(
                 f"Input file must be in either .arff, .csv, "

--- a/skll/utils/commandline/join_features.py
+++ b/skll/utils/commandline/join_features.py
@@ -9,8 +9,8 @@ Script that joins a bunch of feature files together to create one file.
 
 import argparse
 import logging
-import os
 import sys
+from pathlib import Path
 
 from skll.data.readers import EXT_TO_READER
 from skll.data.writers import EXT_TO_WRITER, ARFFWriter, CSVWriter, TSVWriter
@@ -19,7 +19,7 @@ from skll.version import __version__
 
 def main(argv=None):
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and gets things started.
 
     Parameters
     ----------
@@ -27,7 +27,6 @@ def main(argv=None):
         List of arguments, as if specified on the command-line.
         If None, ``sys.argv[1:]`` is used instead.
     """
-
     # Get command line arguments
     parser = argparse.ArgumentParser(
         description="Joins multiple input feature files together into one " " file.",
@@ -69,8 +68,8 @@ def main(argv=None):
     valid_extensions = {ext for ext in EXT_TO_READER if ext != ".libsvm"}
 
     # make sure the input file extensions are those we can process
-    input_extension_set = {os.path.splitext(inf)[1].lower() for inf in args.infile}
-    output_extension = os.path.splitext(args.outfile)[1].lower()
+    input_extension_set = {Path(inf).suffix.lower() for inf in args.infile}
+    output_extension = Path(args.outfile).suffix.lower()
 
     # make sure all the files are in the same format except libsvm files
     if len(input_extension_set) > 1:

--- a/skll/utils/commandline/plot_learning_curves.py
+++ b/skll/utils/commandline/plot_learning_curves.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # License: BSD 3 clause
 """
-A Helper script to generate learning plots from the learning curve output TSV
-file.
+Generate learning plots from the learning curve output TSV file.
 
 This is necessary in scenarios where the plots were not generated as part of
 the original learning curve experiment, e.g. the experiment was run on a remote
@@ -19,8 +18,7 @@ then be used to generate the plots later.
 import argparse
 import logging
 import sys
-from os import makedirs
-from os.path import basename, exists
+from pathlib import Path
 
 from skll.experiments import generate_learning_curve_plots
 from skll.version import __version__
@@ -28,7 +26,7 @@ from skll.version import __version__
 
 def main(argv=None):
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and gets things started.
 
     Parameters
     ----------
@@ -36,7 +34,6 @@ def main(argv=None):
         List of arguments, as if specified on the command-line.
         If None, ``sys.argv[1:]`` is used instead.
     """
-
     # Get command line arguments
     parser = argparse.ArgumentParser(
         description="Generates learning curve plots from the learning curve " "TSV file.",
@@ -52,18 +49,22 @@ def main(argv=None):
     logging.captureWarnings(True)
     logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - " "%(message)s")
 
+    # conver to Path objects
+    tsv_file = Path(args.tsv_file)
+    output_dir = Path(args.output_dir)
+
     # make sure that the input TSV file that's being passed exists
-    if not exists(args.tsv_file):
+    if not tsv_file.exists():
         logging.error(f"Error: the given file {args.tsv_file} does not " "exist.")
         sys.exit(1)
 
     # create the output directory if it doesn't already exist
-    if not exists(args.output_dir):
-        makedirs(args.output_dir)
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True)
 
     # get the experiment name from the learning curve TSV file
     # output_file_name = experiment_name + '_summary.tsv'
-    experiment_name = basename(args.tsv_file).rstrip("_summary.tsv")
+    experiment_name = tsv_file.name.rstrip("_summary.tsv")
     logging.info("Generating learning curve(s)")
     generate_learning_curve_plots(experiment_name, args.output_dir, args.tsv_file)
 

--- a/skll/utils/commandline/skll_convert.py
+++ b/skll/utils/commandline/skll_convert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # License: BSD 3 clause
 """
-Script that converts feature files from one format to another
+Script that converts feature files from one format to another.
 
 :author: Nitin Madnani (nmadnani@ets.org)
 :organization: ETS
@@ -9,8 +9,8 @@ Script that converts feature files from one format to another
 
 import argparse
 import logging
-import os
 import sys
+from pathlib import Path
 
 from bs4 import UnicodeDammit
 
@@ -27,10 +27,7 @@ from skll.version import __version__
 
 
 def _pair_to_dict_tuple(pair):
-    """
-    A helper function for constructing mappings from feature/class names to
-    numbers.
-    """
+    """Consturct mappings from feature/class names to numbers."""
     number, name = pair.split("=")
     number = int(number)
     return (name, number)
@@ -38,7 +35,7 @@ def _pair_to_dict_tuple(pair):
 
 def main(argv=None):
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and gets things started.
 
     Parameters
     ----------
@@ -46,7 +43,6 @@ def main(argv=None):
         List of arguments, as if specified on the command-line.
         If None, ``sys.argv[1:]`` is used instead.
     """
-
     # Get command line arguments
     parser = argparse.ArgumentParser(
         description="Takes an input feature file and converts it to another "
@@ -113,8 +109,8 @@ def main(argv=None):
     logger = logging.getLogger(__name__)
 
     # make sure the input file extension is one we can process
-    input_extension = os.path.splitext(args.infile)[1].lower()
-    output_extension = os.path.splitext(args.outfile)[1].lower()
+    input_extension = Path(args.infile).suffix.lower()
+    output_extension = Path(args.outfile).suffix.lower()
 
     if input_extension not in EXT_TO_READER:
         logger.error(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,10 +1,11 @@
-from os.path import abspath, dirname, join
+"""Define basic paths needed for testing."""
+from pathlib import Path
 
-_my_dir = abspath(dirname(__file__))
-config_dir = join(_my_dir, "configs")
-backward_compatibility_dir = join(_my_dir, "backward_compatibility")
-examples_dir = join(dirname(_my_dir), "examples")
-output_dir = join(_my_dir, "output")
-other_dir = join(_my_dir, "other")
-train_dir = join(_my_dir, "train")
-test_dir = join(_my_dir, "test")
+_my_dir = Path(__file__).resolve().parent
+config_dir = _my_dir / "configs"
+backward_compatibility_dir = _my_dir / "backward_compatibility"
+examples_dir = _my_dir.parent / "examples"
+output_dir = _my_dir / "output"
+other_dir = _my_dir / "other"
+train_dir = _my_dir / "train"
+test_dir = _my_dir / "test"

--- a/tests/test_custom_learner.py
+++ b/tests/test_custom_learner.py
@@ -9,9 +9,7 @@ Module for running tests with custom learners.
 """
 
 import csv
-from glob import glob
-from os.path import join
-from pathlib import Path
+from itertools import chain
 
 import numpy as np
 from nose.tools import raises
@@ -20,26 +18,18 @@ from numpy.testing import assert_array_equal
 from skll.data import NDJWriter
 from skll.experiments import run_configuration
 from skll.learner import Learner
-from skll.utils.constants import KNOWN_DEFAULT_PARAM_GRIDS
 from tests import config_dir, other_dir, output_dir, test_dir, train_dir
 from tests.utils import fill_in_config_paths, make_classification_data, unlink
 
-_ALL_MODELS = list(KNOWN_DEFAULT_PARAM_GRIDS.keys())
-
 
 def setup():
-    """
-    Create necessary directories for testing.
-    """
+    """Create necessary directories for testing."""
     for dir_path in [train_dir, test_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def tearDown():
-    """
-    Clean up after tests.
-    """
-
+    """Clean up after tests."""
     input_files = [
         "test_logistic_custom_learner.jsonlines",
         "test_majority_class_custom_learner.jsonlines",
@@ -47,23 +37,21 @@ def tearDown():
     ]
     for inf in input_files:
         for dir_path in [train_dir, test_dir]:
-            unlink(Path(dir_path) / inf)
+            unlink(dir_path / inf)
 
-    for cfg_file in glob(join(config_dir, "*custom_learner.cfg")):
+    for cfg_file in config_dir.glob("*custom_learner.cfg"):
         unlink(cfg_file)
 
-    for output_file in (
-        glob(join(output_dir, "test_logistic_custom_learner*"))
-        + glob(join(output_dir, "test_majority_class_custom_learner*"))
-        + glob(join(output_dir, "test_model_custom_learner*"))
+    for output_file in chain(
+        output_dir.glob("test_logistic_custom_learner*"),
+        output_dir.glob("test_majority_class_custom_learner*"),
+        output_dir.glob("test_model_custom_learner*"),
     ):
         unlink(output_file)
 
 
 def read_predictions(path):
-    """
-    Read in prediction file as a numpy array.
-    """
+    """Read in prediction file as a numpy array."""
     with open(path) as f:
         reader = csv.reader(f, dialect="excel-tab")
         next(reader)
@@ -75,7 +63,7 @@ def test_majority_class_custom_learner():
     num_labels = 10
 
     # This will make data where the last class happens about 50% of the time.
-    class_weights = [(0.5 / (num_labels - 1)) for x in range(num_labels - 1)] + [0.5]
+    class_weights = [(0.5 / (num_labels - 1)) for _ in range(num_labels - 1)] + [0.5]
     train_fs, test_fs = make_classification_data(
         num_examples=600,
         train_test_ratio=0.8,
@@ -86,27 +74,27 @@ def test_majority_class_custom_learner():
     )
 
     # Write training feature set to a file
-    train_path = join(train_dir, "test_majority_class_custom_learner.jsonlines")
+    train_path = train_dir / "test_majority_class_custom_learner.jsonlines"
     writer = NDJWriter(train_path, train_fs)
     writer.write()
 
     # Write test feature set to a file
-    test_path = join(test_dir, "test_majority_class_custom_learner.jsonlines")
+    test_path = test_dir / "test_majority_class_custom_learner.jsonlines"
     writer = NDJWriter(test_path, test_fs)
     writer.write()
 
     cfgfile = "test_majority_class_custom_learner.template.cfg"
-    config_template_path = join(config_dir, cfgfile)
+    config_template_path = config_dir / cfgfile
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, local=True)
 
     outprefix = "test_majority_class_custom_learner"
 
-    preds = read_predictions(
-        join(output_dir, f"{outprefix}_{outprefix}_MajorityClassLearner_predictions.tsv")
-    )
-    expected = np.array([float(num_labels - 1) for x in preds])
+    prediction_path = output_dir / f"{outprefix}_{outprefix}_MajorityClassLearner_predictions.tsv"
+    preds = read_predictions(prediction_path)
+
+    expected = np.array([float(num_labels - 1) for _ in preds])
     assert_array_equal(preds, expected)
 
 
@@ -124,34 +112,33 @@ def test_logistic_custom_learner():
     )
 
     # Write training feature set to a file
-    train_path = join(train_dir, "test_logistic_custom_learner.jsonlines")
+    train_path = train_dir / "test_logistic_custom_learner.jsonlines"
     writer = NDJWriter(train_path, train_fs)
     writer.write()
 
     # Write test feature set to a file
-    test_path = join(test_dir, "test_logistic_custom_learner.jsonlines")
+    test_path = test_dir / "test_logistic_custom_learner.jsonlines"
     writer = NDJWriter(test_path, test_fs)
     writer.write()
 
     cfgfile = "test_logistic_custom_learner.template.cfg"
-    config_template_path = join(config_dir, cfgfile)
+    config_template_path = config_dir / cfgfile
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, local=True)
 
     outprefix = "test_logistic_custom_learner"
-    preds = read_predictions(
-        join(
-            output_dir,
-            f"{outprefix}_{outprefix}_CustomLogisticRegressionWrapper_" "predictions.tsv",
-        )
+    computed_predictions_path = (
+        output_dir / f"{outprefix}_{outprefix}_CustomLogisticRegressionWrapper_predictions.tsv"
     )
+    computed_preds = read_predictions(computed_predictions_path)
 
-    expected = read_predictions(
-        join(output_dir, f"{outprefix}_{outprefix}_LogisticRegression_predictions.tsv")
+    expected_predictions_path = (
+        output_dir / f"{outprefix}_{outprefix}_LogisticRegression_predictions.tsv"
     )
+    expected_preds = read_predictions(expected_predictions_path)
 
-    assert_array_equal(preds, expected)
+    assert_array_equal(computed_preds, expected_preds)
 
 
 def test_custom_learner_model_loading():
@@ -168,18 +155,18 @@ def test_custom_learner_model_loading():
     )
 
     # Write training feature set to a file
-    train_path = join(train_dir, "test_model_custom_learner.jsonlines")
+    train_path = train_dir / "test_model_custom_learner.jsonlines"
     writer = NDJWriter(train_path, train_fs)
     writer.write()
 
     # Write test feature set to a file
-    test_path = join(test_dir, "test_model_custom_learner.jsonlines")
+    test_path = test_dir / "test_model_custom_learner.jsonlines"
     writer = NDJWriter(test_path, test_fs)
     writer.write()
 
     # run the configuration that trains the custom model and saves it
     cfgfile = "test_model_save_custom_learner.template.cfg"
-    config_template_path = join(config_dir, cfgfile)
+    config_template_path = config_dir / cfgfile
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, local=True)
@@ -187,8 +174,8 @@ def test_custom_learner_model_loading():
     # save the predictions from disk into memory
     # and delete the predictions file
     outprefix = "test_model_custom_learner"
-    pred_file = join(
-        output_dir, f"{outprefix}_{outprefix}_CustomLogisticRegressionWrapper_predictions.tsv"
+    pred_file = (
+        output_dir / f"{outprefix}_{outprefix}_CustomLogisticRegressionWrapper_predictions.tsv"
     )
     preds1 = read_predictions(pred_file)
     unlink(pred_file)
@@ -196,7 +183,7 @@ def test_custom_learner_model_loading():
     # run the configuration that loads the saved model
     # and generates the predictions again
     cfgfile = "test_model_load_custom_learner.template.cfg"
-    config_template_path = join(config_dir, cfgfile)
+    config_template_path = config_dir / cfgfile
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, overwrite=False, quiet=True, local=True)
@@ -217,5 +204,5 @@ def test_custom_learner_api_missing_file():
 def test_custom_learner_api_bad_extension():
     _ = Learner(
         "_CustomLogisticRegressionWrapper",
-        custom_learner_path=join(other_dir, "custom_learner.txt"),
+        custom_learner_path=str(other_dir / "custom_learner.txt"),
     )

--- a/tests/test_custom_metrics.py
+++ b/tests/test_custom_metrics.py
@@ -7,8 +7,7 @@ Module containing tests for custom metrics.
 
 import json
 import sys
-from glob import glob
-from os.path import join
+from itertools import chain
 
 import numpy as np
 from nose.tools import assert_almost_equal, eq_, ok_, raises, with_setup
@@ -34,36 +33,29 @@ from tests.utils import (
 
 
 def setup_func():
-    """
-    Run before each test function.
-    """
+    """Run before each test function."""
     # clean up any already registered metrics to simulate
     # as if we are starting a new Python session
     _cleanup_custom_metrics()
 
 
 def tearDown():
-    """
-    Clean up after all tests are run.
-    """
-
-    for glob_pattern in [
-        join(config_dir, "*custom_metrics.cfg"),
-        join(config_dir, "*custom_metrics_kappa.cfg"),
-        join(config_dir, "*custom_metrics_bad.cfg"),
-        join(config_dir, "*custom_metrics_kwargs1.cfg"),
-        join(config_dir, "*custom_metrics_kwargs2.cfg"),
-        join(config_dir, "*custom_metrics_kwargs3.cfg"),
-        join(config_dir, "*custom_metrics_kwargs4.cfg"),
-        join(output_dir, "test_custom_metrics*"),
-    ]:
-        for f in glob(glob_pattern):
-            unlink(f)
+    """Clean up after all tests are run."""
+    for filepath in chain(
+        config_dir.glob("*custom_metrics.cfg"),
+        config_dir.glob("*custom_metrics_kappa.cfg"),
+        config_dir.glob("*custom_metrics_bad.cfg"),
+        config_dir.glob("*custom_metrics_kwargs1.cfg"),
+        config_dir.glob("*custom_metrics_kwargs2.cfg"),
+        config_dir.glob("*custom_metrics_kwargs3.cfg"),
+        config_dir.glob("*custom_metrics_kwargs4.cfg"),
+        output_dir.glob("test_custom_metrics*"),
+    ):
+        unlink(filepath)
 
 
 def _cleanup_custom_metrics():
-    """A helper function to clean up any custom metrics"""
-
+    """Clean up any custom metrics."""
     for metric_name in [
         "f06_micro",
         "f075_macro",
@@ -110,10 +102,9 @@ def _cleanup_custom_metrics():
 
 @with_setup(setup_func)
 def test_register_custom_metric_load_one():
-    """Test loading a single custom metric"""
-
+    """Test loading a single custom metric."""
     # load a single metric from a custom metric file
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "f075_macro")
 
     # make sure that this metric is now registered with SKLL
@@ -128,10 +119,9 @@ def test_register_custom_metric_load_one():
 
 @with_setup(setup_func)
 def test_register_custom_metric_load_both():
-    """Test loading two custom metrics from one file"""
-
+    """Test loading two custom metrics from one file."""
     # load both metrics in the custom file
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "f075_macro")
     register_custom_metric(custom_metrics_file, "ratio_of_ones")
 
@@ -144,11 +134,10 @@ def test_register_custom_metric_load_both():
 
 @with_setup(setup_func)
 def test_register_custom_metric_load_different_files():
-    """Test loading two custom metrics from two files"""
-
+    """Test loading two custom metrics from two files."""
     # load two custom metrics from two different files
-    custom_metrics_file1 = join(other_dir, "custom_metrics.py")
-    custom_metrics_file2 = join(other_dir, "custom_metrics2.py")
+    custom_metrics_file1 = other_dir / "custom_metrics.py"
+    custom_metrics_file2 = other_dir / "custom_metrics2.py"
     register_custom_metric(custom_metrics_file1, "f075_macro")
     register_custom_metric(custom_metrics_file2, "f06_micro")
 
@@ -162,10 +151,9 @@ def test_register_custom_metric_load_different_files():
 @with_setup(setup_func)
 @raises(NameError)
 def test_reregister_same_metric_same_session():
-    """Test loading custom metric again in same session"""
-
+    """Test loading custom metric again in same session."""
     # try to load a metric from a txt file, not a py file
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "f075_macro")
 
     # re-registering should raise an error
@@ -174,10 +162,9 @@ def test_reregister_same_metric_same_session():
 
 @with_setup(setup_func)
 def test_reregister_same_metric_different_session():
-    """Test loading custom metric again in different session"""
-
+    """Test loading custom metric again in different session."""
     # try to load a metric from a txt file, not a py file
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "f075_macro")
 
     # clean up any already registered metrics to simulate
@@ -191,18 +178,16 @@ def test_reregister_same_metric_different_session():
 @with_setup(setup_func)
 @raises(ValueError)
 def test_register_custom_metric_bad_extension():
-    """Test loading custom metric from non-py file"""
-
+    """Test loading custom metric from non-py file."""
     # try to load a metric from a txt file, not a py file
-    bad_custom_metrics_file = join(other_dir, "custom_metrics.txt")
+    bad_custom_metrics_file = other_dir / "custom_metrics.txt"
     register_custom_metric(bad_custom_metrics_file, "f075_macro")
 
 
 @with_setup(setup_func)
 @raises(ValueError)
 def test_register_custom_metric_missing_name():
-    """Test loading custom metric from empty string"""
-
+    """Test loading custom metric from empty string."""
     # try to load a metric from a missing file name
     # which can happen via a bad configuration file
     register_custom_metric("", "f075_macro")
@@ -211,39 +196,35 @@ def test_register_custom_metric_missing_name():
 @with_setup(setup_func)
 @raises(ValueError)
 def test_register_custom_metric_missing_file():
-    """Test loading custom metric from missing file"""
-
+    """Test loading custom metric from missing file."""
     # try to load a metric from a py file that does not exist
-    missing_custom_metrics_file = join(other_dir, "missing_metrics.py")
+    missing_custom_metrics_file = other_dir / "missing_metrics.py"
     register_custom_metric(missing_custom_metrics_file, "f075_macro")
 
 
 @with_setup(setup_func)
 @raises(AttributeError)
 def test_register_custom_metric_wrong_name():
-    """Test loading custom metric with wrong name"""
-
+    """Test loading custom metric with wrong name."""
     # try to load a metric that does not exist in a file
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "blah")
 
 
 @with_setup(setup_func)
 @raises(NameError)
 def test_register_custom_metric_conflicting_metric_name():
-    """Test loading custom metric with conflicting name"""
-
+    """Test loading custom metric with conflicting name."""
     # try to load a metric that does not exist in a file
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "r2")
 
 
 @with_setup(setup_func)
 def test_register_custom_metric_values():
-    """Test to check values of custom metrics"""
-
+    """Test to check values of custom metrics."""
     # register two metrics in the same file
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "f075_macro")
     register_custom_metric(custom_metrics_file, "ratio_of_ones")
 
@@ -265,17 +246,16 @@ def test_register_custom_metric_values():
 
 @with_setup(setup_func)
 def test_custom_metric_api_experiment():
-    """Test API with custom metrics"""
-
+    """Test API with custom metrics."""
     # register two different metrics from two files
-    custom_metrics_file1 = join(other_dir, "custom_metrics.py")
+    custom_metrics_file1 = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file1, "f075_macro")
-    custom_metrics_file2 = join(other_dir, "custom_metrics2.py")
+    custom_metrics_file2 = other_dir / "custom_metrics2.py"
     register_custom_metric(custom_metrics_file2, "f06_micro")
 
     # read in some train/test data
-    train_file = join(other_dir, "examples_train.jsonlines")
-    test_file = join(other_dir, "examples_test.jsonlines")
+    train_file = other_dir / "examples_train.jsonlines"
+    test_file = other_dir / "examples_test.jsonlines"
 
     train_fs = NDJReader.for_path(train_file).read()
     test_fs = NDJReader.for_path(test_file).read()
@@ -300,13 +280,12 @@ def test_custom_metric_api_experiment():
 
 @with_setup(setup_func)
 def test_custom_metric_config_experiment():
-    """Test config with custom metrics"""
-
+    """Test config with custom metrics."""
     # Run experiment
-    train_file = join(other_dir, "examples_train.jsonlines")
-    test_file = join(other_dir, "examples_test.jsonlines")
+    train_file = other_dir / "examples_train.jsonlines"
+    test_file = other_dir / "examples_test.jsonlines"
     config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_custom_metrics.template.cfg"), train_file, test_file
+        config_dir / "test_custom_metrics.template.cfg", train_file, test_file
     )
     run_configuration(config_path, local=True, quiet=True)
 
@@ -314,11 +293,8 @@ def test_custom_metric_config_experiment():
 
     # objective function f075_macro
     with open(
-        join(
-            output_dir,
-            "test_custom_metrics_train_examples_train.jsonlines_test_"
-            "examples_test.jsonlines_LogisticRegression.results.json",
-        )
+        output_dir / "test_custom_metrics_train_examples_train.jsonlines_test_examples_"
+        "test.jsonlines_LogisticRegression.results.json"
     ) as f:
         result_dict = json.load(f)[0]
 
@@ -335,16 +311,15 @@ def test_custom_metric_config_experiment():
 
 @with_setup(setup_func)
 def test_custom_metric_api_experiment_with_kappa_filename():
-    """Test API with metric defined in a file named kappa"""
-
+    """Test API with metric defined in a file named kappa."""
     # register a dummy metric that just returns 1 from
     # a file called 'kappa.py'
-    custom_metrics_file = join(other_dir, "kappa.py")
+    custom_metrics_file = other_dir / "kappa.py"
     register_custom_metric(custom_metrics_file, "dummy_metric")
 
     # read in some train/test data
-    train_file = join(other_dir, "examples_train.jsonlines")
-    test_file = join(other_dir, "examples_test.jsonlines")
+    train_file = other_dir / "examples_train.jsonlines"
+    test_file = other_dir / "examples_test.jsonlines"
 
     train_fs = NDJReader.for_path(train_file).read()
     test_fs = NDJReader.for_path(test_file).read()
@@ -373,13 +348,12 @@ def test_custom_metric_api_experiment_with_kappa_filename():
 
 @with_setup(setup_func)
 def test_custom_metric_config_experiment_with_kappa_filename():
-    """Test config with metric defined in a file named kappa"""
-
+    """Test config with metric defined in a file named kappa."""
     # Run experiment
-    train_file = join(other_dir, "examples_train.jsonlines")
-    test_file = join(other_dir, "examples_test.jsonlines")
+    train_file = other_dir / "examples_train.jsonlines"
+    test_file = other_dir / "examples_test.jsonlines"
     config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_custom_metrics_kappa.template.cfg"), train_file, test_file
+        config_dir / "test_custom_metrics_kappa.template.cfg", train_file, test_file
     )
     run_configuration(config_path, local=True, quiet=True)
 
@@ -387,12 +361,8 @@ def test_custom_metric_config_experiment_with_kappa_filename():
 
     # objective function f075_macro
     with open(
-        join(
-            output_dir,
-            "test_custom_metrics_kappa_train_examples_train.jsonlines"
-            "_test_examples_test.jsonlines_LogisticRegression.results"
-            ".json",
-        )
+        output_dir / "test_custom_metrics_kappa_train_examples_train.jsonlines"
+        "_test_examples_test.jsonlines_LogisticRegression.results.json"
     ) as f:
         result_dict = json.load(f)[0]
 
@@ -409,13 +379,12 @@ def test_custom_metric_config_experiment_with_kappa_filename():
 
 @with_setup(setup_func)
 def test_custom_metric_config_with_invalid_custom_metric():
-    """Test config with a valid and an invalid custom metric"""
-
+    """Test config with a valid and an invalid custom metric."""
     # Run experiment
-    train_file = join(other_dir, "examples_train.jsonlines")
-    test_file = join(other_dir, "examples_test.jsonlines")
+    train_file = other_dir / "examples_train.jsonlines"
+    test_file = other_dir / "examples_test.jsonlines"
     config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_custom_metrics_bad.template.cfg"), train_file, test_file
+        config_dir / "test_custom_metrics_bad.template.cfg", train_file, test_file
     )
     # since this configuration file consists of an invalid
     # metric, this should raise an error
@@ -431,11 +400,10 @@ def test_custom_metric_config_with_invalid_custom_metric():
 
 @with_setup(setup_func)
 def test_api_with_inverted_custom_metric():
-    """Test API with a lower-is-better custom metric"""
-
+    """Test API with a lower-is-better custom metric."""
     # register a lower-is-better custom metrics from our file
     # which is simply 1 minus the precision score
-    custom_metrics_file1 = join(other_dir, "custom_metrics.py")
+    custom_metrics_file1 = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file1, "one_minus_precision")
 
     # create some classification data
@@ -473,24 +441,20 @@ def test_api_with_inverted_custom_metric():
 
 @with_setup(setup_func)
 def test_config_with_inverted_custom_metric():
-    """Test config with a lower-is-better custom metric"""
-
+    """Test config with a lower-is-better custom metric."""
     # run the first experiment that uses a lower-is-better custom metric
     # for grid saerch defined as simply 1 minus the macro-averaged F1 score
-    train_file = join(other_dir, "examples_train.jsonlines")
-    test_file = join(other_dir, "examples_test.jsonlines")
+    train_file = other_dir / "examples_train.jsonlines"
+    test_file = other_dir / "examples_test.jsonlines"
     config_path1 = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_custom_metrics_kwargs1.template.cfg"), train_file, test_file
+        config_dir / "test_custom_metrics_kwargs1.template.cfg", train_file, test_file
     )
     run_configuration(config_path1, local=True, quiet=True)
 
     # laod the results
     with open(
-        join(
-            output_dir,
-            "test_custom_metrics_kwargs1_train_examples_train.jsonlines"
-            "_LogisticRegression.results.json",
-        )
+        output_dir / "test_custom_metrics_kwargs1_train_examples_"
+        "train.jsonlines_LogisticRegression.results.json"
     ) as f:
         result_dict1 = json.load(f)
         grid_score1 = result_dict1["grid_score"]
@@ -499,17 +463,14 @@ def test_config_with_inverted_custom_metric():
     # now run the second experiment that is identical except that
     # that it uses the regular macro-averaged F1 score for grid search
     config_path2 = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_custom_metrics_kwargs2.template.cfg"), train_file, test_file
+        config_dir / "test_custom_metrics_kwargs2.template.cfg", train_file, test_file
     )
     run_configuration(config_path2, local=True, quiet=True)
 
     # laod the results
     with open(
-        join(
-            output_dir,
-            "test_custom_metrics_kwargs2_train_examples_train.jsonlines"
-            "_LogisticRegression.results.json",
-        )
+        output_dir / "test_custom_metrics_kwargs2_train_examples_"
+        "train.jsonlines_LogisticRegression.results.json"
     ) as f:
         result_dict2 = json.load(f)
         grid_score2 = result_dict2["grid_score"]
@@ -534,10 +495,9 @@ def test_config_with_inverted_custom_metric():
 
 @with_setup(setup_func)
 def test_api_with_custom_prob_metric():
-    """Test API with custom probabilistic metric"""
-
+    """Test API with custom probabilistic metric."""
     # register a custom metric from our file that requires probabilities
-    custom_metrics_file = join(other_dir, "custom_metrics.py")
+    custom_metrics_file = other_dir / "custom_metrics.py"
     register_custom_metric(custom_metrics_file, "fake_prob_metric")
 
     # create some classification data
@@ -564,14 +524,13 @@ def test_api_with_custom_prob_metric():
 
 @with_setup(setup_func)
 def test_config_with_custom_prob_metric():
-    """Test config with custom probabilistic metric"""
-
+    """Test config with custom probabilistic metric."""
     # run the first experiment that uses a custom probabilistic metric
     # for grid search but with a learner that does not produce probabilities
-    train_file = join(other_dir, "examples_train.jsonlines")
-    test_file = join(other_dir, "examples_test.jsonlines")
+    train_file = other_dir / "examples_train.jsonlines"
+    test_file = other_dir / "examples_test.jsonlines"
     config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_custom_metrics_kwargs3.template.cfg"), train_file, test_file
+        config_dir / "test_custom_metrics_kwargs3.template.cfg", train_file, test_file
     )
 
     # this should fail as expected
@@ -587,17 +546,15 @@ def test_config_with_custom_prob_metric():
     # now run the second experiment that is identical except that
     # the learner now produces probabilities
     config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_custom_metrics_kwargs4.template.cfg"), train_file, test_file
+        config_dir / "test_custom_metrics_kwargs4.template.cfg", train_file, test_file
     )
     # this should succeed and produce results
     run_configuration(config_path, local=True, quiet=True)
 
     # laod the results and verify them
     with open(
-        join(
-            output_dir,
-            "test_custom_metrics_kwargs4_train_examples_train.jsonlines" "_SVC.results.json",
-        )
+        output_dir / "test_custom_metrics_kwargs4_train_examples_"
+        "train.jsonlines_SVC.results.json"
     ) as f:
         result_dict = json.load(f)
         grid_score = result_dict["grid_score"]

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -1,7 +1,6 @@
 # License: BSD 3 clause
 """
-Module for running a bunch of simple unit tests. Should be expanded more in
-the future.
+Run cross-validation tests.
 
 :author: Michael Heilman (mheilman@ets.org)
 :author: Nitin Madnani (nmadnani@ets.org)
@@ -13,9 +12,6 @@ import csv
 import itertools
 import json
 import re
-from glob import glob
-from os.path import exists, join
-from pathlib import Path
 
 import numpy as np
 from nose.tools import assert_greater, assert_less, eq_, raises
@@ -27,7 +23,6 @@ from skll.config import load_cv_folds
 from skll.data import FeatureSet
 from skll.experiments import load_featureset, run_configuration
 from skll.learner import Learner
-from skll.utils.constants import KNOWN_DEFAULT_PARAM_GRIDS
 from tests import config_dir, other_dir, output_dir, train_dir
 from tests.utils import (
     compute_expected_folds_for_cv_testing,
@@ -37,44 +32,39 @@ from tests.utils import (
     unlink,
 )
 
-_ALL_MODELS = list(KNOWN_DEFAULT_PARAM_GRIDS.keys())
-
 
 def setup():
-    """
-    Create necessary directories for testing.
-    """
+    """Create necessary directories for testing."""
     for dir_path in [train_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
     # create jsonlines feature files
     create_jsonlines_feature_files(train_dir)
 
 
 def tearDown():
-    """
-    Clean up after tests.
-    """
-    fold_file_path = join(other_dir, "custom_folds.csv")
+    """Clean up after tests."""
+    fold_file_path = other_dir / "custom_folds.csv"
     unlink(fold_file_path)
 
+    config_dir_obj = config_dir
     cfg_files = [
-        join(config_dir, "test_save_cv_folds.cfg"),
-        join(config_dir, "test_save_cv_models.cfg"),
-        join(config_dir, "test_custom_cv_seed_classifier.cfg"),
-        join(config_dir, "test_custom_cv_seed_regressor.cfg"),
-        join(config_dir, "test_folds_file.cfg"),
-        join(config_dir, "test_folds_file_grid.cfg"),
+        config_dir_obj / "test_save_cv_folds.cfg",
+        config_dir_obj / "test_save_cv_models.cfg",
+        config_dir_obj / "test_custom_cv_seed_classifier.cfg",
+        config_dir_obj / "test_custom_cv_seed_regressor.cfg",
+        config_dir_obj / "test_folds_file.cfg",
+        config_dir_obj / "test_folds_file_grid.cfg",
     ]
     for cfg_file in cfg_files:
         unlink(cfg_file)
 
-    for output_file in (
-        glob(join(output_dir, "test_save_cv_folds*"))
-        + glob(join(output_dir, "test_int_labels_cv_*"))
-        + glob(join(output_dir, "test_save_cv_models*"))
-        + glob(join(output_dir, "test_custom_cv_seed*"))
-        + glob(join(output_dir, "test_folds_file*"))
+    for output_file in itertools.chain(
+        output_dir.glob("test_save_cv_folds*"),
+        output_dir.glob("test_int_labels_cv_*"),
+        output_dir.glob("test_save_cv_models*"),
+        output_dir.glob("test_custom_cv_seed*"),
+        output_dir.glob("test_folds_file*"),
     ):
         unlink(output_file)
 
@@ -82,11 +72,7 @@ def tearDown():
 
 
 def make_cv_folds_data(num_examples_per_fold=100, num_folds=3, use_feature_hashing=False):
-    """
-    Create data for pre-specified CV folds tests
-    with or without feature hashing
-    """
-
+    """Create data for pre-specified CV folds tests with or without feature hashing."""
     num_total_examples = num_examples_per_fold * num_folds
 
     # create the numeric features and the binary labels
@@ -136,9 +122,7 @@ def make_cv_folds_data(num_examples_per_fold=100, num_folds=3, use_feature_hashi
 
 
 def test_specified_cv_folds():
-    """
-    Test to check cross-validation results with specified folds, feature hashing, and RBFSampler
-    """
+    """Check cross-validation results with specified folds, feature hashing, and RBFSampler."""
     # This runs four tests.
 
     # The first does not use feature hashing with 9 features (3 numeric, 6
@@ -182,15 +166,12 @@ def test_specified_cv_folds():
 
 
 def test_load_cv_folds():
-    """
-    Test to check that cross-validation folds are correctly loaded from a CSV file
-    """
-
+    """Test to check that cross-validation folds are correctly loaded from a CSV file."""
     # create custom CV folds
     custom_cv_folds = make_cv_folds_data()[1]
 
     # write the generated CV folds to a CSV file
-    fold_file_path = join(other_dir, "custom_folds.csv")
+    fold_file_path = other_dir / "custom_folds.csv"
     with open(fold_file_path, "w", newline="") as foldf:
         w = csv.writer(foldf)
         w.writerow(["id", "fold"])
@@ -205,15 +186,12 @@ def test_load_cv_folds():
 
 @raises(ValueError)
 def test_load_cv_folds_non_float_ids():
-    """
-    Test to check that CV folds with non-float IDs raise error when converted to floats
-    """
-
+    """Test to check that CV folds with non-float IDs raise error when converted to floats."""
     # create custom CV folds
     custom_cv_folds = make_cv_folds_data()[1]
 
     # write the generated CV folds to a CSV file
-    fold_file_path = join(other_dir, "custom_folds.csv")
+    fold_file_path = other_dir / "custom_folds.csv"
     with open(fold_file_path, "w", newline="") as foldf:
         w = csv.writer(foldf)
         w.writerow(["id", "fold"])
@@ -225,10 +203,7 @@ def test_load_cv_folds_non_float_ids():
 
 
 def test_retrieve_cv_folds():
-    """
-    Test to make sure that the fold ids get returned correctly after cross-validation
-    """
-
+    """Test to make sure that the fold ids get returned correctly after cross-validation."""
     # Setup
     learner = Learner("LogisticRegression")
     num_folds = 5
@@ -289,20 +264,17 @@ def test_retrieve_cv_folds():
 
 
 def test_folds_file_logging_num_folds():
-    """
-    Test when using `folds_file`, log shows number of folds and appropriate warning.
-    """
+    """Test when using `folds_file`, log shows number of folds and appropriate warning."""
     # Run experiment
     suffix = ".jsonlines"
-    train_path = join(train_dir, f"f0{suffix}")
+    train_path = train_dir / f"f0{suffix}"
 
-    config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_folds_file.template.cfg"), train_path, None
-    )
+    template_path = config_dir / "test_folds_file.template.cfg"
+    config_path = fill_in_config_paths_for_single_file(template_path, train_path, None)
     run_configuration(config_path, quiet=True, local=True)
 
     # Check experiment log output
-    with open(join(output_dir, "test_folds_file_logging.log")) as f:
+    with open(output_dir / "test_folds_file_logging.log") as f:
         cv_file_pattern = re.compile(
             r'Specifying "folds_file" overrides both explicit and default ' r'"num_cv_folds".'
         )
@@ -311,7 +283,7 @@ def test_folds_file_logging_num_folds():
 
     # Check job log output
     with open(
-        join(output_dir, "test_folds_file_logging_train_f0." "jsonlines_LogisticRegression.log")
+        output_dir / "test_folds_file_logging_train_f0." "jsonlines_LogisticRegression.log"
     ) as f:
         cv_folds_pattern = re.compile(
             r"(Task: cross_validate\n)(.+)(Cross-validating \([0-9]+ folds, seed=[0-9]+\))"
@@ -321,21 +293,18 @@ def test_folds_file_logging_num_folds():
 
 
 def test_folds_file_with_fewer_ids_than_featureset():
-    """
-    Test when using `folds_file`, log shows warning for extra IDs in featureset.
-    """
+    """Test when using `folds_file`, log shows warning for extra IDs in featureset."""
     # Run experiment with a special featureset that has extra IDs
     suffix = ".jsonlines"
-    train_path = join(train_dir, f"f5{suffix}")
+    train_path = train_dir / f"f5{suffix}"
 
-    config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_folds_file.template.cfg"), train_path, None
-    )
+    template_path = config_dir / "test_folds_file.template.cfg"
+    config_path = fill_in_config_paths_for_single_file(template_path, train_path, None)
     run_configuration(config_path, quiet=True, local=True)
 
     # Check job log output
     with open(
-        join(output_dir, "test_folds_file_logging_train_f5." "jsonlines_LogisticRegression.log")
+        output_dir / "test_folds_file_logging_train_f5." "jsonlines_LogisticRegression.log"
     ) as f:
         cv_file_pattern = re.compile(
             r"Feature set contains IDs that are not in folds dictionary. " r"Skipping those IDs."
@@ -346,20 +315,21 @@ def test_folds_file_with_fewer_ids_than_featureset():
 
 def test_folds_file_logging_grid_search():
     """
-    Test that, when `folds_file` is used but `use_folds_file` for grid search
-    is specified, that we get an appropriate message in the log.
+    Test logging with `folds_file`.
+
+    When `folds_file` is used but `use_folds_file` for grid search
+    is specified that we get an appropriate message in the log.
     """
     # Run experiment
     suffix = ".jsonlines"
-    train_path = join(train_dir, f"f0{suffix}")
+    train_path = train_dir / f"f0{suffix}"
 
-    config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_folds_file_grid.template.cfg"), train_path, None
-    )
+    template_path = config_dir / "test_folds_file_grid.template.cfg"
+    config_path = fill_in_config_paths_for_single_file(template_path, train_path, None)
     run_configuration(config_path, quiet=True, local=True)
 
     # Check experiment log output
-    with open(join(output_dir, "test_folds_file_logging.log")) as f:
+    with open(output_dir / "test_folds_file_logging.log") as f:
         cv_file_pattern = re.compile(
             r'Specifying "folds_file" overrides both explicit and default '
             r'"num_cv_folds".\n(.+)The specified "folds_file" will not be '
@@ -370,22 +340,18 @@ def test_folds_file_logging_grid_search():
 
 
 def test_cross_validate_task():
-    """
-    Test that 10-fold cross_validate experiments work and fold ids get saved.
-    """
-
+    """Test that 10-fold cross_validate experiments work and fold ids get saved."""
     # Run experiment
     suffix = ".jsonlines"
-    train_path = join(train_dir, f"f0{suffix}")
+    train_path = train_dir / f"f0{suffix}"
 
-    config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_save_cv_folds.template.cfg"), train_path, None
-    )
+    template_path = config_dir / "test_save_cv_folds.template.cfg"
+    config_path = fill_in_config_paths_for_single_file(template_path, train_path, None)
     run_configuration(config_path, quiet=True, local=True)
 
     # Check final average results
     with open(
-        join(output_dir, "test_save_cv_folds_train_f0.jsonlines_LogisticRegression" ".results.json")
+        output_dir / "test_save_cv_folds_train_f0.jsonlines_LogisticRegression.results.json"
     ) as f:
         result_dict = json.load(f)[10]
 
@@ -397,7 +363,7 @@ def test_cross_validate_task():
     expected_skll_ids = compute_expected_folds_for_cv_testing(examples, num_folds=10)
     # read in the computed fold IDs
     skll_fold_ids = {}
-    with open(join(output_dir, "test_save_cv_folds_skll_fold_ids.csv")) as f:
+    with open(output_dir / "test_save_cv_folds_skll_fold_ids.csv") as f:
         reader = csv.DictReader(f)
         for row in reader:
             skll_fold_ids[row["id"]] = row["cv_test_fold"]
@@ -410,33 +376,32 @@ def test_cross_validate_task():
 
 
 def test_cross_validate_task_save_cv_models():
-    """
-    Test that 10-fold cross_validate experiments work and that CV models
-    are correctly saved.
-    """
-
+    """Test 10-fold cross_validate experiments and model saving."""
     suffix = ".jsonlines"
-    train_path = join(train_dir, f"f0{suffix}")
-    config_path = fill_in_config_paths_for_single_file(
-        join(config_dir, "test_save_cv_models.template.cfg"), train_path, None
-    )
+    train_path = train_dir / f"f0{suffix}"
+
+    template_path = config_dir / "test_save_cv_models.template.cfg"
+    config_path = fill_in_config_paths_for_single_file(template_path, train_path, None)
     run_configuration(config_path, quiet=True, local=True)
+
     cv_model_prefix = "test_save_cv_models_train_f0.jsonlines_LogisticRegression_fold"
     for i in range(1, 11):
-        assert exists(join(output_dir, f"{cv_model_prefix}{i}.model")) is True
+        model_path = output_dir / f"{cv_model_prefix}{i}.model"
+        assert model_path.exists()
 
 
 def check_cross_validate_task_with_custom_seed(learner_type, use_config):
     """
-    This tests cross-validation for either a classifier or a regressor
+    Test cross-validation with custom specified seed.
+
+    Test that cross-validation for either a classifier or a regressor
     with an custom seed and with grid search enabled generates the
     same folds as expected. We run the test using a configuration file
     as well as the API.
     """
-
     # load in the featureset
     suffix = ".jsonlines"
-    train_path = join(train_dir, f"f0{suffix}")
+    train_path = train_dir / f"f0{suffix}"
     if learner_type == "classifier":
         examples = load_featureset(train_path, "", suffix, quiet=True)
     else:
@@ -445,15 +410,14 @@ def check_cross_validate_task_with_custom_seed(learner_type, use_config):
         )
 
     # use a configuration file or the API, as specified
-    template_name = (
-        "test_custom_cv_seed_classifier.template.cfg"
-        if learner_type == "classifier"
-        else "test_custom_cv_seed_regressor.template.cfg"
-    )
     if use_config:
-        config_path = fill_in_config_paths_for_single_file(
-            join(config_dir, template_name), train_path, None
+        template_name = (
+            "test_custom_cv_seed_classifier.template.cfg"
+            if learner_type == "classifier"
+            else "test_custom_cv_seed_regressor.template.cfg"
         )
+        template_path = config_dir / template_name
+        config_path = fill_in_config_paths_for_single_file(template_path, train_path, None)
         run_configuration(config_path, quiet=True, local=True)
 
         # read in the folds file produced by SKLL
@@ -463,7 +427,7 @@ def check_cross_validate_task_with_custom_seed(learner_type, use_config):
             if learner_type == "classifier"
             else "test_custom_cv_seed_reg_skll_fold_ids.csv"
         )
-        with open(join(output_dir, cv_folds_file_name)) as f:
+        with open(output_dir / cv_folds_file_name) as f:
             reader = csv.DictReader(f)
             for row in reader:
                 computed_fold_ids[row["id"]] = row["cv_test_fold"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,15 +1,13 @@
 # License: BSD 3 clause
 """
-Run the examples, just to make sure they are all still working
+Run the examples, just to make sure they are all still working.
 
 :author: Jeremy Biggs (jbiggs@@ets.org)
 """
 
 import json
 import subprocess
-from glob import glob
 from os import environ
-from os.path import basename, dirname, exists, join
 from pathlib import Path
 from shutil import copyfile, copytree, rmtree
 
@@ -18,88 +16,78 @@ from nose.tools import assert_almost_equal, eq_
 from skll.experiments import run_configuration
 from tests import examples_dir, other_dir
 
-_old_titanic_dir = join(examples_dir, "titanic")
-_old_california_dir = join(examples_dir, "california")
-_old_iris_dir = join(examples_dir, "iris")
+_old_titanic_dir = examples_dir / "titanic"
+_old_california_dir = examples_dir / "california"
+_old_iris_dir = examples_dir / "iris"
 
-_new_titanic_dir = join(other_dir, "titanic")
-_new_california_dir = join(other_dir, "california")
-_new_iris_dir = join(other_dir, "iris")
+_new_titanic_dir = other_dir / "titanic"
+_new_california_dir = other_dir / "california"
+_new_iris_dir = other_dir / "iris"
 
 # if we are running the tests without activating the conda
 # environment (as we do when testing the conda and TestPyPI
 # packages), then we will usually pass in a BINDIR environment
 # variable that points to where the environment's `bin` directory
 # is located
-_binary_dir = environ.get("BINDIR", "")
+_binary_dir = Path(environ.get("BINDIR", ""))
 
 
 def setup():
-    """
-    Create necessary directories for testing,
-    and copy files to new locations.
-    """
-
+    """Create directories for testing, and copy files to new locations."""
     # Create the directories we need for california and iris;
     # if these directories already exist, it's fine
     for dir_path in [_new_iris_dir, _new_california_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
     # We get rid of the new titanic directory, if it already exists,
     # because `copytree()` will raise an error if it already exists.
     # Note :: In Python 3.8, `copytree()` has a new argument,
     # `dirs_exist_ok`, which would render this step unnecessary.
-    if Path(_new_titanic_dir).exists():
+    if _new_titanic_dir.exists():
         rmtree(_new_titanic_dir)
 
     # Copy the titanic data to our new directories
     copytree(_old_titanic_dir, _new_titanic_dir)
 
     # Create all of the data sets we need
-    python_binary = join(_binary_dir, "python") if _binary_dir else "python"
+    python_binary = _binary_dir / "python" if _binary_dir else "python"
     subprocess.run(
-        [python_binary, join(examples_dir, "make_titanic_example_data.py")],
-        cwd=dirname(_new_titanic_dir),
+        [python_binary, examples_dir / "make_titanic_example_data.py"],
+        cwd=_new_titanic_dir.parent,
     )
     subprocess.run(
-        [python_binary, join(examples_dir, "make_california_example_data.py")],
-        cwd=dirname(_new_california_dir),
+        [python_binary, examples_dir / "make_california_example_data.py"],
+        cwd=_new_california_dir.parent,
     )
     subprocess.run(
-        [python_binary, join(examples_dir, "make_iris_example_data.py")], cwd=dirname(_new_iris_dir)
+        [python_binary, examples_dir / "make_iris_example_data.py"], cwd=_new_iris_dir.parent
     )
 
     # Move all the configuration files to our new directories
-    for cfg_file in glob(join(_old_titanic_dir, "**.cfg")):
-        copyfile(cfg_file, join(_new_titanic_dir, basename(cfg_file)))
+    for cfg_file in _old_titanic_dir.glob("*.cfg"):
+        copyfile(cfg_file, _new_titanic_dir / cfg_file.name)
 
-    for cfg_file in glob(join(_old_california_dir, "**.cfg")):
-        copyfile(cfg_file, join(_new_california_dir, basename(cfg_file)))
+    for cfg_file in _old_california_dir.glob("*.cfg"):
+        copyfile(cfg_file, _new_california_dir / cfg_file.name)
 
-    for cfg_file in glob(join(_old_iris_dir, "**.cfg")):
-        copyfile(cfg_file, join(_new_iris_dir, basename(cfg_file)))
+    for cfg_file in _old_iris_dir.glob("*.cfg"):
+        copyfile(cfg_file, _new_iris_dir / cfg_file.name)
 
 
 def tearDown():
-    """
-    Clean up after tests, remove all directories we created.
-    """
+    """Clean up after tests, remove all directories we created."""
     for dir_path in [_new_iris_dir, _new_california_dir, _new_titanic_dir]:
         rmtree(dir_path)
 
 
 def run_configuration_and_check_outputs(config_path):
-    """
-    Run the configuration, and then check the JSON results
-    against expected JSON files
-    """
-
+    """Run given configuration, and check JSON results against expected ones."""
     # run this experiment, get the `results_json_path`
-    results_json_path = run_configuration(config_path, local=True, quiet=True)[0]
+    results_json_path = Path(run_configuration(config_path, local=True, quiet=True)[0])
 
     # if the results path exists, check the output
-    if exists(results_json_path):
-        results_json_exp_path = join(other_dir, "expected", basename(results_json_path))
+    if results_json_path.exists():
+        results_json_exp_path = other_dir / "expected" / results_json_path
         with open(results_json_path) as results_json_file:
             results_obj = json.load(results_json_file)[0]
         with open(results_json_exp_path) as results_json_exp_file:
@@ -133,24 +121,18 @@ def run_configuration_and_check_outputs(config_path):
 
 
 def test_titanic_configs():
-    """
-    Run all of the configuration files for the titanic example
-    """
-    for config_path in glob(join(_new_titanic_dir, "*.cfg")):
-        run_configuration_and_check_outputs(config_path)
+    """Run all of the configuration files for the titanic example."""
+    for config_path in _new_titanic_dir.glob("*.cfg"):
+        run_configuration_and_check_outputs(str(config_path))
 
 
 def test_california_configs():
-    """
-    Run all of the configuration files for the california example
-    """
-    for config_path in glob(join(_new_california_dir, "*.cfg")):
-        run_configuration_and_check_outputs(config_path)
+    """Run all of the configuration files for the california example."""
+    for config_path in _new_california_dir.glob("*.cfg"):
+        run_configuration_and_check_outputs(str(config_path))
 
 
 def test_iris_configs():
-    """
-    Run all of the configuration files for the iris example
-    """
-    for config_path in glob(join(_new_iris_dir, "*.cfg")):
-        run_configuration_and_check_outputs(config_path)
+    """Run all of the configuration files for the iris example."""
+    for config_path in _new_iris_dir.glob("*.cfg"):
+        run_configuration_and_check_outputs(str(config_path))

--- a/tests/test_featureset.py
+++ b/tests/test_featureset.py
@@ -1,7 +1,6 @@
 # License: BSD 3 clause
 """
-Module for running a bunch of simple unit tests. Should be expanded more in
-the future.
+Run tests related to FeatureSets.
 
 :author: Michael Heilman (mheilman@ets.org)
 :author: Nitin Madnani (nmadnani@ets.org)
@@ -10,11 +9,8 @@ the future.
 """
 
 import itertools
-import os
 from collections import OrderedDict
 from io import StringIO
-from os.path import exists, join
-from pathlib import Path
 from shutil import rmtree
 
 import numpy as np
@@ -37,50 +33,40 @@ from skll.data import (
 from skll.data.readers import DictListReader
 from skll.experiments import load_featureset
 from skll.utils.commandline import skll_convert
-from skll.utils.constants import KNOWN_DEFAULT_PARAM_GRIDS
 from tests import other_dir, output_dir, test_dir, train_dir
 from tests.utils import make_classification_data, make_regression_data, unlink
 
-_ALL_MODELS = list(KNOWN_DEFAULT_PARAM_GRIDS.keys())
-
 
 def setup():
-    """
-    Create necessary directories for testing.
-    """
+    """Create necessary directories for testing."""
     for dir_path in [train_dir, test_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def tearDown():
-    """
-    Clean up files created during testing.
-    """
+    """Clean up files created during testing."""
     for filetype in ["csv", "jsonlines", "libsvm", "tsv"]:
-        unlink(Path(other_dir) / f"empty.{filetype}")
+        unlink(other_dir / f"empty.{filetype}")
 
     file_names = [
         f"{x}.jsonlines" for x in ["test_string_ids", "test_string_ids_df", "test_string_labels_df"]
     ]
     for file_name in file_names:
-        unlink(Path(other_dir) / file_name)
+        unlink(other_dir / file_name)
 
     for dir_name in ["test_conversion", "test_merging"]:
-        rmtree(Path(train_dir) / dir_name)
+        rmtree(train_dir / dir_name)
 
 
 def _create_empty_file(filetype):
-    filepath = join(other_dir, f"empty.{filetype}")
+    filepath = other_dir / f"empty.{filetype}"
     open(filepath, "w").close()
     return filepath
 
 
 @raises(ValueError)
 def test_empty_ids():
-    """
-    Test to ensure that an error is raised if ids is None
-    """
-
+    """Test to ensure that an error is raised if ids is None."""
     # get a 100 instances with 4 features each
     X, y = make_classification(
         n_samples=100,
@@ -117,10 +103,7 @@ def test_empty_file_read():
 
 
 def test_empty_labels():
-    """
-    Test to check behaviour when labels is None
-    """
-
+    """Test to check behaviour when labels is None."""
     # create a feature set with empty labels
     fs, _ = make_classification_data(
         num_examples=100, num_features=4, num_labels=3, empty_labels=True, train_test_ratio=1.0
@@ -129,10 +112,7 @@ def test_empty_labels():
 
 
 def test_length():
-    """
-    Test to whether len() returns the number of instances
-    """
-
+    """Test to whether len() returns the number of instances."""
     # create a featureset
     fs, _ = make_classification_data(
         num_examples=100, num_features=4, num_labels=3, train_test_ratio=1.0
@@ -142,9 +122,7 @@ def test_length():
 
 
 def test_string_feature():
-    """
-    Test that string-valued features are properly encoded as binary features
-    """
+    """Test that string-valued features are properly encoded as binary features."""
     # create a featureset that is derived from an original
     # set of features containing 3 numeric features and
     # one string-valued feature that can take six possible
@@ -173,10 +151,7 @@ def test_string_feature():
 
 
 def test_equality():
-    """
-    Test featureset equality
-    """
-
+    """Test featureset equality."""
     # create a featureset
     fs1, _ = make_classification_data(
         num_examples=100, num_features=4, num_labels=3, train_test_ratio=1.0
@@ -251,9 +226,7 @@ def test_equality():
 
 
 def test_vectorizer_inequality():
-    """
-    Test to make sure that vectorizer equality fails properly
-    """
+    """Test to make sure that vectorizer equality fails properly."""
     v = DictVectorizer()
     assert_not_equal(v, 1)
     assert_not_equal(v, "passthrough")
@@ -262,10 +235,7 @@ def test_vectorizer_inequality():
 
 @raises(ValueError)
 def test_merge_different_vectorizers():
-    """
-    Test to ensure rejection of merging featuresets with different vectorizers
-    """
-
+    """Test to ensure rejection of merging featuresets with different vectorizers."""
     # create a featureset each with a DictVectorizer
     fs1, _ = make_classification_data(
         num_examples=100, num_features=4, num_labels=3, train_test_ratio=1.0
@@ -286,10 +256,7 @@ def test_merge_different_vectorizers():
 
 @raises(ValueError)
 def test_merge_different_hashers():
-    """
-    Test to ensure rejection of merging featuresets with different FeatureHashers
-    """
-
+    """Test to ensure rejection of merging featuresets with different FeatureHashers."""
     # create a feature set with 4 feature hashing bins
     fs1, _ = make_classification_data(
         num_examples=100,
@@ -316,10 +283,7 @@ def test_merge_different_hashers():
 
 @raises(ValueError)
 def test_merge_different_labels_same_ids():
-    """
-    Test to ensure rejection of merging featuresets that have conflicting labels
-    """
-
+    """Test to ensure rejection of merging featuresets that have conflicting labels."""
     # create a feature set
     fs1, _ = make_classification_data(
         num_examples=100, num_features=4, num_labels=3, train_test_ratio=1.0
@@ -339,10 +303,7 @@ def test_merge_different_labels_same_ids():
 
 
 def test_merge_missing_labels():
-    """
-    Test to ensure that labels are sucessfully copied when merging
-    """
-
+    """Test to ensure that labels are sucessfully copied when merging."""
     # create a feature set
     fs1, _ = make_classification_data(
         num_examples=100, num_features=4, num_labels=3, train_test_ratio=1.0
@@ -369,9 +330,7 @@ def test_merge_missing_labels():
 
 @raises(ValueError)
 def test_write_hashed_featureset():
-    """
-    Test to check that hashed featuresets cannot be written out
-    """
+    """Test to check that hashed featuresets cannot be written out."""
     fs, _ = make_classification_data(
         num_examples=100,
         num_features=4,
@@ -379,15 +338,12 @@ def test_write_hashed_featureset():
         feature_bins=2,
         random_state=1234,
     )
-    writer = NDJWriter(join(output_dir, "foo.jsonlines"), fs)
+    writer = NDJWriter(output_dir / "foo.jsonlines", fs)
     writer.write()
 
 
 def test_subtract():
-    """
-    Test to ensure that subtraction works
-    """
-
+    """Test to ensure that subtraction works."""
     # create a feature set
     fs1, _ = make_classification_data(
         num_examples=100, num_features=4, num_labels=2, train_test_ratio=1.0, random_state=1234
@@ -415,10 +371,7 @@ def test_subtract():
 
 @raises(ValueError)
 def test_mismatch_ids_features():
-    """
-    Test to catch mistmatch between the shape of the ids vector and the feature matrix
-    """
-
+    """Test to catch mistmatch between the shape of the ids vector and the feature matrix."""
     # get a 100 instances with 4 features each
     X, y = make_classification(
         n_samples=100,
@@ -444,10 +397,7 @@ def test_mismatch_ids_features():
 
 @raises(ValueError)
 def test_mismatch_labels_features():
-    """
-    Test to catch mistmatch between the shape of the labels vector and the feature matrix
-    """
-
+    """Test to catch mistmatch between the shape of the labels vector and the feature matrix."""
     # get a 100 instances with 4 features but ignore the labels we
     # get from here
     X, y = make_classification(
@@ -477,10 +427,7 @@ def test_mismatch_labels_features():
 
 @raises(ValueError)
 def test_iteration_without_dictvectorizer():
-    """
-    Test to allow iteration only if the vectorizer is a DictVectorizer
-    """
-
+    """Test to allow iteration only if the vectorizer is a DictVectorizer."""
     # create a feature set
     fs, _ = make_classification_data(
         num_examples=100,
@@ -518,10 +465,7 @@ def check_filter_ids(inverse=False):
 
 
 def test_filter_ids():
-    """
-    Test filtering with specified IDs, with and without inverting
-    """
-
+    """Test filtering with specified IDs, with and without inverting."""
     yield check_filter_ids
     yield check_filter_ids, True
 
@@ -552,10 +496,7 @@ def check_filter_labels(inverse=False):
 
 
 def test_filter_labels():
-    """
-    Test filtering with specified labels, with and without inverting
-    """
-
+    """Test filtering with specified labels, with and without inverting."""
     yield check_filter_labels
     yield check_filter_labels, True
 
@@ -597,20 +538,14 @@ def check_filter_features(inverse=False):
 
 
 def test_filter_features():
-    """
-    Test filtering with specified features, with and without inverting
-    """
-
+    """Test filtering with specified features, with and without inverting."""
     yield check_filter_features
     yield check_filter_features, True
 
 
 @raises(ValueError)
 def test_filter_with_hashing():
-    """
-    Test to ensure rejection of filtering by features when using hashing
-    """
-
+    """Test to ensure rejection of filtering by features when using hashing."""
     # create a feature set
     fs, _ = make_classification_data(
         num_examples=100,
@@ -626,10 +561,7 @@ def test_filter_with_hashing():
 
 
 def test_feature_merging_order_invariance():
-    """
-    Test whether featuresets with different orders of IDs can be merged
-    """
-
+    """Test whether featuresets with different orders of IDs can be merged."""
     # First, randomly generate two feature sets and then make sure they have
     # the same labels.
     train_fs1, _, _ = make_regression_data()
@@ -685,9 +617,9 @@ def make_merging_data(num_feat_files, suffix, numeric_ids):
 
     np.random.seed(1234567890)
 
-    merge_dir = join(train_dir, "test_merging")
-    if not exists(merge_dir):
-        os.makedirs(merge_dir)
+    merge_dir = train_dir / "test_merging"
+    if not merge_dir.exists():
+        merge_dir.mkdir(parents=True)
 
     # Create lists we will write files from
     ids = []
@@ -710,12 +642,12 @@ def make_merging_data(num_feat_files, suffix, numeric_ids):
     for i in range(num_feat_files):
         feat_num = i * num_feats_per_file
         subset_dict[str(i)] = [f"f{feat_num + j:03d}" for j in range(num_feats_per_file)]
-    train_path = join(merge_dir, suffix)
+    train_path = merge_dir / suffix
     train_fs = FeatureSet("train", ids, labels=labels, features=features)
     Writer.for_path(train_path, train_fs, subsets=subset_dict).write()
 
     # Merged
-    train_path = join(merge_dir, f"all{suffix}")
+    train_path = merge_dir / f"all{suffix}"
     Writer.for_path(train_path, train_fs).write()
 
 
@@ -726,7 +658,7 @@ def check_load_featureset(suffix, numeric_ids):
     make_merging_data(num_feat_files, suffix, numeric_ids)
 
     # Load unmerged data and merge it
-    dirpath = join(train_dir, "test_merging")
+    dirpath = train_dir / "test_merging"
     featureset = [str(i) for i in range(num_feat_files)]
     merged_exs = load_featureset(dirpath, featureset, suffix, quiet=True)
 
@@ -754,7 +686,7 @@ def test_load_featureset():
 
 
 def test_ids_to_floats():
-    path = join(train_dir, "test_input_2examples_1.jsonlines")
+    path = train_dir / "test_input_2examples_1.jsonlines"
 
     examples = Reader.for_path(path, ids_to_floats=True, quiet=True).read()
     assert isinstance(examples.ids[0], float)
@@ -797,9 +729,9 @@ def make_conversion_data(num_feat_files, from_suffix, to_suffix, with_labels=Tru
 
     np.random.seed(1234567890)
 
-    convert_dir = join(train_dir, "test_conversion")
-    if not exists(convert_dir):
-        os.makedirs(convert_dir)
+    convert_dir = train_dir / "test_conversion"
+    if not convert_dir.exists():
+        convert_dir.mkdir(parents=True)
 
     # Create lists we will write files from
     ids = []
@@ -841,7 +773,7 @@ def make_conversion_data(num_feat_files, from_suffix, to_suffix, with_labels=Tru
 
     # Write out unmerged features in the `from_suffix` file format
     for i in range(num_feat_files):
-        train_path = join(convert_dir, f"{feature_name_prefix}_{i}{with_labels_part}{from_suffix}")
+        train_path = convert_dir / f"{feature_name_prefix}_{i}{with_labels_part}{from_suffix}"
         sub_features = []
         for example_num in range(num_examples):
             feat_num = i * num_feats_per_file
@@ -862,7 +794,7 @@ def make_conversion_data(num_feat_files, from_suffix, to_suffix, with_labels=Tru
             Writer.for_path(train_path, train_fs).write()
 
     # Write out the merged features in the `to_suffix` file format
-    train_path = join(convert_dir, f"{feature_name_prefix}{with_labels_part}_all{to_suffix}")
+    train_path = convert_dir / f"{feature_name_prefix}{with_labels_part}_all{to_suffix}"
     train_fs = FeatureSet(
         "train", ids, labels=labels, features=features, vectorizer=feat_vectorizer
     )
@@ -889,7 +821,7 @@ def check_convert_featureset(from_suffix, to_suffix, with_labels=True):
     make_conversion_data(num_feat_files, from_suffix, to_suffix, with_labels=with_labels)
 
     # the path to the unmerged feature files
-    dirpath = join(train_dir, "test_conversion")
+    dirpath = train_dir / "test_conversion"
 
     # get the feature name prefix
     feature_name_prefix = f"{from_suffix.lstrip('.')}_to_{to_suffix.lstrip('.')}"
@@ -900,13 +832,11 @@ def check_convert_featureset(from_suffix, to_suffix, with_labels=True):
     # Load each unmerged feature file in the `from_suffix` format and convert
     # it to the `to_suffix` format
     for feature in range(num_feat_files):
-        input_file_path = join(
-            dirpath, f"{feature_name_prefix}_{feature}{with_labels_part}{from_suffix}"
+        input_file_path = (
+            dirpath / f"{feature_name_prefix}_{feature}{with_labels_part}{from_suffix}"
         )
-        output_file_path = join(
-            dirpath, f"{feature_name_prefix}_{feature}{with_labels_part}{to_suffix}"
-        )
-        skll_convert_args = ["--quiet", input_file_path, output_file_path]
+        output_file_path = dirpath / f"{feature_name_prefix}_{feature}{with_labels_part}{to_suffix}"
+        skll_convert_args = ["--quiet", str(input_file_path), str(output_file_path)]
         if not with_labels:
             skll_convert_args.append("--no_labels")
         skll_convert.main(skll_convert_args)
@@ -947,10 +877,11 @@ def test_convert_featureset():
 
 def featureset_creation_from_dataframe_helper(with_labels, use_feature_hasher):
     """
+    Create featureset from dataframes for tests.
+
     Helper function for the two unit tests for FeatureSet.from_data_frame().
     Since labels are optional, run two tests, one with, one without.
     """
-
     # First, setup the test data.
     # get a 100 instances with 4 features each
     X, y = make_classification(
@@ -1048,7 +979,7 @@ def test_writing_ndj_featureset_with_string_ids():
     fs_test = FeatureSet(
         "test", ids=["1", "2"], labels=[1, 2], features=Xtest, vectorizer=test_dict_vectorizer
     )
-    output_path = join(other_dir, "test_string_ids.jsonlines")
+    output_path = other_dir / "test_string_ids.jsonlines"
     test_writer = NDJWriter(output_path, fs_test)
     test_writer.write()
 
@@ -1072,7 +1003,7 @@ def test_featureset_creation_from_dataframe_with_string_ids():
         features=Xtest,
         vectorizer=test_dict_vectorizer,
     )
-    output_path = join(other_dir, "test_string_ids_df.jsonlines")
+    output_path = other_dir / "test_string_ids_df.jsonlines"
     test_writer = NDJWriter(output_path, fs_test)
     test_writer.write()
 
@@ -1097,7 +1028,7 @@ def test_featureset_creation_from_dataframe_with_string_labels():
         vectorizer=test_dict_vectorizer,
     )
 
-    output_path = join(other_dir, "test_string_labels_df.jsonlines")
+    output_path = other_dir / "test_string_labels_df.jsonlines"
     test_writer = NDJWriter(output_path, fs_test)
     test_writer.write()
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,17 +1,14 @@
 # License: BSD 3 clause
 """
-Tests related to data preprocessing options with run_experiment.
+Tests related to data preprocessing options with `run_experiment`.
 
 :author: Michael Heilman (mheilman@ets.org)
 :author: Nitin Madnani (nmadnani@ets.org)
 """
 
-import glob
 import json
 import os
 import re
-from os.path import join
-from pathlib import Path
 
 import numpy as np
 import scipy.sparse as sp
@@ -23,40 +20,33 @@ from skll.data import FeatureSet, NDJWriter
 from skll.experiments import run_configuration
 from skll.learner import Learner
 from skll.learner.utils import SelectByMinCount
-from skll.utils.constants import KNOWN_DEFAULT_PARAM_GRIDS
 from tests import config_dir, output_dir, test_dir, train_dir
 from tests.utils import fill_in_config_paths, unlink
 
-_ALL_MODELS = list(KNOWN_DEFAULT_PARAM_GRIDS.keys())
 SCORE_OUTPUT_RE = re.compile(r"Objective Function Score \(Test\) = ([\-\d\.]+)")
 
 
 def setup():
-    """
-    Create necessary directories for testing.
-    """
+    """Create necessary directories for testing."""
     for dir_path in [train_dir, test_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def tearDown():
-    """
-    Clean up after tests.
-    """
-
-    for output_file in glob.glob(join(output_dir, "test_class_map*")):
+    """Clean up after tests."""
+    for output_file in output_dir.glob("test_class_map*"):
         os.unlink(output_file)
 
     for dir_path in [train_dir, test_dir]:
-        unlink(Path(dir_path) / "test_class_map.jsonlines")
+        unlink(dir_path / "test_class_map.jsonlines")
 
     config_files = ["test_class_map.cfg", "test_class_map_feature_hasher.cfg"]
     for cf in config_files:
-        unlink(Path(config_dir) / cf)
+        unlink(config_dir / cf)
 
 
 def test_SelectByMinCount():
-    """Test SelectByMinCount feature selector"""
+    """Test SelectByMinCount feature selector."""
     m2 = [
         [0.001, 0.0, 0.0, 0.0],
         [0.00001, -2.0, 0.0, 0.0],
@@ -87,7 +77,7 @@ def test_SelectByMinCount():
 
 def make_class_map_data():
     # Create training file
-    train_path = join(train_dir, "test_class_map.jsonlines")
+    train_path = train_dir / "test_class_map.jsonlines"
     ids = []
     labels = []
     features = []
@@ -105,7 +95,7 @@ def make_class_map_data():
     writer.write()
 
     # Create test file
-    test_path = join(test_dir, "test_class_map.jsonlines")
+    test_path = test_dir / "test_class_map.jsonlines"
     ids = []
     labels = []
     features = []
@@ -123,20 +113,15 @@ def make_class_map_data():
 
 
 def test_class_map():
-    """
-    Test class maps
-    """
-
+    """Test class maps."""
     make_class_map_data()
 
-    config_template_path = join(config_dir, "test_class_map.template.cfg")
+    config_template_path = config_dir / "test_class_map.template.cfg"
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, local=True)
 
-    with open(
-        join(output_dir, "test_class_map_test_class_map_LogisticRegression.results" ".json")
-    ) as f:
+    with open(output_dir / "test_class_map_test_class_map_LogisticRegression.results" ".json") as f:
         outd = json.loads(f.read())
         logistic_result_score = outd[0]["accuracy"]
 
@@ -144,20 +129,15 @@ def test_class_map():
 
 
 def test_class_map_feature_hasher():
-    """
-    Test class maps with feature hashing
-    """
-
+    """Test class maps with feature hashing."""
     make_class_map_data()
 
-    config_template_path = join(config_dir, "test_class_map_feature_hasher.template.cfg")
+    config_template_path = config_dir / "test_class_map_feature_hasher.template.cfg"
     config_path = fill_in_config_paths(config_template_path)
 
     run_configuration(config_path, quiet=True, local=True)
 
-    with open(
-        join(output_dir, "test_class_map_test_class_map_LogisticRegression.results." "json")
-    ) as f:
+    with open(output_dir / "test_class_map_test_class_map_LogisticRegression.results." "json") as f:
         outd = json.loads(f.read())
         logistic_result_score = outd[0]["accuracy"]
 

--- a/tests/test_voting_learners_api_1.py
+++ b/tests/test_voting_learners_api_1.py
@@ -7,7 +7,6 @@ Initialization, training, saving, and loading tests for voting learners.
 """
 
 from itertools import product
-from os.path import exists, join
 from pathlib import Path
 
 import numpy as np
@@ -29,20 +28,20 @@ FS_DIGITS, _ = make_digits_data(test_size=0, use_digit_names=True)
 TRAIN_FS_HOUSING, TEST_FS_HOUSING = make_california_housing_data(num_examples=2000)
 FS_HOUSING, _ = make_california_housing_data(num_examples=2000, test_size=0)
 FS_HOUSING.ids = np.arange(2000)
-CUSTOM_LEARNER_PATH = Path(other_dir) / "custom_logistic_wrapper.py"
+CUSTOM_LEARNER_PATH = other_dir / "custom_logistic_wrapper.py"
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests.."""
     for dir_path in [other_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def tearDown():
-    """Clean up after tests"""
+    """Clean up after tests."""
     for model_path in [
         Path("test_current_directory.model"),
-        Path(output_dir) / "test_other_directory.model",
+        output_dir / "test_other_directory.model",
     ]:
         if model_path.exists():
             model_path.unlink()
@@ -308,7 +307,6 @@ def test_train():
 
 def test_train_with_custom_path():
     """Test voting classifier with custom learner path."""
-
     # instantiate and train a voting classifier on the digits training set
     learner_names = ["CustomLogisticRegressionWrapper", "SVC"]
     vl = VotingLearner(learner_names, custom_learner_path=str(CUSTOM_LEARNER_PATH))
@@ -344,7 +342,7 @@ def test_train_bad_param_grid_list():
 
 
 def check_save_and_load(learner_type, use_current_directory):
-    """Check that saving models works as expected"""
+    """Check that saving models works as expected."""
     # if the voting learner is a classifier
     if learner_type == "classifier":
         # use 3 classifiers, the digits training set, and accuracy
@@ -363,14 +361,14 @@ def check_save_and_load(learner_type, use_current_directory):
 
     # save this trained model into the current directory
     if use_current_directory:
-        model_name = "test_current_directory.model"
+        model_name = Path("test_current_directory.model")
     else:
-        model_name = join(output_dir, "test_other_directory.model")
+        model_name = output_dir / "test_other_directory.model"
 
     vl.save(model_name)
 
     # make sure that the model saved and that it's the same model
-    ok_(exists(model_name))
+    ok_(model_name.exists())
     vl2 = VotingLearner.from_file(model_name)
     eq_(vl._learner_names, vl2._learner_names)
     eq_(vl.model_type, vl2.model_type)

--- a/tests/test_voting_learners_api_2.py
+++ b/tests/test_voting_learners_api_2.py
@@ -8,7 +8,6 @@ Evaluation and learning curve tests for voting learners.
 
 import re
 from itertools import product
-from pathlib import Path
 
 import numpy as np
 from nose.tools import assert_almost_equal, eq_, ok_, raises
@@ -31,18 +30,17 @@ FS_DIGITS, _ = make_digits_data(test_size=0, use_digit_names=True)
 TRAIN_FS_HOUSING, TEST_FS_HOUSING = make_california_housing_data(num_examples=2000)
 FS_HOUSING, _ = make_california_housing_data(num_examples=2000, test_size=0)
 FS_HOUSING.ids = np.arange(2000)
-CUSTOM_LEARNER_PATH = Path(other_dir) / "custom_logistic_wrapper.py"
+CUSTOM_LEARNER_PATH = other_dir / "custom_logistic_wrapper.py"
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [other_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def check_evaluate(learner_type, with_grid_search, with_soft_voting):
     """Run checks when evaluating voting learners."""
-
     # to test the evaluate() method, we instantiate the SKLL voting learner,
     # train it on either the digits (classification) or housing (regression)
     # data set, and evaluate on the corresponding test set; then we do the
@@ -258,7 +256,7 @@ def test_learning_curve_min_examples_check():
 def test_learning_curve_min_examples_check_override():
     # creates a logger which writes to a temporary log file
     log_file_path = (
-        Path(output_dir) / "test_check_override_voting_learner_" "learning_curve_min_examples.log"
+        output_dir / "test_check_override_voting_learner_" "learning_curve_min_examples.log"
     )
 
     logger = get_skll_logger(

--- a/tests/test_voting_learners_api_3.py
+++ b/tests/test_voting_learners_api_3.py
@@ -24,18 +24,18 @@ FS_DIGITS, _ = make_digits_data(test_size=0, use_digit_names=True)
 TRAIN_FS_HOUSING, TEST_FS_HOUSING = make_california_housing_data(num_examples=2000)
 FS_HOUSING, _ = make_california_housing_data(num_examples=2000, test_size=0)
 FS_HOUSING.ids = np.arange(2000)
-CUSTOM_LEARNER_PATH = Path(other_dir) / "custom_logistic_wrapper.py"
+CUSTOM_LEARNER_PATH = other_dir / "custom_logistic_wrapper.py"
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [other_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_predict_voting*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_predict_voting*"):
         output_file_path.unlink()
 
 
@@ -55,7 +55,7 @@ def check_predict(
 
     # set the prediction prefix in case we need to write out the predictions
     prediction_prefix = (
-        Path(output_dir) / f"test_predict_voting_"
+        output_dir / f"test_predict_voting_"
         f"{learner_type}_"
         f"{with_grid_search}_"
         f"{with_class_labels}"

--- a/tests/test_voting_learners_api_4.py
+++ b/tests/test_voting_learners_api_4.py
@@ -7,7 +7,6 @@ Cross-validation tests without grid search for voting learners.
 """
 
 from itertools import product
-from os.path import exists
 from pathlib import Path
 
 import numpy as np
@@ -33,23 +32,23 @@ FS_DIGITS, _ = make_digits_data(test_size=0, use_digit_names=True)
 TRAIN_FS_HOUSING, TEST_FS_HOUSING = make_california_housing_data(num_examples=2000)
 FS_HOUSING, _ = make_california_housing_data(num_examples=2000, test_size=0)
 FS_HOUSING.ids = np.arange(2000)
-CUSTOM_LEARNER_PATH = Path(other_dir) / "custom_logistic_wrapper.py"
+CUSTOM_LEARNER_PATH = other_dir / "custom_logistic_wrapper.py"
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [other_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_xval_voting_no_gs*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_xval_voting_no_gs*"):
         output_file_path.unlink()
 
 
 def test_cross_validate_with_continuous_labels():
-    """Test that voting learner cross validation fails with continuous labels"""
+    """Test that voting learner cross validation fails with continuous labels."""
     fs, _ = make_classification_data(
         num_examples=500, train_test_ratio=0.8, num_labels=3, non_negative=True
     )
@@ -65,7 +64,7 @@ def test_cross_validate_with_continuous_labels():
 
 
 def test_cross_validate_grid_search_but_no_objective():
-    """Test that voting learner cross validation fails with continuous labels"""
+    """Test that voting learner cross validation fails with continuous labels."""
     fs, _ = make_classification_data(
         num_examples=500, train_test_ratio=0.8, num_labels=3, non_negative=True
     )
@@ -89,7 +88,7 @@ def check_cross_validate_without_grid_search(
 
     # set the prediction prefix in case we need to write out the predictions
     prediction_prefix = (
-        Path(output_dir) / f"test_xval_voting_no_gs_" f"{learner_type}_" f"{with_soft_voting}"
+        output_dir / f"test_xval_voting_no_gs_" f"{learner_type}_" f"{with_soft_voting}"
     )
     prediction_prefix = str(prediction_prefix)
 
@@ -236,7 +235,8 @@ def check_cross_validate_without_grid_search(
     # `predict()` anyway
     if with_individual_predictions:
         for learner_name in learner_names:
-            ok_(exists(f"{prediction_prefix}_{learner_name}_predictions.tsv"))
+            prediction_path = Path(f"{prediction_prefix}_{learner_name}_predictions.tsv")
+            ok_(prediction_path.exists())
 
 
 def test_cross_validate_without_grid_search():

--- a/tests/test_voting_learners_api_5.py
+++ b/tests/test_voting_learners_api_5.py
@@ -7,7 +7,6 @@ Cross-validation tests with grid search for voting learners.
 """
 
 from itertools import product
-from os.path import exists
 from pathlib import Path
 
 import numpy as np
@@ -33,18 +32,18 @@ FS_DIGITS, _ = make_digits_data(test_size=0, use_digit_names=True)
 TRAIN_FS_HOUSING, TEST_FS_HOUSING = make_california_housing_data(num_examples=2000)
 FS_HOUSING, _ = make_california_housing_data(num_examples=2000, test_size=0)
 FS_HOUSING.ids = np.arange(2000)
-CUSTOM_LEARNER_PATH = Path(other_dir) / "custom_logistic_wrapper.py"
+CUSTOM_LEARNER_PATH = other_dir / "custom_logistic_wrapper.py"
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [other_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_xval_voting_gs*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_xval_voting_gs*"):
         output_file_path.unlink()
 
 
@@ -65,7 +64,7 @@ def check_cross_validate_with_grid_search(
 
     # set the prediction prefix in case we need to write out the predictions
     prediction_prefix = (
-        Path(output_dir) / f"test_xval_voting_gs_" f"{learner_type}_" f"{with_soft_voting}"
+        output_dir / f"test_xval_voting_gs_" f"{learner_type}_" f"{with_soft_voting}"
     )
     prediction_prefix = str(prediction_prefix)
 
@@ -241,7 +240,7 @@ def check_cross_validate_with_grid_search(
     # `predict()` anyway
     if with_individual_predictions:
         for learner_name in learner_names:
-            ok_(exists(f"{prediction_prefix}_{learner_name}_predictions.tsv"))
+            ok_(Path(f"{prediction_prefix}_{learner_name}_predictions.tsv").exists())
 
 
 def test_cross_validate_with_grid_search():

--- a/tests/test_voting_learners_expts_1.py
+++ b/tests/test_voting_learners_expts_1.py
@@ -12,7 +12,6 @@ tested comprehensively in ``test_voting_learners_api_1.py``.
 """
 
 from itertools import product
-from os.path import join
 from pathlib import Path
 from unittest.mock import DEFAULT, patch
 
@@ -31,31 +30,30 @@ from tests.utils import (
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [train_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
     # create the training and test data files that we will use
     create_jsonlines_feature_files(train_dir)
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_voting_learner_train*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_voting_learner_train*"):
         output_file_path.unlink()
 
     for output_file_path in Path(".").glob("test_voting_learner_train*"):
         output_file_path.unlink()
 
-    config_file_path = Path(config_dir) / "test_voting_learner_train.cfg"
+    config_file_path = config_dir / "test_voting_learner_train.cfg"
     config_file_path.unlink()
 
     remove_jsonlines_feature_files(train_dir)
 
 
 def check_train_task(learner_type, options_dict):
-    """Check given combination of training configuration options"""
-
+    """Check given combination of training configuration options."""
     # create a configuration file with the given options
     (
         config_path,
@@ -150,9 +148,9 @@ def check_train_task(learner_type, options_dict):
             if not options_dict["with_grid_search"] or (
                 options_dict["with_grid_search"] and not options_dict["with_multiple_objectives"]
             ):
-                expected_save_args = (join(output_dir, f"{job_name}.model"),)
+                expected_save_args = (output_dir / f"{job_name}.model",)
             else:
-                expected_save_args = (join(output_dir, f"{job_name}_{objectives[idx]}.model"),)
+                expected_save_args = (output_dir / f"{job_name}_{objectives[idx]}.model",)
             eq_(actual_call[0], expected_save_args)
 
     # stop all the manual patchers

--- a/tests/test_voting_learners_expts_2.py
+++ b/tests/test_voting_learners_expts_2.py
@@ -12,7 +12,6 @@ tested comprehensively in ``test_voting_learners_api_2.py``.
 """
 
 from itertools import product
-from os.path import join
 from pathlib import Path
 from unittest.mock import DEFAULT, patch
 
@@ -31,9 +30,9 @@ from tests.utils import (
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [train_dir, test_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
     # create the training and test data files that we will use
     create_jsonlines_feature_files(train_dir)
@@ -41,14 +40,14 @@ def setup():
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_voting_learner_evaluate*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_voting_learner_evaluate*"):
         output_file_path.unlink()
 
     for output_file_path in Path(".").glob("test_voting_learner_evaluate*"):
         output_file_path.unlink()
 
-    config_file_path = Path(config_dir) / "test_voting_learner_evaluate.cfg"
+    config_file_path = config_dir / "test_voting_learner_evaluate.cfg"
     config_file_path.unlink()
 
     remove_jsonlines_feature_files(train_dir)
@@ -56,8 +55,7 @@ def tearDown():
 
 
 def check_evaluate_task(learner_type, options_dict):
-    """Check given combination of training configuration options"""
-
+    """Check given combination of training configuration options."""
     # create a configuration file with the given options
     (
         config_path,
@@ -177,10 +175,10 @@ def check_evaluate_task(learner_type, options_dict):
             eq_(
                 mocks["save"].call_count, len(objectives) if options_dict["with_grid_search"] else 1
             )
-            eq_(mocks["save"].call_args[0][0], join(output_dir, f"{job_name}.model"))
+            eq_(mocks["save"].call_args[0][0], output_dir / f"{job_name}.model")
         else:
             eq_(mock_vl_from_file.call_count, 1)
-            eq_(mock_vl_from_file.call_args[0][0], join(other_dir, f"{job_name}.model"))
+            eq_(mock_vl_from_file.call_args[0][0], other_dir / f"{job_name}.model")
 
         # check that evaluate was called the expected number of times
         eq_(
@@ -190,7 +188,7 @@ def check_evaluate_task(learner_type, options_dict):
         # check that each evaluate call had the expected arguments
         expected_eval_kwargs = {
             "grid_objective": objectives[idx] if options_dict["with_grid_search"] else None,
-            "prediction_prefix": join(output_dir, job_name)
+            "prediction_prefix": str(output_dir / job_name)
             if options_dict["with_prediction_prefix"]
             else job_name,
             "individual_predictions": options_dict["with_individual_predictions"],

--- a/tests/test_voting_learners_expts_3.py
+++ b/tests/test_voting_learners_expts_3.py
@@ -12,7 +12,6 @@ tested comprehensively in ``test_voting_learners_api_3.py``.
 """
 
 from itertools import product
-from os.path import join
 from pathlib import Path
 from unittest.mock import DEFAULT, patch
 
@@ -31,9 +30,9 @@ from tests.utils import (
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [train_dir, test_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
     # create the training and test data files that we will use
     create_jsonlines_feature_files(train_dir)
@@ -41,14 +40,14 @@ def setup():
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_voting_learner_predict*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_voting_learner_predict*"):
         output_file_path.unlink()
 
     for output_file_path in Path(".").glob("test_voting_learner_predict*"):
         output_file_path.unlink()
 
-    config_file_path = Path(config_dir) / "test_voting_learner_predict.cfg"
+    config_file_path = config_dir / "test_voting_learner_predict.cfg"
     config_file_path.unlink()
 
     remove_jsonlines_feature_files(train_dir)
@@ -56,8 +55,7 @@ def tearDown():
 
 
 def check_predict_task(learner_type, options_dict):
-    """Check given combination of prediction configuration options"""
-
+    """Check given combination of prediction configuration options."""
     # create a configuration file with the given options
     (
         config_path,
@@ -177,17 +175,17 @@ def check_predict_task(learner_type, options_dict):
             eq_(
                 mocks["save"].call_count, len(objectives) if options_dict["with_grid_search"] else 1
             )
-            eq_(mocks["save"].call_args[0][0], join(output_dir, f"{job_name}.model"))
+            eq_(mocks["save"].call_args[0][0], output_dir / f"{job_name}.model")
         else:
             eq_(mock_vl_from_file.call_count, 1)
-            eq_(mock_vl_from_file.call_args[0][0], join(other_dir, f"{job_name}.model"))
+            eq_(mock_vl_from_file.call_args[0][0], other_dir / f"{job_name}.model")
 
         # check that predict was called the expected number of times
         eq_(mocks["predict"].call_count, len(objectives) if options_dict["with_grid_search"] else 1)
 
         # check that each predict call had the expected arguments
         expected_predict_kwargs = {
-            "prediction_prefix": join(output_dir, job_name)
+            "prediction_prefix": str(output_dir / job_name)
             if options_dict["with_prediction_prefix"]
             else job_name,
             "individual_predictions": options_dict["with_individual_predictions"],

--- a/tests/test_voting_learners_expts_4.py
+++ b/tests/test_voting_learners_expts_4.py
@@ -12,7 +12,6 @@ tested comprehensively in ``test_voting_learners_api_4.py``.
 """
 
 from itertools import product
-from os.path import join
 from pathlib import Path
 from unittest.mock import DEFAULT, patch
 
@@ -31,31 +30,30 @@ from tests.utils import (
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [train_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
     # create the training and test data files that we will use
     create_jsonlines_feature_files(train_dir)
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_voting_learner_cross_validate*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_voting_learner_cross_validate*"):
         output_file_path.unlink()
 
     for output_file_path in Path(".").glob("test_voting_learner_cross_validate*"):
         output_file_path.unlink()
 
-    config_file_path = Path(config_dir) / "test_voting_learner_cross_validate.cfg"
+    config_file_path = config_dir / "test_voting_learner_cross_validate.cfg"
     config_file_path.unlink()
 
     remove_jsonlines_feature_files(train_dir)
 
 
 def check_xval_task(learner_type, options_dict):
-    """Check given combination of cross-validation configuration options"""
-
+    """Check given combination of cross-validation configuration options."""
     # create a configuration file with the given options
     (
         config_path,
@@ -200,14 +198,13 @@ def check_xval_task(learner_type, options_dict):
                     options_dict["with_grid_search"]
                     and not options_dict["with_multiple_objectives"]
                 ):
-                    expected_save_args = (join(output_dir, f"{job_name}_fold{fold_idx+1}.model"),)
+                    expected_save_args = (output_dir / f"{job_name}_fold{fold_idx+1}.model",)
                 else:
                     expected_save_args = (
-                        join(
-                            output_dir,
-                            f"{job_name}_{objectives[objective_idx]}_fold{fold_idx+1}.model",
-                        ),
+                        output_dir
+                        / f"{job_name}_{objectives[objective_idx]}_fold{fold_idx+1}.model",
                     )
+
                 eq_(actual_call[0], expected_save_args)
 
     # stop all the patchers

--- a/tests/test_voting_learners_expts_5.py
+++ b/tests/test_voting_learners_expts_5.py
@@ -30,9 +30,9 @@ from tests.utils import (
 
 
 def setup():
-    """Set up the tests"""
+    """Set up the tests."""
     for dir_path in [train_dir, test_dir, output_dir]:
-        Path(dir_path).mkdir(exist_ok=True)
+        dir_path.mkdir(exist_ok=True)
 
     # create the training and test data files that we will use
     create_jsonlines_feature_files(train_dir)
@@ -40,14 +40,14 @@ def setup():
 
 
 def tearDown():
-    """Clean up after tests"""
-    for output_file_path in Path(output_dir).glob("test_voting_learner_learning_curve*"):
+    """Clean up after tests."""
+    for output_file_path in output_dir.glob("test_voting_learner_learning_curve*"):
         output_file_path.unlink()
 
     for output_file_path in Path(".").glob("test_voting_learner_learning_curve*"):
         output_file_path.unlink()
 
-    config_file_path = Path(config_dir) / "test_voting_learner_learning_curve.cfg"
+    config_file_path = config_dir / "test_voting_learner_learning_curve.cfg"
     config_file_path.unlink()
 
     remove_jsonlines_feature_files(train_dir)
@@ -55,8 +55,7 @@ def tearDown():
 
 
 def check_learning_curve_task(learner_type, options_dict):
-    """Check given combination of prediction configuration options"""
-
+    """Check given combination of prediction configuration options."""
     # create a configuration file with the given options
     (
         config_path,


### PR DESCRIPTION
- Update all code to use `pathlib.Path` instead of `os.path.*` where possible. 
- Add `pyproject.toml`. 
- Fix docstrings to pass pydocstyle pre-commit checks.
- Update `.pre-commit-config.yaml` to specify more flags for `ruff` so that it can cover pydocstyle, isort, and flake8 checks. 
- Other minor changes: replace unused variables with `_` etc. 

This PR closes #637. 