### PR TITLE
Migrate to new codecov uploader.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ variables:
     - echo "except ImportError:" >> sitecustomize.py
     - echo "    pass" >> sitecustomize.py
   script:
-    - "/root/sklldev/bin/nosetests --with-coverage --cover-package=skll ${TESTFILES}"
+    - "/root/sklldev/bin/nosetests --with-coverage --cover-package=skll --cover-xml ${TESTFILES}"
   after_script:
     - /root/sklldev/bin/codecov
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,9 @@ variables:
 # set up the basic job
 .runtests:
   before_script:
-    - "conda create --prefix /root/sklldev --channel conda-forge --file requirements.txt python=${PYVERSION} codecov --yes --quiet"
-    - /root/sklldev/bin/pip install -e .
+    - "conda create --prefix /root/sklldev --channel conda-forge --file requirements.txt python=${PYVERSION} --yes --quiet"
+    - curl -o /root/sklldev/bin/codecov https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x /root/sklldev/bin/codecov
     - echo "import os" > sitecustomize.py
     - echo "try:" >> sitecustomize.py
     - echo "    import coverage" >> sitecustomize.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,8 @@ variables:
 # set up the basic job
 .runtests:
   before_script:
-    - "conda create --prefix /root/sklldev --channel conda-forge --file requirements.txt python=${PYVERSION} --yes --quiet"
-    - curl -o /root/sklldev/bin/codecov https://uploader.codecov.io/latest/linux/codecov
+    - "conda create --prefix /root/sklldev --channel conda-forge --file requirements.txt python=${PYVERSION} curl --yes --quiet"
+    - /root/sklldev/bin/curl -o /root/sklldev/bin/codecov https://uploader.codecov.io/latest/linux/codecov
     - chmod +x /root/sklldev/bin/codecov
     - echo "import os" > sitecustomize.py
     - echo "try:" >> sitecustomize.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ variables:
 .runtests:
   before_script:
     - "conda create --prefix /root/sklldev --channel conda-forge --file requirements.txt python=${PYVERSION} curl --yes --quiet"
+    - /root/sklldev/bin/pip install -e .
     - /root/sklldev/bin/curl -o /root/sklldev/bin/codecov https://uploader.codecov.io/latest/linux/codecov
     - chmod +x /root/sklldev/bin/codecov
     - echo "import os" > sitecustomize.py

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -1013,7 +1013,7 @@ def _setup_config_parser(config_path, validate=True):
 
     Raises
     ------
-    IOError
+    FileNotFoundError
         If the configuration file does not exist.
     """
     # initialize config parser with the given defaults
@@ -1024,7 +1024,7 @@ def _setup_config_parser(config_path, validate=True):
 
     # Read file if it exists
     if not config_path.exists():
-        raise FileNotFoundError("The configuration file {config_path} does not exist.")
+        raise FileNotFoundError(f"The configuration file {config_path} does not exist.")
 
     config.read(config_path)
 

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -1077,9 +1077,10 @@ class ARFFReader(DelimitedReader):
 
 def safe_float(text, replace_dict=None, logger=None):
     """
-    Convert string to int and then float.
+    Convert string to a float.
 
-    If neither is possible, return the original string value.
+    It first tries to convert to an integer and then to a float if that fails.
+    If neither is possible, the originals string value is returned.
 
     Parameters
     ----------

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -1734,7 +1734,7 @@ class Learner(object):
         """
         Generate learning curves for the learner using the examples.
 
-        The learning curves arge generated on the training examples
+        The learning curves are generated on the training examples
         via cross-validation. Adapted from the scikit-learn code for learning
         curve generation (cf.``sklearn.model_selection.learning_curve``).
 

--- a/skll/learner/utils.py
+++ b/skll/learner/utils.py
@@ -456,7 +456,7 @@ def compute_num_folds_from_example_counts(cv_folds, labels, model_type, logger=N
 
 def contiguous_ints_or_floats(numbers):
     """
-    Check for continuity in given list of numbers.
+    Check for continuity in the given list of numbers.
 
     Check whether the given list of numbers contains
     contiguous integers or contiguous integer-like
@@ -506,7 +506,7 @@ def contiguous_ints_or_floats(numbers):
 
 def get_acceptable_classification_metrics(label_array):
     """
-    Return acceptable metrics given the the unique set of labels being classified.
+    Return acceptable metrics given the unique set of labels being classified.
 
     Parameters
     ----------

--- a/skll/utils/commandline/plot_learning_curves.py
+++ b/skll/utils/commandline/plot_learning_curves.py
@@ -49,7 +49,7 @@ def main(argv=None):
     logging.captureWarnings(True)
     logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - " "%(message)s")
 
-    # conver to Path objects
+    # convert to Path objects
     tsv_file = Path(args.tsv_file)
     output_dir = Path(args.output_dir)
 


### PR DESCRIPTION
- Use the latest version of codecov report uploader. 
- Install `curl` in the environment since it's needed to get the uploader.
- Typo fixes from last PR that didn't get merged (sorry). 

This PR closes #726.