### PR TITLE
Improve docstrings and type hints (Part 3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: 'v0.0.264'
     hooks:
       - id: ruff
-        args: [--line-length=100, --select, "D,E,F,I", --ignore, "D212", --per-file-ignores, "tests/test*.py:D103,skll/data/featureset.py:E501"]
+        args: [--line-length=100, --select, "D,E,F,I", --ignore, "D212", --per-file-ignores, "tests/test*.py:D103,skll/data/featureset.py:E501,skll/learner/__init__.py:E501,skll/learner/voting.py:E501,skll/learner/utils.py:E501"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.2.0'
     hooks:

--- a/skll/data/readers.py
+++ b/skll/data/readers.py
@@ -205,7 +205,7 @@ class Reader(object):
 
         Parameters
         ----------
-        file
+        file : Ignored
             Not used.
 
         Raises

--- a/skll/data/writers.py
+++ b/skll/data/writers.py
@@ -218,13 +218,13 @@ class Writer(object):
 
         Parameters
         ----------
-        feature_set
+        feature_set : Ignored
             Not used.
 
-        output_file
+        output_file : Ignored
             Not used.
 
-        filter_features
+        filter_features : Ignored
            Not used.
         """
         pass
@@ -235,16 +235,16 @@ class Writer(object):
 
         Parameters
         ----------
-        id_ :
+        id_ : Ignored
             Not used.
 
-        label_
+        label_ : Ignored
             Not used.
 
-        feat_dict
+        feat_dict : Ignored
             Not used.
 
-        output_file
+        output_file : Ignored
              Not used.
 
         Raises
@@ -260,13 +260,13 @@ class Writer(object):
 
         Parameters
         ----------
-        feature_set
+        feature_set : Ignored
             Not used.
 
-        output_file
+        output_file : Ignored
             Not used.
 
-        filter_features
+        filter_features : Ignored
             Not used.
 
         Raises
@@ -679,7 +679,7 @@ class ARFFWriter(Writer):
 
         Parameters
         ----------
-        feature_set
+        feature_set : Ignored
             Not used.
 
         output_file : IO[str]
@@ -739,7 +739,7 @@ class ARFFWriter(Writer):
         feat_dict : :class:`skll.types.FeatureDict`
             The feature dictionary for the current instance.
 
-        output_file
+        output_file : Ignored.
             Not used.
 
         Raises

--- a/skll/experiments/__init__.py
+++ b/skll/experiments/__init__.py
@@ -8,6 +8,8 @@ Functions for running and interacting with SKLL experiments.
 :author: Chee Wee Leong (cleong@ets.org)
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import logging
@@ -61,19 +63,17 @@ __all__ = ["generate_learning_curve_plots", "load_featureset", "run_configuratio
 
 def _classify_featureset(args: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
-    Classification job to be submitted to grid.
+    Run classification job.
 
     Parameters
     ----------
     args : Dict[str, Any]
-        A dictionary with arguments for classifying the
-        ``FeatureSet`` instance.
+        A dictionary with arguments for classifying the ``FeatureSet`` instance.
 
     Returns
     -------
     res : List[Dict[str, Any]]
-        The results of the classification, in the format
-        of a list of dictionaries.
+        The results of the classification, in the format of a list of dictionaries.
 
     Raises
     ------
@@ -620,28 +620,22 @@ def run_configuration(
 
     Parameters
     ----------
-    config_file : PathOrStr
+    config_file : :class:`skll.types.PathOrStr`
         Path to the configuration file we would like to use.
-    local : bool
+    local : bool, default=False
         Should this be run locally instead of on the cluster?
-        Defaults to ``False``.
-    overwrite : bool
+    overwrite : bool, default=True
         If the model files already exist, should we overwrite
         them instead of re-using them?
-        Defaults to ``True``.
-    queue : str
+    queue : str, default="all.q"
         The DRMAA queue to use if we're running on the cluster.
-        Defaults to ``'all.q'``.
-    hosts : Optional[List[str]]
+    hosts : Optional[List[str]], default=None
         If running on the cluster, these are the machines we should use.
-        Defaults to ``None``.
-    write_summary : bool
+    write_summary : bool, default=True
         Write a TSV file with a summary of the results.
-        Defaults to ``True``.
-    quiet : bool
+    quiet : bool, default=False
         Suppress printing of "Loading..." messages.
-        Defaults to ``False``.
-    ablation : int
+    ablation : int, default=0
         Number of features to remove when doing an ablation
         experiment. If positive, we will perform repeated ablation
         runs for all combinations of features removing the
@@ -649,15 +643,12 @@ def run_configuration(
         combinations of all lengths. If 0, the default, no
         ablation is performed. If negative, a ``ValueError`` is
         raised.
-        Defaults to 0.
-    resume : bool
+    resume : bool, default=False
         If result files already exist for an experiment, do not
         overwrite them. This is very useful when doing a large
         ablation experiment and part of it crashes.
-        Defaults to ``False``.
-    log_level : int
+    log_level : int, default=logging.INFO
         The level for logging messages.
-        Defaults to ``logging.INFO``.
 
     Returns
     -------

--- a/skll/experiments/input.py
+++ b/skll/experiments/input.py
@@ -34,50 +34,42 @@ def load_featureset(
 
     Parameters
     ----------
-    dir_path : PathOrStr
+    dir_path : :class:`skll.types.PathOrStr`
         Path to the directory that contains the feature files.
     feat_files : List[str]
         A list of feature file prefixes.
     suffix : str
         The suffix to add to feature file prefixes to get the full filenames.
-    id_col : str
+    id_col : str, default="id"
         Name of the column which contains the instance IDs.
         If no column with that name exists, or `None` is
         specified, example IDs will be automatically generated.
-        Defaults to ``'id'``.
-    label_col : str
+    label_col : str, default="y"
         Name of the column which contains the class labels.
         If no column with that name exists, or `None` is
         specified, the data is considered to be unlabeled.
-        Defaults to ``'y'``.
-    ids_to_floats : bool
+    ids_to_floats : bool, default=False
         Whether to convert the IDs to floats to save memory. Will raise error
         if we encounter non-numeric IDs.
-        Defaults to ``False``.
-    quiet : bool
+    quiet : bool, default=False
         Do not print "Loading..." status message to stderr.
-        Defaults to ``False``.
-    class_map : Optional[ClassMap]
+    class_map : Optional[:class:`skll.types.ClassMap`], default=None
         Mapping from original class labels to new ones. This is
         mainly used for collapsing multiple labels into a single
         class. Anything not in the mapping will be kept the same.
-        Defaults to ``None``.
-    feature_hasher : bool
+    feature_hasher : bool, default=False
         Should we use a FeatureHasher when vectorizing features?
-        Defaults to ``False``.
-    num_features : Optional[int]
+    num_features : Optional[int], default=None
         The number of features to use with the ``FeatureHasher``.
         This should always be set to the power of 2 greater
         than the actual number of features you're using.
-        Defaults to ``None``.
-    logger : Optional[logging.Logger]
+    logger : Optional[logging.Logger], default=None
         A logger instance to use to log messages instead of creating
         a new one by default.
-        Defaults to ``None``.
 
     Returns
     -------
-    merged_set : skll.data.FeatureSet
+    merged_set : :class:`skll.data.featureset.FeatureSet`
         A ``FeatureSet`` instance containing the specified labels, IDs, features,
         and feature vectorizer.
     """

--- a/skll/experiments/output.py
+++ b/skll/experiments/output.py
@@ -221,9 +221,8 @@ def _print_fancy_output(
     ----------
     learner_result_dicts : List[Dict[str, Any]]
         List of result dictionaries.
-    output_file : IO[str]
+    output_file : IO[str], default=sys.stdout
         The file buffer to print to.
-        Defaults to ``sys.stdout``.
     """
     if not learner_result_dicts:
         raise ValueError("Result dictionary list is empty!")
@@ -413,9 +412,8 @@ def _write_summary_file(result_json_paths: List[str], output_file: IO[str], abla
         A list of paths to the individual result JSON files.
     output_file : IO[str]
         The file buffer to write to.
-    ablation : int
+    ablation : int, default=0
         The number of features to remove when doing ablation experiment.
-        Defaults to 0.
     """
     learner_result_dicts = []
     # Map from feature set names to all features in them

--- a/skll/experiments/output.py
+++ b/skll/experiments/output.py
@@ -8,6 +8,8 @@ Functions related to running experiments and parsing configuration files.
 :author: Chee Wee Leong (cleong@ets.org)
 """
 
+from __future__ import annotations
+
 import csv
 import json
 import math
@@ -91,9 +93,9 @@ def generate_learning_curve_plots(
     ----------
     experiment_name : str
         The name of the experiment.
-    output_dir : PathOrStr
+    output_dir : :class:`skll.types.PathOrStr`
         Path to the output directory for the plots.
-    learning_curve_tsv_file : PathOrStr
+    learning_curve_tsv_file : :class:`skll.types.PathOrStr`
         The path to the learning curve TSV file.
     """
     # convert output_dir to Path object

--- a/skll/experiments/utils.py
+++ b/skll/experiments/utils.py
@@ -82,7 +82,7 @@ def _create_learner_result_dicts(
 
     Parameters
     ----------
-    task_results : List[EvaluateTaskResults]
+    task_results : List[:class:`skll.types.EvaluateTaskResults`]
         The task results list.
     grid_scores : Union[List[None], List[float]]
         List of grid scores or a list of ``None`` instances for tasks that do not
@@ -99,8 +99,7 @@ def _create_learner_result_dicts(
     Returns
     -------
     res : List[Dict[str, Any]]
-        The results of the learners, as a list of
-        dictionaries.
+        The results of the learners, as a list of dictionaries.
     """
     res = []
 
@@ -233,16 +232,14 @@ def _get_stat_float(label_result_dict: Dict[str, float], stat: str) -> float:
     Parameters
     ----------
     label_result_dict : Dict[str, float]
-        Dictionary containing the stat we'd like
-        to retrieve for a particular label.
+        Dictionary containing the stats to retrieve for a particular label.
     stat : str
         The statistic we're looking for in the dictionary.
 
     Returns
     -------
     float
-        The value of the stat if it's in the dictionary, and NaN
-        otherwise.
+        The value of the stat if it's in the dictionary, and NaN otherwise.
     """
     if stat in label_result_dict and label_result_dict[stat] is not None:
         return label_result_dict[stat]

--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -122,11 +122,10 @@ class Learner(object):
     model_type : str
         Name of estimator to create (e.g., ``'LogisticRegression'``).
         See the skll package documentation for valid options.
-    probability : bool
+    probability : bool, default=False
         Should learner return probabilities of all
         labels (instead of just label with highest probability)?
-        Defaults to ``False``.
-    pipeline : bool
+    pipeline : bool, default=False
         Should learner contain a pipeline attribute that
         contains a scikit-learn Pipeline object composed
         of all steps including the vectorizer, the feature
@@ -134,19 +133,16 @@ class Learner(object):
         actual estimator. Note that this will increase the
         size of the learner object in memory and also when
         it is saved to disk.
-        Defaults to ``False``.
-    feature_scaling : str
+    feature_scaling : str, default="none"
         How to scale the features, if at all. Options are
         -  'with_std': scale features using the standard deviation
         -  'with_mean': center features using the mean
         -  'both': do both scaling as well as centering
         -  'none': do neither scaling nor centering
-        Defaults to 'none'.
-    model_kwargs : Optional[Dict[str, Any]]
+    model_kwargs : Optional[Dict[str, Any]], default=None
         A dictionary of keyword arguments to pass to the
         initializer for the specified model.
-        Defaults to ``None``.
-    pos_label : Optional[LabelType]
+    pos_label : Optional[:class:`skll.types.LabelType`], default=None
         An integer or string denoting the label of the class to be
         treated as the positive class in a binary classification
         setting. If ``None``, the class represented by the label
@@ -154,29 +150,23 @@ class Learner(object):
         class. For example, if the two labels in data are "A"
         and "B" and ``pos_label`` is not specified, "B" will
         be chosen as the positive class.
-        Defaults to ``None``.
-    min_feature_count : int
+    min_feature_count : int, default=1
         The minimum number of examples a feature
         must have a nonzero value in to be included.
-        Defaults to 1.
-    sampler : Optional[str]
+    sampler : Optional[str], default=None
         The sampler to use for kernel approximation, if desired.
         Valid values are
         -  'AdditiveChi2Sampler'
         -  'Nystroem'
         -  'RBFSampler'
         -  'SkewedChi2Sampler'
-        Defaults to ``None``.
-    sampler_kwargs : Optional[Dict[str, Any]]
+    sampler_kwargs : Optional[Dict[str, Any]], default=None
         A dictionary of keyword arguments to pass to the
         initializer for the specified sampler.
-        Defaults to ``None``.
-    custom_learner_path : Optional[str]
+    custom_learner_path : Optional[str], default=None
         Path to module where a custom classifier is defined.
-        Defaults to ``None``.
-    logger : Optional[logging.Logger]
+    logger : Optional[logging.Logger], default=None
         A logging object. If ``None`` is passed, get logger from ``__name__``.
-        Defaults to ``None``.
     """
 
     def __init__(
@@ -382,15 +372,14 @@ class Learner(object):
 
         Parameters
         ----------
-        learner_path : PathOrStr
+        learner_path : :class:`skll.types.PathOrStr`
             The path to a saved ``Learner`` instance file.
-        logger : Optional[logging.Logger]
+        logger : Optional[logging.Logger], default=None
             A logging object. If ``None`` is passed, get logger from ``__name__``.
-            Defaults to ``None``.
 
         Returns
         -------
-        learner : skll.learner.Learner
+        :class:`skll.learner.Learner`
             The ``Learner`` instance loaded from the file.
         """
         # use the logger that's passed in or if nothing was passed in,
@@ -423,7 +412,7 @@ class Learner(object):
 
         Parameters
         ----------
-        learner_path : PathOrStr
+        learner_path : :class:`skll.types.PathOrStr`
             The path to a saved learner object file to load.
         """
         del self.__dict__
@@ -641,7 +630,7 @@ class Learner(object):
 
         Parameters
         ----------
-        learner_path : PathOrStr
+        learner_path : :class:`skll.types.PathOrStr`
             The path to save the ``Learner`` instance to.
         """
         _save_learner_to_disk(self, learner_path)
@@ -654,7 +643,7 @@ class Learner(object):
         -------
         estimator
             The estimator that was created.
-        default_param_grid : dict
+        default_param_grid : Dict[str, Any]
             The parameter grid for the estimator.
 
         Raises
@@ -693,7 +682,8 @@ class Learner(object):
         Raises
         ------
         ValueError
-            If ``self.feat_vectorizer`` is either ``None`` or a ``FeatureHasher``.
+            If ``self.feat_vectorizer`` is either ``None`` or a
+            :class:`sklearn.feature_extraction.FeatureHasher``.
         """
         if isinstance(self.feat_vectorizer, DictVectorizer):
             return self.feat_vectorizer.get_feature_names_out()[self.feat_selector.get_support()]
@@ -709,7 +699,7 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to use for training.
 
         Raises
@@ -767,7 +757,7 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The examples to use for training.
         """
         # we don't need to do this if we have already done it
@@ -805,7 +795,7 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to use for training.
         """
         # Check feature values and labels
@@ -845,33 +835,27 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to use for training.
-        param_grid : Optional[Dict[str, Any]]
+        param_grid : Optional[Dict[str, Any]], default=None
             The parameter grid to search through for grid
             search. If ``None``, a default parameter grid
             will be used.
-            Defaults to ``None``.
-        grid_search_folds : Union[int, FoldMapping]
+        grid_search_folds : Union[int, :class:`skll.types.FoldMapping`], default=5
             The number of folds to use when doing the
             grid search, or a mapping from example IDs to folds.
-            Defaults to 5.
-        grid_search : bool
+        grid_search : bool, default=True
             Should we do grid search?
-            Defaults to ``True``.
-        grid_objective : Optional[str]
+        grid_objective : Optional[str], default=None
             The name of the objective function to use when
             doing the grid search. Must be specified if
             ``grid_search`` is ``True``.
-            Defaults to ``None``.
-        grid_jobs : Optional[int]
+        grid_jobs : Optional[int], default=None
             The number of jobs to run in parallel when doing the
             grid search. If ``None`` or 0, the number of
             grid search folds will be used.
-            Defaults to ``None``.
-        shuffle : bool
+        shuffle : bool, default=False
             Shuffle examples (e.g., for grid search CV.)
-            Defaults to ``False``.
 
         Returns
         -------
@@ -1195,27 +1179,24 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to evaluate the performance of the
             model on.
-        prediction_prefix : Optional[str]
+        prediction_prefix : Optional[str], default=None
             If not ``None``, predictions will also be written out to a file with
             the name  ``<prediction_prefix>_predictions.tsv``. Note that
             the prefix can also contain a path.
-            Defaults to ``None``.
-        append : bool
+        append : bool, default=False
             Should we append the current predictions to the file if it exists?
-            Defaults to ``False``.
-        grid_objective : Optional[str]
+        grid_objective : Optional[str], default=None
             The objective function that was used when doing the grid search.
-            Defaults to ``None``.
-        output_metrics : List[str]
+        output_metrics : List[str], default=[]
             List of additional metric names to compute in addition to grid
-            objective. Empty by default.
+            objective.
 
         Returns
         -------
-        EvaluateTaskResults
+        :class:`skll.types.EvaluateTaskResults`
             A 6-tuple containing the confusion matrix, the overall accuracy,
             the per-label PRFs, the model parameters, the grid search objective
             function score, and the additional evaluation metrics, if any.
@@ -1313,24 +1294,21 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to predict labels for.
-        prediction_prefix : str, optional
+        prediction_prefix : Optional[str], default=None
             If not ``None``, predictions will also be written out to a file with
             the name  ``<prediction_prefix>_predictions.tsv``. For classifiers,
             the predictions written out are class labels unless the learner is
             probabilistic AND ``class_labels`` is set to ``False``. Note that
             this prefix can also contain a path.
-            Defaults to ``None``.
-        append : bool, optional
+        append : bool, default=False
             Should we append the current predictions to the file if it exists?
-            Defaults to ``False``.
-        class_labels : bool, optional
+        class_labels : bool, default=True
             If ``False``, return either the class probabilities (probabilistic
             classifiers) or the class indices (non-probabilistic ones). If
             ``True``, return the class labels no matter what. Ignored for
             regressors.
-            Defaults to ``True``.
 
         Returns
         -------
@@ -1532,73 +1510,60 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to cross-validate learner performance on.
-        stratified : bool
+        stratified : bool, default=True
             Should we stratify the folds to ensure an even
             distribution of labels for each fold?
-            Defaults to ``True``.
-        cv_folds : Union[int, FoldMapping]
+        cv_folds : Union[int, :class:`skll.types.FoldMapping`], default=10
             The number of folds to use for cross-validation, or
             a mapping from example IDs to folds.
-            Defaults to 10.
-        cv_seed: int
+        cv_seed: int, default=123456789
             The value for seeding the random number generator
             used to create the random folds. Note that this
             seed is *only* used if either ``grid_search`` or
             ``shuffle`` are set to ``True``.
-            Defaults to 123456789.
-        grid_search : bool
+        grid_search : bool, default=True
             Should we do grid search when training each fold?
             Note: This will make this take *much* longer.
-            Defaults to ``True``.
-        grid_search_folds : Union[int, FoldMapping]
+        grid_search_folds : Union[int, :class:`skll.types.FoldMapping`], default=5
             The number of folds to use when doing the
             grid search, or a mapping from example IDs to folds.
-            Defaults to 5.
-        grid_jobs : Optional[int]
+        grid_jobs : Optional[int], default=None
             The number of jobs to run in parallel when doing the
             grid search. If ``None`` or 0, the number of
             grid search folds will be used.
-            Defaults to ``None``.
-        grid_objective : Optional[str]
+        grid_objective : Optional[str], default=None
             The name of the objective function to use when
             doing the grid search. Must be specified if
             ``grid_search`` is ``True``.
-            Defaults to ``None``.
-        output_metrics : List[str]
+        output_metrics : List[str], default = []
             List of additional metric names to compute in
-            addition to the metric used for grid search. Empty by default.
-        prediction_prefix : Optional[str]
+            addition to the metric used for grid search.
+        prediction_prefix : Optional[str], default=None
             If saving the predictions, this is the
             prefix that will be used for the filename.
             It will be followed by ``"_predictions.tsv"``
-            Defaults to ``None``.
-        param_grid : Optional[Dict[str, Any]]
+        param_grid : Optional[Dict[str, Any]], default=None
             The parameter grid to search.
-            Defaults to ``None``.
-        shuffle : bool
+        shuffle : bool, default=False
             Shuffle examples before splitting into folds for CV.
-            Defaults to ``False``.
-        save_cv_folds : bool
+        save_cv_folds : bool, default=True
              Whether to save the cv fold ids or not?
-             Defaults to ``True``.
-        save_cv_models : bool
+        save_cv_models : bool, default=False
             Whether to save the cv models or not?
-            Defaults to ``False``.
-        use_custom_folds_for_grid_search : bool
+        use_custom_folds_for_grid_search : bool, default=True
             If ``cv_folds`` is a custom dictionary, but ``grid_search_folds``
             is not, perhaps due to user oversight, should the same custom
             dictionary automatically be used for the inner grid-search
             cross-validation?
-            Defaults to ``True``.
 
         Returns
         -------
-        CrossValidateTaskResults
+        :class:`skll.types.CrossValidateTaskResults`
            A 5-tuple containing the following:
 
-            List[EvaluateTaskResults]: the confusion matrix, overall accuracy,
+            List[:class:`skll.types.EvaluateTaskResults`]: the confusion matrix, overall accuracy,
             per-label PRFs, model parameters, objective function score, and
             evaluation metrics (if any) for each fold.
 
@@ -1609,10 +1574,10 @@ class Learner(object):
             etc, that are mapped to lists of values associated with each
             hyperparameter set combination.
 
-            Optional[FoldMapping]: dictionary containing the test-fold number
+            Optional[:class:`skll.types.FoldMapping`]: dictionary containing the test-fold number
             for each id if ``save_cv_folds`` is ``True``, otherwise ``None``.
 
-            Optional[List[skll.learner.Learner]]: list of learners, one for
+            Optional[List[:class:`skll.learner.Learner`]]: list of learners, one for
             each fold if ``save_cv_models`` is ``True``, otherwise ``None``.
 
         Raises
@@ -1777,16 +1742,15 @@ class Learner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to generate the learning curve on.
-        cv_folds : Union[int, FoldMapping]
+        cv_folds : Union[int, :class:`skll.types.FoldMapping`], default=10
             The number of folds to use for cross-validation, or a mapping from
             example IDs to folds.
-            Defaults to 10.
         metric : str
             The name of the metric function to use when computing the train
             and test scores for the learning curve.
-        train_sizes : LearningCurveSizes
+        train_sizes : :class:`skll.types.LearningCurveSizes`, default= :func:`numpy.linspace` with start=0.1, stop=1.0, num=5
             Relative or absolute numbers of training examples
             that will be used to generate the learning curve.
             If the type is float, it is regarded as a fraction
@@ -1797,14 +1761,12 @@ class Learner(object):
             sets. Note that for classification the number of
             samples usually have to be big enough to contain
             at least one sample from each class.
-            Defaults to  ``np.linspace(0.1, 1.0, 5)``.
-        override_minimum : bool
+        override_minimum : bool, default=False
             Learning curves can be unreliable for very small sizes
             esp. for > 2 labels. If this option is set to ``True``, the
             learning curve would be generated even if the number
             of example is less 500 along with a warning. If ``False``,
             the curve is not generated and an exception is raised instead.
-            Defaults to ``False``.
 
         Returns
         -------

--- a/skll/learner/utils.py
+++ b/skll/learner/utils.py
@@ -109,10 +109,12 @@ class FilteredLeaveOneGroupOut(LeaveOneGroupOut):
 
     Parameters
     ----------
-    keep : set of str
+    keep : Iterable[IdType]
         A set of IDs to keep.
     example_ids : numpy.ndarray, of length n_samples
         A list of example IDs.
+    logger : Optional[logging.Logger], default=None
+        A logger instance.
     """
 
     def __init__(
@@ -176,9 +178,8 @@ class SelectByMinCount(SelectKBest):
 
     Parameters
     ----------
-    min_count : int, optional
+    min_count : int, default=1
         The minimum feature count to select.
-        Defaults to 1.
     """
 
     def __init__(self, min_count: int = 1):
@@ -195,7 +196,7 @@ class SelectByMinCount(SelectKBest):
         X : numpy.ndarray, with shape (n_samples, n_features)
             The training data to fit.
         y : Ignored
-            This is ignored.
+            Not used.
 
         Returns
         -------
@@ -241,14 +242,14 @@ def add_unseen_labels(
 
     Parameters
     ----------
-    train_label_dict : Dict[LabelType, int]
+    train_label_dict : Dict[:class:`skll.types.LabelType`, int]
         Dictionary mapping training set class labels to class indices.
-    test_label_list : List[LabelType]
+    test_label_list : List[:class:`skll.types.LabelType`]
         List containing labels in the test set.
 
     Returns
     -------
-    Dict[LabelType, int]
+    Dict[:class:`skll.types.LabelType`, int]
         Dictionary mapping merged labels from both the training and test sets
         to indices.
     """
@@ -296,25 +297,21 @@ def compute_evaluation_metrics(
         The predictions to be used for computing the metrics.
     model_type : str
         One of "classifier" or "regressor".
-    label_dict : Optional[Dict[LabelType, int]]
+    label_dict : Optional[Dict[LabelType, int]], default=None
         Dictionary mapping class labels to indices for classification.
-        Defaults to ``None``.
-    grid_objective : Optional[str]
+    grid_objective : Optional[str], default=None
         The objective used for tuning the hyper-parameters of the model
         that generated the predictions. If ``None``, it means that no
         grid search was done.
-        Defaults to ``None``.
-    probability : bool
+    probability : bool, default=False
         Does the model output class probabilities?
-        Defaults to ``False``.
-    logger : Optional[logging.Logger]
+    logger : Optional[logging.Logger], default=None
         A logger instance to use for logging messages and warnings.
         If ``None``, a new one is created.
-        Defaults to ``None``.
 
     Returns
     -------
-    ComputeEvalMetricsResults
+    :class:`skll.types.ComputeEvalMetricsResults`
         5-tuple including the confusion matrix, the overall accuracy, the
         per-label PRFs, the grid search objective function score, and the
         additional evaluation metrics, if any. For regressors, the
@@ -472,10 +469,9 @@ def compute_num_folds_from_example_counts(
         The example labels.
     model_type : str
         One of "classifier" or "regressor".
-    logger : Optional[logging.Logger]
+    logger : Optional[logging.Logger], default=None
         A logger instance to use for logging messages and warnings.
         If ``None``, a new one is created.
-        Defaults to ``None``.
 
     Returns
     -------
@@ -655,14 +651,14 @@ def load_custom_learner(
 
     Parameters
     ----------
-    custom_learner_path : PathOrStr
+    custom_learner_path : :class:`skll.types.PathOrStr`
         The path to a custom learner.
     custom_learner_name : str
         The name of a custom learner.
 
     Returns
     -------
-    skll.learner.Learner
+    :class:`skll.learner.Learner`
         The SKLL learner object loaded from the given path.
 
     Raises
@@ -706,7 +702,7 @@ def get_predictions(
 
     Parameters
     ----------
-    learner : skll.Learner
+    learner : Union[:class:`skll.learner.Learner`, :class:`skll.learner.voting.VotingLearner`]
         The already-trained ``Learner`` or ``VotingLearner`` instance that is
         used to generate the predictions.
     xtest : numpy.ndarray
@@ -714,7 +710,7 @@ def get_predictions(
 
     Returns
     -------
-    prediction_dict : dict
+    prediction_dict : Dict[str, Any]
         Dictionary containing the three types of predictions as the keys
         and either ``None`` or a numpy array as the value.
 
@@ -947,14 +943,12 @@ def rescaled(cls):
 
         Parameters
         ----------
-        constrain : bool
+        constrain : bool, default=True
             Whether to constrain predictions within min and max values.
-            Defaults to True.
-        rescale : bool
+        rescale : bool, default=True
             Whether to rescale prediction values using z-scores.
-            Defaults to True.
-        kwargs : dict
-            Arguments for base class.
+        kwargs : Dict[str, Any]
+            Keyword arguments for base class.
         """
         # pylint: disable=W0201
         self.constrain = constrain
@@ -990,24 +984,22 @@ def setup_cv_fold_iterator(
 
     Parameters
     ----------
-    cv_folds : Union[int, FoldMapping]
+    cv_folds : Union[int, :class:`skll.types.FoldMapping`]
         The number of folds to use for cross-validation, or
         a mapping from example IDs to folds.
-    examples : skll.data.FeatureSet
+    examples : :class:`skll.data.featureset.FeatureSet`
         The ``FeatureSet`` instance for which the CV iterator is to be computed.
     model_type : str
         One of "classifier" or "regressor".
-    stratified : bool
+    stratified : bool, default=False
         Should the cross-validation iterator be set up in a stratified fashion?
-        Defaults to ``False``.
-    logger : Optional[logging.Logger]
+    logger : Optional[logging.Logger], default=None
         A logger instance to use for logging messages and warnings.
         If ``None``, a new one is created.
-        Defaults to ``None``.
 
     Returns
     -------
-    StratifiedKFold
+    :class:`skll.types.StratifiedKFold`
         k-fold iterator
     Optional[List[str]]
         List of cross-validation groups
@@ -1052,15 +1044,15 @@ def setup_cv_split_iterator(
 
     Parameters
     ----------
-    cv_folds : Union[int, FoldMapping]
+    cv_folds : Union[int, :class:`skll.types.FoldMapping`]
         The number of folds to use for cross-validation, or
         a mapping from example IDs to folds.
-    examples : skll.data.FeatureSet
+    examples : :class:`skll.data.featureset.FeatureSet`
         The given featureset which is to be split.
 
     Returns
     -------
-    FeaturesetIterator
+    :class:`skll.types.FeaturesetIterator`
         Iterator over the train/test featuresets
     int
         The maximum number of training samples available.
@@ -1107,11 +1099,11 @@ def train_and_score(
 
     Parameters
     ----------
-    learner : skll.learner.Learner
+    learner : :class:`skll.learner.Learner`
         A SKLL ``Learner`` instance.
-    train_examples : skll.data.FeatureSet
+    train_examples : :class:`skll.data.featureset.FeatureSet`
         The training examples.
-    test_examples : skll.data.FeatureSet
+    test_examples : :class:`skll.data.featureset.FeatureSet`
         The test examples.
     metric : str
         The scoring function passed to ``use_score_func()``.
@@ -1190,11 +1182,10 @@ def write_predictions(
         "<file_prefix>_predictions.tsv".
     model_type : str
         One of "classifier" or "regressor".
-    label_list : List[LabelType]
+    label_list : List[:class:`skll.types.LabelType`]
         List of class labels, required if ``probability`` is ``True``.
-    append : bool
+    append : bool, default=False
         Should we append the current predictions to the file if it exists?
-        Defaults to ``False``.
     """
     # create a new file starting with the given prefix
     prediction_file = f"{file_prefix}_predictions.tsv"
@@ -1243,9 +1234,9 @@ def _save_learner_to_disk(
 
     Parameters
     ----------
-    learner : Union[skll.learner.Learner, skll.learner.voting.VotingLearner]
+    learner : Union[:class:`skll.learner.Learner`, :class:`skll.learner.voting.VotingLearner`]
         A ``Learner`` or ``VotingLearner`` instance to save to disk.
-    filepath : PathOrStr
+    filepath : :class:`skll.types.PathOrStr`
         The path to save the learner instance to.
     """
     # create the directory if it doesn't exist
@@ -1269,16 +1260,16 @@ def _load_learner_from_disk(
 
     Parameters
     ----------
-    learner_type : Union[Type[skll.learner.Learner], Type[skll.learner.voting.VotingLearner]]
+    learner_type : Union[Type[:class:`skll.learner.Learner`], Type[:class:`skll.learner.voting.VotingLearner`]]
         The type of learner instance to load from disk.
-    filepath : PathOrStr
+    filepath : :class:`skll.types.PathOrStr`
         The path to a saved ``Learner`` or ``VotingLearner`` file.
-    logger : logging object
+    logger : logging.Logger
         A logging object.
 
     Returns
     -------
-    learner : skll.learner.Learner or skll.learner.voting.VotingLearner
+    learner : Union[:class:`skll.learner.Learner`, :class:`skll.learner.voting.VotingLearner`]
         The ``Learner`` or ``VotingLearner`` instance loaded from the file.
 
     Raises

--- a/skll/learner/voting.py
+++ b/skll/learner/voting.py
@@ -55,30 +55,28 @@ class VotingLearner(object):
 
     Parameters
     ----------
-    learner_names : list of str
+    learner_names : List[str]
         List of the learner names that will participate in the voting process.
-    voting : str, optional
+    voting : Optional[str], default="hard"
         One of "hard" or "soft". If "hard", the predicted class labels
         are used for majority rule voting. If "soft", the predicted class
         label is based on the argmax of the sums of the predicted
         probabilities from each of the underlying learnrs. This parameter
         is only relevant for classification.
-        Defaults to "hard".
-    custom_learner_path : Union[str, Path], optional
+    custom_learner_path : Optional[:class:`skll.types.PathOrStr`], default=None
         Path to a Python file containing the definitions of any custom
         learners. Any and all custom learners in ``estimator_names`` must
         be defined in this file. If the custom learner does not inherit
         from an already existing scikit-learn estimator, it must explicitly
         define an `_estimator_type` attribute indicating whether it's a
         "classifier" or a "regressor".
-    feature_scaling : str, optional
+    feature_scaling : str, default="none"
         How to scale the features, if at all for each estimator. Options are
         -  "with_std": scale features using the standard deviation
         -  "with_mean": center features using the mean
         -  "both": do both scaling as well as centering
         -  "none": do neither scaling nor centering
-        Defaults to 'none'.
-    pos_label : str, optional
+    pos_label : Optional[:class:`skll.types.LabelType`], default=None
         A string denoting the label of the class to be
         treated as the positive class in a binary classification
         setting, for each estimator. If ``None``, the class represented
@@ -86,18 +84,15 @@ class VotingLearner(object):
         positive class. For example, if the two labels in data are "A"
         and "B" and ``pos_label`` is not specified, "B" will
         be chosen as the positive class.
-        Defaults to ``None``.
-    min_feature_count : int, optional
+    min_feature_count : int, default=1
         The minimum number of examples a feature must have a nonzero
         value in to be included, for each estimator.
-        Defaults to 1.
-    model_kwargs_list : list of dicts, optional
+    model_kwargs_list : Optional[List[Dict[str, Any]]], default=None
         A list of dictionaries of keyword arguments to pass to the
         initializer for each of the estimators. There's a one-to-one
         correspondence between the order of this list and the order
         of the ``learner_names`` list.
-        Defaults to ``None``.
-    sampler_list : list of str, optional
+    sampler_list : Optional[List[str]], default=None
         The samplers to use for kernel approximation, if desired, for each
         estimator. Valid values are:
         -  "AdditiveChi2Sampler"
@@ -106,16 +101,13 @@ class VotingLearner(object):
         -  "SkewedChi2Sampler"
         There's a one-to-one correspondence between the order of this list
         and the order of the ``learner_names`` list.
-        Defaults to ``None``.
-    sampler_kwargs_list : dict, optional
+    sampler_kwargs_list : Optional[List[Dict[str, Any]]], default=None
         A list of dictionaries of keyword arguments to pass to the
         initializer for the specified sampler, one per estimator.
         There's a one-to-one correspondence between the order of this
         list and the order of the ``learner_names`` list.
-        Defaults to ``None``.
-    logger : logging object, optional
+    logger : Optional[logging.Logger], default=None
         A logging object. If ``None`` is passed, get logger from ``__name__``.
-        Defaults to ``None``.
     """
 
     def __init__(
@@ -242,7 +234,7 @@ class VotingLearner(object):
 
         Parameters
         ----------
-        learner_path : PathOrStr
+        learner_path : :class:`skll.types.PathOrStr`
             The path to save the ``VotingLearner`` instance to.
         """
         _save_learner_to_disk(self, learner_path)
@@ -256,11 +248,10 @@ class VotingLearner(object):
 
         Parameters
         ----------
-        learner_path : PathOrStr
+        learner_path : :class:`skll.types.PathOrStr`
             The path to a saved ``VotingLearner`` instance file.
-        logger : Optional[logging.Logger]
+        logger : Optional[logging.Logger], default=None
             A logging object. If ``None`` is passed, get logger from ``__name__``.
-            Defaults to ``None``.
 
         Returns
         -------
@@ -306,37 +297,31 @@ class VotingLearner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to use for training.
-        param_grid_list : Optional[List[Dict[str, Any]]]
+        param_grid_list : Optional[List[Dict[str, Any]]], default=None
             The list of parameter grids to search through for grid
             search, one for each underlying learner. The order of
             the dictionaries should correspond to the order in
             which the underlying estimators were specified when the
             ``VotingLearner`` was instantiated. If ``None``, the default
             parameter grids will be used for the underlying estimators.
-            Defaults to ``None``.
-        grid_search_folds : Union[int, FoldMapping]
+        grid_search_folds : Union[int, :class:`skll.types.FoldMapping`], default=5
             The number of folds to use when doing the grid search
             for each of the underlying learners, or a mapping from
             example IDs to folds.
-            Defaults to 5.
-        grid_search : bool
+        grid_search : bool, default=True
             Should we use grid search when training each underlying learner?
-            Defaults to ``True``.
-        grid_objective : Optional[str]
+        grid_objective : Optional[str], default=None
             The name of the objective function to use when
             doing the grid search for each underlying learner.
             Must be specified if ``grid_search`` is ``True``.
-            Defaults to ``None``.
-        grid_jobs : Optional[int]
+        grid_jobs : Optional[int], default=None
             The number of jobs to run in parallel when doing the
             grid search for each underlying learner. If ``None`` or 0,
             the number of grid search folds will be used.
-            Defaults to ``None``.
-        shuffle : bool
+        shuffle : bool, default=False
             Shuffle examples (e.g., for grid search CV.)
-            Defaults to ``False``.
         """
         if param_grid_list is None:
             self._param_grids = []
@@ -435,24 +420,20 @@ class VotingLearner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to predict labels for.
-        prediction_prefix : Optional[str]
+        prediction_prefix : Optional[str], default=None
             If saving the predictions, this is the prefix that will be used for
             the filename. It will be followed by ``"_predictions.tsv"``
-            Defaults to ``None``.
-        append : bool
+        append : bool, default=False
             Should we append the current predictions to the file if it exists?
-            Defaults to ``False``.
-        class_labels : bool
+        class_labels : bool, default=True
             For classifier, should we convert class indices to their (str) labels
             for the returned array? Note that class labels are always written out
             to disk.
-            Defaults to ``True``.
-        individual_predictions : bool
+        individual_predictions : bool, default=False
             Return (and, optionally, write out) the predictions from each
             underlying learner.
-            Defaults to ``False``.
 
         Returns
         -------
@@ -547,31 +528,26 @@ class VotingLearner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to evaluate the performance of the model on.
-        prediction_prefix : Optional[str]
+        prediction_prefix : Optional[str], default=None
             If saving the predictions, this is the
             prefix that will be used for the filename.
             It will be followed by ``"_predictions.tsv"``
-            Defaults to ``None``.
-        append : bool
+        append : bool, default=False
             Should we append the current predictions to the file if
             it exists?
-            Defaults to ``False``.
-        grid_objective : Optional[str]
+        grid_objective : Optional[str], default=None
             The objective function used when doing the grid search.
-            Defaults to ``None``.
-        individual_predictions : bool
+        individual_predictions : bool, default=False
             Optionally, write out the predictions from each underlying learner.
-            Defaults to ``False``.
-        output_metrics : List[str]
+        output_metrics : List[str], default=[]
             List of additional metric names to compute in
-            addition to grid objective. Empty by default.
-            Defaults to an empty list.
+            addition to grid objective.
 
         Returns
         -------
-        EvaluateTaskResults
+        :class:`skll.types.EvaluateTaskResults`
             The confusion matrix, the overall accuracy, the per-label
             PRFs, the model parameters, the grid search objective
             function score, and the additional evaluation metrics, if any.
@@ -670,86 +646,71 @@ class VotingLearner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to cross-validate learner performance on.
-        stratified : bool
+        stratified : bool, default=True
             Should we stratify the folds to ensure an even
             distribution of labels for each fold?
-            Defaults to ``True``.
-        cv_folds : Union[int, FoldMapping]
+        cv_folds : Union[int, :class:`skll.types.FoldMapping`], default=10
             The number of folds to use for cross-validation, or
             a mapping from example IDs to folds.
-            Defaults to 10.
-        cv_seed: int
+        cv_seed: int, default=123456789
             The value for seeding the random number generator
             used to create the random folds. Note that this
             seed is *only* used if either ``grid_search`` or
             ``shuffle`` are set to ``True``.
-            Defaults to 123456789.
-        grid_search : bool
+        grid_search : bool, default=True
             Should we do grid search when training each fold?
             Note: This will make this take *much* longer.
-            Defaults to ``True``.
-        grid_search_folds : Union[int, FoldMapping]
+        grid_search_folds : Union[int, :class:`skll.types.FoldMapping`], default=5
             The number of folds to use when doing the grid search, or a mapping
             from example IDs to folds.
-            Defaults to 5.
-        grid_jobs : Optional[int]
+        grid_jobs : Optional[int], default=None
             The number of jobs to run in parallel when doing the grid search.
             If ``None`` or 0, the number of grid search folds will be used.
-            Defaults to ``None``.
-        grid_objective : Optional[str]
+        grid_objective : Optional[str], default=None
             The name of the objective function to use when doing the grid search.
             Must be specified if ``grid_search`` is ``True``.
-            Defaults to ``None``.
-        output_metrics : Optional[List[str]]
+        output_metrics : Optional[List[str]], default=[]
             List of additional metric names to compute in addition to the metric
             used for grid search.
-            Defaults to an empty list.
-        prediction_prefix : Optional[str]
+        prediction_prefix : Optional[str], default=None
             If saving the predictions, this is the prefix that will be used for
             the filename. It will be followed by ``"_predictions.tsv"``
-            Defaults to ``None``.
-        param_grid_list : Optional[List[Dict[str, Any]]]
+        param_grid_list : Optional[List[Dict[str, Any]]], default=None
             The list of parameters grid to search through for grid
             search, one for each underlying learner. The order of
             the dictionaries should correspond to the order If ``None``,
             the default parameter grids will be used for the underlying
             estimators.
-            Defaults to ``None``.
-        shuffle : bool
+        shuffle : bool, default=False
             Shuffle examples before splitting into folds for CV.
-            Defaults to ``False``.
-        save_cv_folds : bool
+        save_cv_folds : bool, default=True
              Whether to save the cv fold ids or not?
-             Defaults to ``True``.
-        save_cv_models : bool
+        save_cv_models : bool, default=False
             Whether to save the cv models or not?
-            Defaults to ``False``.
-        individual_predictions : bool
+        individual_predictions : bool, default=False
             Write out the cross-validated predictions from each underlying
             learner as well.
-            Defaults to ``False``.
-        use_custom_folds_for_grid_search : bool
+        use_custom_folds_for_grid_search : bool, default=True
             If ``cv_folds`` is a custom dictionary, but ``grid_search_folds``
             is not, perhaps due to user oversight, should the same custom
             dictionary automatically be used for the inner grid-search
             cross-validation?
-            Defaults to ``True``.
 
         Returns
         -------
-        CrossValidateTaskResults
+        :class:`skll.types.CrossValidateTaskResults`
            A 3-tuple containing the following:
 
-            List[EvaluateTaskResults]: the confusion matrix, overall accuracy,
+            List[:class:`skll.types.EvaluateTaskResults`]: the confusion matrix, overall accuracy,
             per-label PRFs, model parameters, objective function score, and
             evaluation metrics (if any) for each fold.
 
-            Optional[FoldMapping]: dictionary containing the test-fold number
+            Optional[:class:`skll.types.FoldMapping`]: dictionary containing the test-fold number
             for each id if ``save_cv_folds`` is ``True``, otherwise ``None``.
 
-            Optional[List[skll.learner.voting.VotingLearner]]: list of voting
+            Optional[List[:class:`skll.learner.voting.VotingLearner`]]: list of voting
             learners, one for each fold if ``save_cv_models`` is ``True``,
             otherwise ``None``.
 
@@ -909,17 +870,16 @@ class VotingLearner(object):
 
         Parameters
         ----------
-        examples : skll.data.FeatureSet
+        examples : :class:`skll.data.featureset.FeatureSet`
             The ``FeatureSet`` instance to generate the learning curve on.
         metric : str
             The name of the metric function to use
             when computing the train and test scores
             for the learning curve.
-        cv_folds : Union[int, FoldMapping]
+        cv_folds : Union[int, :class:`skll.types.FoldMapping`], default=10
             The number of folds to use for cross-validation, or
             a mapping from example IDs to folds.
-            Defaults to 10.
-        train_sizes : LearningCurveSizes
+        train_sizes : :class:`skll.types.LearningCurveSizes`, default= :func:`numpy.linspace` with start=0.1, stop=1.0, num=5
             Relative or absolute numbers of training examples
             that will be used to generate the learning curve.
             If the type is float, it is regarded as a fraction
@@ -930,14 +890,12 @@ class VotingLearner(object):
             sets. Note that for classification the number of
             samples usually have to be big enough to contain
             at least one sample from each class.
-            Defaults to  ``np.linspace(0.1, 1.0, 5)``.
-        override_minimum : bool
+        override_minimum : bool, default=False
             Learning curves can be unreliable for very small sizes
             esp. for > 2 labels. If this option is set to ``True``, the
             learning curve would be generated even if the number
             of example is less 500 along with a warning. If ``False``,
             the curve is not generated and an exception is raised instead.
-            Defaults to ``False``.
 
         Returns
         -------


### PR DESCRIPTION
- chore: ignore E501 errors in various files. 
- chore: fix docstrings and types in `skll.experiments` and `skll.learner` modules. 

To review this, please look at the [built documentation](https://skll.readthedocs.io/en/647-improve-docstrings-typehints-3/index.html) and check that under "API documentation",  look at the sections "`experiments` Package" and "`learner` Package" and confirm that:

- All parameters have a docstring.
- All type hints have clickable types or type hints.
- The default values are all specified as default = blah.
- All other changes look okay.

This is part of #647.