### PR TITLE
Add type hints to `skll.config` module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,7 @@ repos:
     hooks:
       - id: ruff
         args: [--line-length=100, --select, "D,E,F,I", --ignore, "D212", --per-file-ignores, "tests/test*.py:D103"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.2.0'
+    hooks:
+      - id: mypy

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -12,6 +12,7 @@ import configparser
 import itertools
 import logging
 import os
+from numbers import Number
 from os.path import basename, join
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -20,6 +21,7 @@ import numpy as np
 import ruamel.yaml as yaml
 
 from skll.data.readers import safe_float
+from skll.types import FoldMapping, PathOrStr
 from skll.utils.constants import (
     PROBABILISTIC_METRICS,
     VALID_FEATURE_SCALING_OPTIONS,
@@ -273,7 +275,7 @@ class SKLLConfigParser(configparser.ConfigParser):
 
 
 def parse_config_file(
-    config_path: Union[str, Path], log_level=logging.INFO
+    config_path: PathOrStr, log_level=logging.INFO
 ) -> Tuple[
     str,
     str,
@@ -299,8 +301,8 @@ def parse_config_file(
     int,
     str,
     Optional[int],
-    Optional[Union[int, Dict[Union[float, str], str]]],
-    Optional[Union[int, Dict[Union[float, str], str]]],
+    Optional[Union[int, FoldMapping]],
+    Optional[Union[int, FoldMapping]],
     int,
     bool,
     bool,
@@ -319,7 +321,7 @@ def parse_config_file(
     str,
     str,
     List[int],
-    Union[List[float], List[int]],
+    List[Number],
     List[str],
     bool,
 ]:
@@ -330,7 +332,7 @@ def parse_config_file(
 
     Parameters
     ----------
-    config_path : Union[str, Path]
+    config_path : PathOrStr
         The path to the configuration file.
 
     log_level : int, default=logging.INFO
@@ -422,7 +424,7 @@ def parse_config_file(
     grid_search_jobs : Optional[int]
         Number of folds to run in parallel when using grid search.
 
-    grid_search_folds : Optional[Union[int, Dict[Union[float, str], str]]]
+    grid_search_folds : Optional[Union[int, FoldMapping]]
         Folds to use for grid search. This may be:
         - `None`: if no grid search is to be done
         - `int`: an integer specifying how many folds to use
@@ -430,7 +432,7 @@ def parse_config_file(
           in the data to fold IDs. Example IDs may be either strings or
           floats depending on the value of `ids_to_floats`.
 
-    cv_folds : Optional[Union[int, Dict[Union[float, str], str]]]
+    cv_folds : Optional[Union[int, FoldMapping]]
         Folds to use for cross-validation. This may be:
         - `None`: if no cross-validation is to be done
         - `int`: an integer specifying how many folds to use
@@ -496,7 +498,7 @@ def parse_config_file(
     learning_curve_cv_folds_list : List[int]
         A list of integers specifying the number of folds to use for CV.
 
-    learning_curve_train_sizes : Union[List[float], List[int]]
+    learning_curve_train_sizes : List[Number]
         List of floats or integers representing relative or absolute numbers
         of training examples that will be used to generate the learning
         curve respectively.
@@ -911,7 +913,7 @@ def parse_config_file(
     # the folds can either be a None, or number, or a mapping
     # from example IDs to fold IDs; we initialize to the specified
     # number to start with
-    grid_search_folds: Optional[Union[int, Dict[Union[float, str], str]]] = config.getint(
+    grid_search_folds: Optional[Union[int, FoldMapping]] = config.getint(
         "Tuning", "grid_search_folds"
     )
 
@@ -1070,7 +1072,7 @@ def parse_config_file(
     )
 
 
-def _setup_config_parser(config_path: Union[str, Path], validate=True) -> SKLLConfigParser:
+def _setup_config_parser(config_path: PathOrStr, validate=True) -> SKLLConfigParser:
     """
     Return a config parser at a given path.
 
@@ -1078,7 +1080,7 @@ def _setup_config_parser(config_path: Union[str, Path], validate=True) -> SKLLCo
 
     Parameters
     ----------
-    config_path : Union[str, Path]
+    config_path : PathOrStr
         The path to the configuration file.
 
     validate : bool, default=True

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -1019,7 +1019,6 @@ def parse_config_file(
     train_set_name = basename(train_path)
     test_set_name = basename(test_path) if test_path else "cv"
 
-    __import__("ipdb").set_trace()
     return (
         experiment_name,
         task,

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -428,7 +428,7 @@ def parse_config_file(
         Folds to use for grid search. This may be:
         - `None`: if no grid search is to be done
         - `int`: an integer specifying how many folds to use
-        - `Dict[Union[float, str], str]`: a dictionary mapping example IDs
+        - `FoldMapping`: a dictionary mapping example IDs
           in the data to fold IDs. Example IDs may be either strings or
           floats depending on the value of `ids_to_floats`.
 
@@ -436,7 +436,7 @@ def parse_config_file(
         Folds to use for cross-validation. This may be:
         - `None`: if no cross-validation is to be done
         - `int`: an integer specifying how many folds to use
-        - `Dict[Union[float, str], str]`: a dictionary mapping example IDs
+        - `FoldMapping`: a dictionary mapping example IDs
           in the data to fold IDs. Example IDs may be either strings or
           floats depending on the value of `ids_to_floats`.
 

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -280,7 +280,7 @@ def parse_config_file(
     str,
     str,
     str,
-    List[Dict[str, Any]],
+    Dict[str, Any],
     bool,
     int,
     str,
@@ -353,7 +353,7 @@ def parse_config_file(
     sampler : str
         The name of a sampler to perform non-linear transformations of the input.
 
-    fixed_sampler_parameters : List[Dict[str, Any]]
+    fixed_sampler_parameters : Dict[str, Any]
         A dictionary containing parameters you want to have fixed for the sampler.
 
     feature_hasher : bool
@@ -486,7 +486,7 @@ def parse_config_file(
 
     class_map : Optional[Dict[str, List[str]]]
         A class map collapsing several labels into one. The keys
-        are the collased labels and each key's value is the list of
+        are the collapsed labels and each key's value is the list of
         labels to be collapsed into said label.
 
     custom_learner_path : str

--- a/skll/config/utils.py
+++ b/skll/config/utils.py
@@ -11,11 +11,14 @@ import csv
 import errno
 import logging
 from pathlib import Path
+from typing import Dict, List, Union
 
 import ruamel.yaml as yaml
 
+from skll.data import FeatureSet
 
-def fix_json(json_string):
+
+def fix_json(json_string: str) -> str:
     """
     Fix incorrectly formatted quotes and capitalized booleans in given JSON string.
 
@@ -26,7 +29,7 @@ def fix_json(json_string):
 
     Returns
     -------
-    json_string : str
+    str
         The normalized JSON string.
     """
     json_string = json_string.replace("True", "true")
@@ -35,7 +38,9 @@ def fix_json(json_string):
     return json_string
 
 
-def load_cv_folds(folds_file, ids_to_floats=False):
+def load_cv_folds(
+    folds_file: Union[str, Path], ids_to_floats=False
+) -> Dict[Union[float, str], str]:
     """
     Load cross-validation folds from a CSV file.
 
@@ -51,8 +56,10 @@ def load_cv_folds(folds_file, ids_to_floats=False):
 
     Returns
     -------
-    res : dict
-        A dictionary with example IDs as the keys and fold IDs as the values.
+    res : Dict[Union[float, str], str]
+        Dictionary with example IDs as the keys and fold IDs as the values.
+        If `ids_to_floats` is set to `True`, the example IDs are floats but
+        otherwise they are strings.
 
     Raises
     ------
@@ -64,21 +71,23 @@ def load_cv_folds(folds_file, ids_to_floats=False):
         next(reader)  # discard the header
         res = {}
         for row in reader:
+            example_id: Union[float, str] = row[0]
+            fold_id: str = row[1]
             if ids_to_floats:
                 try:
-                    row[0] = float(row[0])
+                    example_id = float(example_id)
                 except ValueError:
                     raise ValueError(
                         "You set ids_to_floats to true, but ID "
                         f"{row[0]} could not be converted to "
                         "float"
                     )
-            res[row[0]] = row[1]
+            res[example_id] = fold_id
 
     return res
 
 
-def locate_file(file_path, config_dir):
+def locate_file(file_path: Union[str, Path], config_dir: Union[str, Path]) -> str:
     """
     Locate a file, given a file path and configuration directory.
 
@@ -117,7 +126,7 @@ def locate_file(file_path, config_dir):
         return str(path_to_check)
 
 
-def _munge_featureset_name(featureset):
+def _munge_featureset_name(featureset: FeatureSet) -> str:
     """
     Create a munged name for the featureset.
 
@@ -141,7 +150,7 @@ def _munge_featureset_name(featureset):
     return res
 
 
-def _parse_and_validate_metrics(metrics, option_name, logger=None):
+def _parse_and_validate_metrics(metrics: str, option_name: str, logger=None) -> List[str]:
     """
     Parse and validate string containing list of metrics.
 

--- a/skll/config/utils.py
+++ b/skll/config/utils.py
@@ -11,11 +11,12 @@ import csv
 import errno
 import logging
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import List, Union
 
 import ruamel.yaml as yaml
 
 from skll.data import FeatureSet
+from skll.types import FoldMapping, PathOrStr
 
 
 def fix_json(json_string: str) -> str:
@@ -38,9 +39,7 @@ def fix_json(json_string: str) -> str:
     return json_string
 
 
-def load_cv_folds(
-    folds_file: Union[str, Path], ids_to_floats=False
-) -> Dict[Union[float, str], str]:
+def load_cv_folds(folds_file: PathOrStr, ids_to_floats=False) -> FoldMapping:
     """
     Load cross-validation folds from a CSV file.
 
@@ -48,7 +47,7 @@ def load_cv_folds(
 
     Parameters
     ----------
-    folds_file : Union[str, Path]
+    folds_file : PathOrStr
         The path to a folds file to read.
 
     ids_to_floats : bool, default=False
@@ -56,7 +55,7 @@ def load_cv_folds(
 
     Returns
     -------
-    res : Dict[Union[float, str], str]
+    res : FoldMapping
         Dictionary with example IDs as the keys and fold IDs as the values.
         If `ids_to_floats` is set to `True`, the example IDs are floats but
         otherwise they are strings.
@@ -87,16 +86,16 @@ def load_cv_folds(
     return res
 
 
-def locate_file(file_path: Union[str, Path], config_dir: Union[str, Path]) -> str:
+def locate_file(file_path: PathOrStr, config_dir: PathOrStr) -> str:
     """
     Locate a file, given a file path and configuration directory.
 
     Parameters
     ----------
-    file_path : Union[str, Path]
+    file_path : PathOrStr
         The file to locate. Path may be absolute or relative.
 
-    config_dir : Union[str, Path]
+    config_dir : PathOrStr
         The path to the configuration file directory.
 
     Returns

--- a/skll/types.py
+++ b/skll/types.py
@@ -1,0 +1,16 @@
+# License: BSD 3 clause
+"""
+Custom type annotations for readability.
+
+:author: Nitin Madnani (nmadnani@ets.org)
+"""
+
+from pathlib import Path
+from typing import Dict, Union
+
+# a string path or Path object
+PathOrStr = Union[Path, str]
+
+# a mapping from example ID to fold ID;
+# the example ID may be a float or a str
+FoldMapping = Dict[Union[float, str], str]


### PR DESCRIPTION
- Add `mypy` pre-commit check.
- Add type hints to `skll/config/__init.py` and `skll/config/utils.py`.
- Minor code changes to make improve static typing of the code.
- Update docstrings to use the actual type hints. 

This is the first PR in support of #561, with many more to come. 