### PR TITLE
Add type hints in`skll.utils` module and in all other remaining files. 

### DIFF
--- a/skll/data/featureset.py
+++ b/skll/data/featureset.py
@@ -29,11 +29,11 @@ class FeatureSet(object):
     name : str
         The name of this feature set.
 
-    ids :list or  np.array of shape (n_ids,)
+    ids : Union[List[str], numpy.ndarray]
         Example IDs for this set.
 
-    labels : np.array of shape (n_labels,), default=None
-        labels for this set.
+    labels : Optional[Union[List[str], numpy.ndarray], default=None
+        Labels for this set.
 
     features : Optional[Union[FeatureDictList, np.ndarray]], default=None
         The features for each instance represented as either a

--- a/skll/data/writers.py
+++ b/skll/data/writers.py
@@ -565,7 +565,9 @@ class ARFFWriter(Writer):
         super(ARFFWriter, self).__init__(path, feature_set, **kwargs)
         self._dict_writer: Optional[DictWriter[str]] = None
 
-    def _write_header(self, feature_set: FeatureSet, output_file: IO[str], filter_features) -> None:
+    def _write_header(
+        self, feature_set: FeatureSet, output_file: IO[str], filter_features: Set[str]
+    ) -> None:
         """
         Write headers to ARFF file.
 
@@ -577,10 +579,10 @@ class ARFFWriter(Writer):
         feature_set : skll.data.FeatureSet
             The FeatureSet being written to a file.
 
-        output_file : file buffer
+        output_file : IO[str]
             The file being written to.
 
-        filter_features : set of str
+        filter_features : Set[str]
             If only writing a subset of the features in the
             FeatureSet to ``output_file``, these are the
             features to include in this file.

--- a/skll/metrics.py
+++ b/skll/metrics.py
@@ -12,18 +12,26 @@ import sys
 from importlib import import_module
 from inspect import signature
 from pathlib import Path
+from typing import Optional, Union
 
 import numpy as np
 from scipy.stats import kendalltau, pearsonr, spearmanr
 from sklearn.metrics import confusion_matrix, f1_score, make_scorer
 from sklearn.metrics._scorer import _SCORERS
 
+from skll.types import PathOrStr
+
 # a set that will hold the names of any custom metrics;
 # this is a private variable only meant for internal use
 _CUSTOM_METRICS = set()
 
 
-def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
+def kappa(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    weights: Optional[Union[str, np.ndarray]] = None,
+    allow_off_by_one: bool = False,
+) -> float:
     """
     Calculate the kappa inter-rater agreement.
 
@@ -43,35 +51,33 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
 
     Parameters
     ----------
-    y_true : array-like of float
+    y_true : numpy.ndarray
         The true/actual/gold labels for the data.
-    y_pred : array-like of float
+    y_pred : numpy.ndarray
         The predicted/observed labels for the data.
-    weights : str or np.array, optional
+    weights : Optional[Union[str, numpy.ndarray]]
         Specifies the weight matrix for the calculation.
         Options are ::
-
             -  None = unweighted-kappa
-            -  'quadratic' = quadratic-weighted kappa
-            -  'linear' = linear-weighted kappa
+            -  "quadratic" = quadratic-weighted kappa
+            -  "linear" = linear-weighted kappa
             -  two-dimensional numpy array = a custom matrix of
-
-        weights. Each weight corresponds to the
-        :math:`w_{ij}` values in the wikipedia description
-        of how to calculate weighted Cohen's kappa.
-        Defaults to None.
-    allow_off_by_one : bool, optional
+               weights. Each weight corresponds to the
+               :math:`w_{ij}` values in the wikipedia description
+               of how to calculate weighted Cohen's kappa.
+        Defaults to ``None``.
+    allow_off_by_one : bool
         If true, ratings that are off by one are counted as
         equal, and all other differences are reduced by
         one. For example, 1 and 2 will be considered to be
         equal, whereas 1 and 3 will have a difference of 1
         for when building the weights matrix.
-        Defaults to False.
+        Defaults to ``False``.
 
     Returns
     -------
-    k : float
-        The kappa score, or weighted kappa score.
+    float
+        The weighted or unweighted kappa score.
 
     Raises
     ------
@@ -93,8 +99,8 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
     # If it is a str that can't be typecast, then the user is
     # given a hopefully useful error message.
     try:
-        y_true = [int(np.round(float(y))) for y in y_true]
-        y_pred = [int(np.round(float(y))) for y in y_pred]
+        y_true = np.array([int(np.round(float(y))) for y in y_true])
+        y_pred = np.array([int(np.round(float(y))) for y in y_pred])
     except ValueError:
         raise ValueError(
             "For kappa, the labels should be integers or strings"
@@ -108,8 +114,8 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
 
     # shift the values so that the lowest value is 0
     # (to support scales that include negative values)
-    y_true = [y - min_rating for y in y_true]
-    y_pred = [y - min_rating for y in y_pred]
+    y_true = y_true - min_rating
+    y_pred = y_pred - min_rating
 
     # Build the observed/confusion matrix
     num_ratings = max_rating - min_rating + 1
@@ -122,25 +128,28 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
         weights = None
     else:
         wt_scheme = ""
+
     if weights is None:
-        weights = np.empty((num_ratings, num_ratings))
+        kappa_weights = np.empty((num_ratings, num_ratings))
         for i in range(num_ratings):
             for j in range(num_ratings):
                 diff = abs(i - j)
                 if allow_off_by_one and diff:
                     diff -= 1
                 if wt_scheme == "linear":
-                    weights[i, j] = diff
+                    kappa_weights[i, j] = diff
                 elif wt_scheme == "quadratic":
-                    weights[i, j] = diff**2
+                    kappa_weights[i, j] = diff**2
                 elif not wt_scheme:  # unweighted
-                    weights[i, j] = bool(diff)
+                    kappa_weights[i, j] = bool(diff)
                 else:
                     raise ValueError("Invalid weight scheme specified for " f"kappa: {wt_scheme}")
+    else:
+        kappa_weights = weights
 
-    hist_true = np.bincount(y_true, minlength=num_ratings)
+    hist_true: np.ndarray = np.bincount(y_true, minlength=num_ratings)
     hist_true = hist_true[:num_ratings] / num_scored_items
-    hist_pred = np.bincount(y_pred, minlength=num_ratings)
+    hist_pred: np.ndarray = np.bincount(y_pred, minlength=num_ratings)
     hist_pred = hist_pred[:num_ratings] / num_scored_items
     expected = np.outer(hist_true, hist_pred)
 
@@ -149,13 +158,15 @@ def kappa(y_true, y_pred, weights=None, allow_off_by_one=False):
 
     # If all weights are zero, that means no disagreements matter.
     k = 1.0
-    if np.count_nonzero(weights):
-        k -= sum(sum(weights * observed)) / sum(sum(weights * expected))
+    if np.count_nonzero(kappa_weights):
+        observed_sum = np.sum(kappa_weights * observed)
+        expected_sum = np.sum(kappa_weights * expected)
+        k -= np.sum(observed_sum) / np.sum(expected_sum)
 
     return k
 
 
-def correlation(y_true, y_pred, corr_type="pearson"):
+def correlation(y_true: np.ndarray, y_pred: np.ndarray, corr_type: str = "pearson") -> float:
     """
     Calculate given correlation type between ``y_true`` and ``y_pred``.
 
@@ -169,19 +180,18 @@ def correlation(y_true, y_pred, corr_type="pearson"):
 
     Parameters
     ----------
-    y_true : array-like of float
+    y_true : numpy.ndarray
         The true/actual/gold labels for the data.
-    y_pred : array-like of float
+    y_pred : numpy.ndarray
         The predicted/observed labels for the data.
-    corr_type : str, optional
+    corr_type : str
         Which type of correlation to compute. Possible
-        choices are ``pearson``, ``spearman``,
-        and ``kendall_tau``.
-        Defaults to ``pearson``.
+        choices are "pearson", "spearman", and "kendall_tau".
+        Defaults to "pearson".
 
     Returns
     -------
-    ret_score : float
+    float
         correlation value if well-defined, else 0.0
     """
     # get the correlation function to use based on the given type
@@ -204,38 +214,37 @@ def correlation(y_true, y_pred, corr_type="pearson"):
     return ret_score
 
 
-def f1_score_least_frequent(y_true, y_pred):
+def f1_score_least_frequent(y_true: np.ndarray, y_pred: np.ndarray) -> float:
     """
     Calculate F1 score of the least frequent label/class.
 
     Parameters
     ----------
-    y_true : array-like of float
+    y_true : numpy.ndarray
         The true/actual/gold labels for the data.
-    y_pred : array-like of float
+    y_pred : numpy.ndarray
         The predicted/observed labels for the data.
 
     Returns
     -------
-    ret_score : float
+    float
         F1 score of the least frequent label.
     """
     least_frequent = np.bincount(y_true).argmin()
     return f1_score(y_true, y_pred, average=None)[least_frequent]
 
 
-def register_custom_metric(custom_metric_path, custom_metric_name):
+def register_custom_metric(custom_metric_path: PathOrStr, custom_metric_name: str):
     """
     Import, load, and register the custom metric function from the given path.
 
     Parameters
     ----------
-    custom_metric_path : Union[str, Path]
+    custom_metric_path : PathOrStr
         The path to a custom metric.
     custom_metric_name : str
-        The name of the custom metric function to load.
-        This function must take only two array-like
-        arguments: the true labels and the predictions,
+        The name of the custom metric function to load. This function must take
+        only two array-like arguments: the true labels and the predictions,
         in that order.
 
     Raises
@@ -294,8 +303,10 @@ def register_custom_metric(custom_metric_path, custom_metric_name):
     make_scorer_kwargs = {}
     for make_scorer_kwarg in ["greater_is_better", "needs_proba", "needs_threshold"]:
         if make_scorer_kwarg in metric_func_parameters:
-            parameter_value = metric_func_parameters.get(make_scorer_kwarg).default
-            make_scorer_kwargs.update({make_scorer_kwarg: parameter_value})
+            parameter = metric_func_parameters.get(make_scorer_kwarg)
+            if parameter is not None:
+                parameter_value = parameter.default
+                make_scorer_kwargs.update({make_scorer_kwarg: parameter_value})
 
     # make the scorer function with the extracted keyword arguments
     # and add it to the `CUSTOM_METRICS` set
@@ -305,7 +316,7 @@ def register_custom_metric(custom_metric_path, custom_metric_name):
     return metric_func
 
 
-def use_score_func(func_name, y_true, y_pred):
+def use_score_func(func_name: str, y_true: np.ndarray, y_pred: np.ndarray) -> float:
     """
     Call the given scoring function.
 
@@ -317,14 +328,14 @@ def use_score_func(func_name, y_true, y_pred):
     ----------
     func_name : str
         The name of the objective function to use.
-    y_true : array-like of float
+    y_true : numpy.ndarray
         The true/actual/gold labels for the data.
-    y_pred : array-like of float
+    y_pred : numpy.ndarray
         The predicted/observed labels for the data.
 
     Returns
     -------
-    ret_score : float
+    float
         The scored result from the given scorer.
     """
     scorer = _SCORERS[func_name]

--- a/skll/metrics.py
+++ b/skll/metrics.py
@@ -57,14 +57,11 @@ def kappa(
         The predicted/observed labels for the data.
     weights : Optional[Union[str, numpy.ndarray]]
         Specifies the weight matrix for the calculation.
-        Options are ::
-            -  None = unweighted-kappa
-            -  "quadratic" = quadratic-weighted kappa
-            -  "linear" = linear-weighted kappa
-            -  two-dimensional numpy array = a custom matrix of
-               weights. Each weight corresponds to the
-               :math:`w_{ij}` values in the wikipedia description
-               of how to calculate weighted Cohen's kappa.
+        Possible values are: ``None`` (unweighted-kappa), ``"quadratic"``
+        (quadratically weighted kappa), ``"linear"`` (linearly weighted kappa),
+        and a two-dimensional numpy array (a custom matrix of weights). Each
+        weight in this array corresponds to the :math:`w_{ij}` values in the
+        Wikipedia description of how to calculate weighted Cohen's kappa.
         Defaults to ``None``.
     allow_off_by_one : bool
         If true, ratings that are off by one are counted as

--- a/skll/utils/commandline/compute_eval_from_predictions.py
+++ b/skll/utils/commandline/compute_eval_from_predictions.py
@@ -35,7 +35,7 @@ def get_prediction_from_probabilities(
     """
     Convert a list of class-probabilities into a class prediction.
 
-    If the prediction method is 'expected_value', the class labels must be integers.
+    If the prediction method is ``"expected_value"``, the class labels must be integers.
 
     Parameters
     ----------
@@ -46,12 +46,12 @@ def get_prediction_from_probabilities(
     prediction_method: str
         Indicates how to get a single class prediction from the probabilities.
         Must be one of:
-            1. "highest": Selects the class with the highest probability. If
+            1. ``"highest"``: Selects the class with the highest probability. If
                multiple classes have the same probability, a class is selected randomly.
-            2. "expected_value": Calculates an expected value over integer classes and
+            2. ``"expected_value"``: Calculates an expected value over integer classes and
                rounds to the nearest int.
     random_state: int
-        Seed for `np.random.RandomState`, used for randomly selecting a class when necessary.
+        Seed for ``np.random.RandomState``, used for randomly selecting a class when necessary.
 
     Returns
     -------
@@ -62,7 +62,7 @@ def get_prediction_from_probabilities(
     ------
     ValueError
         If ``classes`` does not contain integers and ``prediction_method`` is
-        "expected_value".
+        ``"expected_value"``.
 
     """
     prng = np.random.RandomState(random_state)
@@ -98,11 +98,11 @@ def compute_eval_from_predictions(
     predictions_file: PathOrStr
         Path to a SKLL predictions output TSV file with id and prediction column names.
     metric_names: List[str]
-        A list of SKLL metric names (e.g., ["pearson", "unweighted_kappa"]).
+        A list of SKLL metric names (e.g., ``["pearson", "unweighted_kappa"]``).
     prediction_method: Optional[str]
         Indicates how to get a single class prediction from the probabilities.
-        Currently supported options are  "highest", which selects the class
-        with the highest probability, and "expected_value", which calculates
+        Currently supported options are ``"highest"``, which selects the class
+        with the highest probability, and ``"expected_value"``, which calculates
         an expected value over integer classes and rounds to the nearest int.
         If predictions file does not contain probabilities, this should be set
         to ``None``.
@@ -116,8 +116,8 @@ def compute_eval_from_predictions(
     Raises
     ------
     ValueError
-        If the requested prediction method is 'expected_value' but the class names can't
-        be converted to ints.
+        If the requested prediction method is ``"expected_value"`` but
+        the class names can't be converted to ints.
     """
     # convert the examples file and predictions file to a Path
     examples_file = Path(examples_file)

--- a/skll/utils/commandline/compute_eval_from_predictions.py
+++ b/skll/utils/commandline/compute_eval_from_predictions.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python
 # License: BSD 3 clause
 """
-script for computing additional evaluation metrics
+Compute additional evaluation metrics from predictions.
 
 :author: Michael Heilman (mheilman@ets.org)
+:author: Nitin Madnani (nmadnani@ets.org)
 """
 
 import argparse
 import csv
 import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Union
 
-from numpy.random import RandomState
+import numpy as np
 
 from skll.data import Reader, safe_float
 from skll.metrics import use_score_func
+from skll.types import PathOrStr
 from skll.version import __version__
 
 # Make warnings from built-in warnings module get formatted more nicely
@@ -23,17 +27,21 @@ logger = logging.getLogger(__name__)
 
 
 def get_prediction_from_probabilities(
-    classes, probabilities, prediction_method, random_state=1234567890
-):
+    classes: Union[List[int], List[str]],
+    probabilities: List[float],
+    prediction_method: str,
+    random_state: int = 1234567890,
+) -> Union[int, str]:
     """
-    Convert a list of class-probabilities into a class prediction. This function assumes
-    that, if the prediction method is 'expected_value', the class labels are integers.
+    Convert a list of class-probabilities into a class prediction.
+
+    If the prediction method is 'expected_value', the class labels must be integers.
 
     Parameters
     ----------
-    classes: list of str or int
+    classes: Union[List[int], List[str]]
         List of string or integer class names.
-    probabilities: list of float
+    probabilities: List[float]
         List of probabilities for the respective classes.
     prediction_method: str
         Indicates how to get a single class prediction from the probabilities.
@@ -42,56 +50,68 @@ def get_prediction_from_probabilities(
                multiple classes have the same probability, a class is selected randomly.
             2. "expected_value": Calculates an expected value over integer classes and
                rounds to the nearest int.
-
     random_state: int
-        Seed for `RandomState`, used for randomly selecting a class when necessary.
+        Seed for `np.random.RandomState`, used for randomly selecting a class when necessary.
 
     Returns
     -------
-    predicted_class: str or int
-        Predicted class.
+    Union[int, str]
+        The predicted class.
+
+    Raises
+    ------
+    ValueError
+        If ``classes`` does not contain integers and ``prediction_method`` is
+        "expected_value".
 
     """
-    prng = RandomState(random_state)
+    prng = np.random.RandomState(random_state)
     if prediction_method == "highest":
         highest_p = max(probabilities)
         best_classes = [classes[i] for i, p in enumerate(probabilities) if p == highest_p]
         if len(best_classes) > 1:
-            return prng.choice(best_classes)
+            ans = prng.choice(best_classes)
         else:
-            return best_classes[0]
-
+            ans = best_classes[0]
     elif prediction_method == "expected_value":
-        exp_val = sum([classes[i] * prob for i, prob in enumerate(probabilities)])
-        return int(round(exp_val))
+        exp_val = 0.0
+        for class_, probability in zip(classes, probabilities):
+            exp_val += class_ * probability  # type: ignore
+        ans = int(round(exp_val))
+
+    return ans
 
 
 def compute_eval_from_predictions(
-    examples_file, predictions_file, metric_names, prediction_method=None
-):
+    examples_file: PathOrStr,
+    predictions_file: PathOrStr,
+    metric_names: List[str],
+    prediction_method: Optional[str] = None,
+) -> Dict[str, float]:
     """
-    Compute evaluation metrics from prediction files after you have run an
-    experiment.
+    Compute evaluation metrics from prediction files after running an experiment.
 
     Parameters
     ----------
-    examples_file: str
+    examples_file: PathOrStr
         Path to a SKLL examples file (in .jsonlines or other format).
-    predictions_file: str
+    predictions_file: PathOrStr
         Path to a SKLL predictions output TSV file with id and prediction column names.
-    metric_names: list of str
-        A list of SKLL metric names (e.g., [pearson, unweighted_kappa]).
-    prediction_method: str or None
-        Indicates how to get a single class prediction from the probabilities. Currently
-        supported options are  "highest", which selects the class with the highest
-        probability, and "expected_value", which calculates an expected value over
-        integer classes and rounds to the nearest int. If predictions file does not
-        contain probabilities, this should be set to None.
+    metric_names: List[str]
+        A list of SKLL metric names (e.g., ["pearson", "unweighted_kappa"]).
+    prediction_method: Optional[str]
+        Indicates how to get a single class prediction from the probabilities.
+        Currently supported options are  "highest", which selects the class
+        with the highest probability, and "expected_value", which calculates
+        an expected value over integer classes and rounds to the nearest int.
+        If predictions file does not contain probabilities, this should be set
+        to ``None``.
+        Defaults to ``None``.
 
     Returns
     -------
-    dict
-        Maps metrics names to corresponding values.
+    Dict[str, float]
+        Mapping of metrics names to corresponding values.
 
     Raises
     ------
@@ -99,10 +119,14 @@ def compute_eval_from_predictions(
         If the requested prediction method is 'expected_value' but the class names can't
         be converted to ints.
     """
+    # convert the examples file and predictions file to a Path
+    examples_file = Path(examples_file)
+    predictions_file = Path(predictions_file)
 
     # read gold standard labels
     data = Reader.for_path(examples_file).read()
-    gold = dict(zip(data.ids, data.labels))
+    if data.labels is not None:
+        gold = dict(zip(data.ids, data.labels))
 
     # read predictions
     pred = {}
@@ -113,6 +137,7 @@ def compute_eval_from_predictions(
         # If there are more than two columns, assume column 0 contains the ids, and
         # columns 1-n contain class probabilities. Convert them to a class prediction
         # using the specified `method`.
+        classes: Union[List[int], List[str]]
         if len(header) > 2:
             classes = [c for c in header[1:] if c]
             if prediction_method is None:
@@ -126,7 +151,7 @@ def compute_eval_from_predictions(
             for row in reader:
                 probabilities = [safe_float(p) for p in row[1:]]
                 prediction = get_prediction_from_probabilities(
-                    classes, probabilities, prediction_method
+                    classes, probabilities, prediction_method  # type: ignore
                 )
                 pred[row[0]] = safe_float(prediction)
         else:
@@ -151,22 +176,23 @@ def compute_eval_from_predictions(
     for metric_name in metric_names:
         score = use_score_func(
             metric_name,
-            [gold[ex_id] for ex_id in example_ids],
-            [pred[ex_id] for ex_id in example_ids],
+            np.array([gold[ex_id] for ex_id in example_ids]),
+            np.array([pred[ex_id] for ex_id in example_ids]),
         )
         res[metric_name] = score
     return res
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and get things started.
 
     Parameters
     ----------
-    argv: list of str
-        List of arguments, as if specified on the command-line. If None, `sys.argv[1:]`
-        is used instead.
+    argv: Optional[List[str]]
+        List of arguments, as if specified on the command-line. If ``None``,
+        then ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/filter_features.py
+++ b/skll/utils/commandline/filter_features.py
@@ -12,21 +12,23 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import List, Optional
 
 from skll.data.readers import EXT_TO_READER, safe_float
 from skll.data.writers import EXT_TO_WRITER, ARFFWriter, CSVWriter, TSVWriter
 from skll.version import __version__
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
     Handle command line arguments and gets things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/generate_predictions.py
+++ b/skll/utils/commandline/generate_predictions.py
@@ -13,23 +13,26 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import List, Optional, Union
 
 import numpy as np
 
 from skll.data.readers import EXT_TO_READER
 from skll.learner import Learner
+from skll.types import LabelType
 from skll.version import __version__
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None):
     """
     Handle command line arguments and gets things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(
@@ -199,9 +202,10 @@ def main(argv=None):
             # on the predictions we have so far
 
             # Threshold the positive class label probability
+            predictions: Union[np.ndarray, List[LabelType]]
             if args.threshold is not None:
                 predictions = []
-                for neg_label_prob, pos_label_prob in original_predictions:
+                for _, pos_label_prob in original_predictions:
                     chosen_label = pos_label if pos_label_prob >= args.threshold else neg_label
                     predictions.append(chosen_label)
 
@@ -210,7 +214,6 @@ def main(argv=None):
                 predictions = original_predictions
 
             # now initialize the output file
-            outputfh = None
             try:
                 outputfh = open(args.output_file, "a") if args.output_file else sys.stdout
 

--- a/skll/utils/commandline/join_features.py
+++ b/skll/utils/commandline/join_features.py
@@ -11,21 +11,23 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import List, Optional
 
 from skll.data.readers import EXT_TO_READER
 from skll.data.writers import EXT_TO_WRITER, ARFFWriter, CSVWriter, TSVWriter
 from skll.version import __version__
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
     Handle command line arguments and gets things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/plot_learning_curves.py
+++ b/skll/utils/commandline/plot_learning_curves.py
@@ -19,20 +19,22 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import List, Optional
 
 from skll.experiments import generate_learning_curve_plots
 from skll.version import __version__
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
     Handle command line arguments and gets things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/print_model_weights.py
+++ b/skll/utils/commandline/print_model_weights.py
@@ -12,6 +12,7 @@ import argparse
 import logging
 import sys
 from collections import defaultdict
+from typing import DefaultDict, Dict, List, Optional
 
 import numpy as np
 from sklearn.linear_model import LogisticRegression
@@ -21,17 +22,17 @@ from skll.learner import Learner
 from skll.version import __version__
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and get things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
-
     parser = argparse.ArgumentParser(
         description="Prints out the weights of a" " given model.",
         conflict_handler="resolve",
@@ -75,7 +76,7 @@ def main(argv=None):
         or (isinstance(model, SVC) and model.kernel == "linear")
     ):
         multiclass = True
-    weight_items = weights.items()
+    weight_items = iter(weights.items())
     if args.sign == "positive":
         weight_items = (x for x in weight_items if x[1] > 0)
     elif args.sign == "negative":
@@ -103,7 +104,7 @@ def main(argv=None):
         print()
 
     print("Number of nonzero features:", len(weights), file=sys.stderr)
-    weight_by_class = defaultdict(dict)
+    weight_by_class: DefaultDict[str, Dict[str, float]] = defaultdict(dict)
     if multiclass and args.sort_by_labels:
         for label_feature, weight in weight_items:
             label, feature = label_feature.split()

--- a/skll/utils/commandline/run_experiment.py
+++ b/skll/utils/commandline/run_experiment.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # License: BSD 3 clause
 """
-Runs a bunch of scikit-learn jobs in parallel on the cluster given a
-config file.
+Runs scikit-learn jobs given a config file.
 
 :author: Dan Blanchard (dblanchard@ets.org)
 :author: Michael Heilman (mheilman@ets.org)
@@ -12,22 +11,23 @@ config file.
 
 import logging
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from typing import List, Optional
 
 from skll.experiments import run_configuration
 from skll.version import __version__
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and get things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
-
     # Get command line arguments
     parser = ArgumentParser(
         description="Runs the scikit-learn experiments "

--- a/skll/utils/commandline/skll_convert.py
+++ b/skll/utils/commandline/skll_convert.py
@@ -11,6 +11,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 from bs4 import UnicodeDammit
 
@@ -26,22 +27,23 @@ from skll.data.writers import (
 from skll.version import __version__
 
 
-def _pair_to_dict_tuple(pair):
-    """Consturct mappings from feature/class names to numbers."""
-    number, name = pair.split("=")
-    number = int(number)
+def _pair_to_dict_tuple(pair: str) -> Tuple[str, int]:
+    """Construct mappings from feature/class names to numbers."""
+    number_str, name = pair.split("=")
+    number = int(number_str)
     return (name, number)
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
     Handle command line arguments and gets things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(
@@ -121,6 +123,8 @@ def main(argv=None):
         sys.exit(1)
 
     # Build feature and label vectorizers from existing libsvm file if asked
+    feat_map: Dict[str, int]
+    label_map: Optional[Dict[str, int]]
     if args.reuse_libsvm_map and output_extension == ".libsvm":
         feat_map = {}
         label_map = {}

--- a/skll/utils/commandline/summarize_results.py
+++ b/skll/utils/commandline/summarize_results.py
@@ -1,31 +1,32 @@
 #!/usr/bin/env python
 # License: BSD 3 clause
 """
-Little helper script to create a summary file out of a list of JSON results
-files.
+Create a summary file from a list of JSON results files.
 
 :author: Dan Blanchard (dblanchard@ets.org)
+:author: Nitin Madnani (nmadnani@ets.org)
 :organization: ETS
 """
 
 import argparse
 import logging
+from typing import List, Optional
 
 from skll.experiments.output import _write_summary_file
 from skll.version import __version__
 
 
-def main(argv=None):
+def main(argv: Optional[List[str]] = None) -> None:
     """
-    Handles command line arguments and gets things started.
+    Handle command line arguments and get things started.
 
     Parameters
     ----------
-    argv : list of str
+    argv : Optional[List[str]]
         List of arguments, as if specified on the command-line.
-        If None, ``sys.argv[1:]`` is used instead.
+        If ``None``, ``sys.argv[1:]`` is used instead.
+        Defaults to ``None``.
     """
-
     # Get command line arguments
     parser = argparse.ArgumentParser(
         description="Creates an experiment summary TSV file from a list of "

--- a/skll/utils/logging.py
+++ b/skll/utils/logging.py
@@ -10,6 +10,7 @@ import re
 import warnings
 from functools import partial
 from os.path import sep
+from typing import Optional
 
 orig_showwarning = warnings.showwarning
 SKLEARN_WARNINGS_RE = re.compile(re.escape(f"{sep}sklearn{sep}"))
@@ -19,23 +20,26 @@ def send_sklearn_warnings_to_logger(
     logger, message, category, filename, lineno, file=None, line=None
 ):
     """
-    Return method that sends `sklearn`-specific warnings to a logger
-    that can be used to replace warnings.showwarning (via `partial`,
+    Return method that sends `sklearn`-specific warnings to a logger.
+
+    This method that can be used to replace warnings.showwarning (via `partial`,
     specifying a `logger` instance).
     """
-
     if SKLEARN_WARNINGS_RE.search(filename):
         logger.warning(f"{filename}:{lineno}: {category.__name__}:{message}")
     else:
         orig_showwarning(message, category, filename, lineno, file=file, line=line)
 
 
-def get_skll_logger(name, filepath=None, log_level=logging.INFO):
+def get_skll_logger(
+    name: str, filepath: Optional[str] = None, log_level: int = logging.INFO
+) -> logging.Logger:
     """
-    Create and return logger instances that are appropriate for use
-    in SKLL code, e.g., that they can log to both STDERR as well
-    as a file. This function will try to reuse any previously created
-    logger based on the given name and filepath.
+    Create and return logger instances appropriate for use in SKLL code.
+
+    These logger instances can log to both STDERR as well as a file. This
+    function will try to reuse any previously created logger based on the
+    given name and filepath.
 
     Parameters
     ----------
@@ -55,7 +59,6 @@ def get_skll_logger(name, filepath=None, log_level=logging.INFO):
     logger: logging.Logger
         A ``Logger`` instance.
     """
-
     # first get the logger instance associated with the
     # given name if one already exists
     logger = logging.getLogger(name)
@@ -95,7 +98,6 @@ def close_and_remove_logger_handlers(logger):
     -------
     NoneType
     """
-
     for handler in logger.handlers[:]:
         handler.close()
         logger.removeHandler(handler)


### PR DESCRIPTION
- Add type hints to `skll.utils` package.
- Add type hints to `metrics.py` and `logging.py`.
- Add type hints to `skll.data.*` that were missed in previous PRs.
- Refactor some code as necessary.
- Update all docstrings. 
- Ignore some type errors that are redundant. 


This is the last series of type-hinting PRs and will close #561. 