### PR TITLE
Improve docstrings & type hints (Part 4)

### DIFF
--- a/skll/learner/__init__.py
+++ b/skll/learner/__init__.py
@@ -683,7 +683,7 @@ class Learner(object):
         ------
         ValueError
             If ``self.feat_vectorizer`` is either ``None`` or a
-            :class:`sklearn.feature_extraction.FeatureHasher``.
+            :class:`sklearn.feature_extraction.FeatureHasher`.
         """
         if isinstance(self.feat_vectorizer, DictVectorizer):
             return self.feat_vectorizer.get_feature_names_out()[self.feat_selector.get_support()]

--- a/skll/metrics.py
+++ b/skll/metrics.py
@@ -55,21 +55,19 @@ def kappa(
         The true/actual/gold labels for the data.
     y_pred : numpy.ndarray
         The predicted/observed labels for the data.
-    weights : Optional[Union[str, numpy.ndarray]]
+    weights : Optional[Union[str, numpy.ndarray]], default=None
         Specifies the weight matrix for the calculation.
         Possible values are: ``None`` (unweighted-kappa), ``"quadratic"``
         (quadratically weighted kappa), ``"linear"`` (linearly weighted kappa),
         and a two-dimensional numpy array (a custom matrix of weights). Each
         weight in this array corresponds to the :math:`w_{ij}` values in the
         Wikipedia description of how to calculate weighted Cohen's kappa.
-        Defaults to ``None``.
-    allow_off_by_one : bool
+    allow_off_by_one : bool, default=False
         If true, ratings that are off by one are counted as
         equal, and all other differences are reduced by
         one. For example, 1 and 2 will be considered to be
         equal, whereas 1 and 3 will have a difference of 1
         for when building the weights matrix.
-        Defaults to ``False``.
 
     Returns
     -------
@@ -181,10 +179,9 @@ def correlation(y_true: np.ndarray, y_pred: np.ndarray, corr_type: str = "pearso
         The true/actual/gold labels for the data.
     y_pred : numpy.ndarray
         The predicted/observed labels for the data.
-    corr_type : str
+    corr_type : str, default="pearson"
         Which type of correlation to compute. Possible
         choices are "pearson", "spearman", and "kendall_tau".
-        Defaults to "pearson".
 
     Returns
     -------
@@ -237,7 +234,7 @@ def register_custom_metric(custom_metric_path: PathOrStr, custom_metric_name: st
 
     Parameters
     ----------
-    custom_metric_path : PathOrStr
+    custom_metric_path : :class:`skll.types.PathOrStr`
         The path to a custom metric.
     custom_metric_name : str
         The name of the custom metric function to load. This function must take

--- a/skll/utils/commandline/compute_eval_from_predictions.py
+++ b/skll/utils/commandline/compute_eval_from_predictions.py
@@ -50,8 +50,9 @@ def get_prediction_from_probabilities(
                multiple classes have the same probability, a class is selected randomly.
             2. ``"expected_value"``: Calculates an expected value over integer classes and
                rounds to the nearest int.
-    random_state: int
-        Seed for ``np.random.RandomState``, used for randomly selecting a class when necessary.
+    random_state: int, default=1234567890
+        Seed for ``np.random.RandomState``, used for randomly selecting a class
+        when necessary.
 
     Returns
     -------
@@ -93,20 +94,19 @@ def compute_eval_from_predictions(
 
     Parameters
     ----------
-    examples_file: PathOrStr
+    examples_file: :class:`skll.types.PathOrStr`
         Path to a SKLL examples file (in .jsonlines or other format).
-    predictions_file: PathOrStr
+    predictions_file: :class:`skll.types.PathOrStr`
         Path to a SKLL predictions output TSV file with id and prediction column names.
     metric_names: List[str]
         A list of SKLL metric names (e.g., ``["pearson", "unweighted_kappa"]``).
-    prediction_method: Optional[str]
+    prediction_method: Optional[str], default=None
         Indicates how to get a single class prediction from the probabilities.
         Currently supported options are ``"highest"``, which selects the class
         with the highest probability, and ``"expected_value"``, which calculates
         an expected value over integer classes and rounds to the nearest int.
         If predictions file does not contain probabilities, this should be set
         to ``None``.
-        Defaults to ``None``.
 
     Returns
     -------
@@ -189,10 +189,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv: Optional[List[str]]
+    argv: Optional[List[str]], default=None
         List of arguments, as if specified on the command-line. If ``None``,
         then ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/filter_features.py
+++ b/skll/utils/commandline/filter_features.py
@@ -25,10 +25,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/generate_predictions.py
+++ b/skll/utils/commandline/generate_predictions.py
@@ -29,10 +29,9 @@ def main(argv: Optional[List[str]] = None):
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/join_features.py
+++ b/skll/utils/commandline/join_features.py
@@ -24,10 +24,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/plot_learning_curves.py
+++ b/skll/utils/commandline/plot_learning_curves.py
@@ -31,10 +31,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/print_model_weights.py
+++ b/skll/utils/commandline/print_model_weights.py
@@ -28,7 +28,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
         Defaults to ``None``.

--- a/skll/utils/commandline/run_experiment.py
+++ b/skll/utils/commandline/run_experiment.py
@@ -23,10 +23,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = ArgumentParser(

--- a/skll/utils/commandline/skll_convert.py
+++ b/skll/utils/commandline/skll_convert.py
@@ -40,10 +40,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/commandline/summarize_results.py
+++ b/skll/utils/commandline/summarize_results.py
@@ -22,10 +22,9 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     Parameters
     ----------
-    argv : Optional[List[str]]
+    argv : Optional[List[str]], default=None
         List of arguments, as if specified on the command-line.
         If ``None``, ``sys.argv[1:]`` is used instead.
-        Defaults to ``None``.
     """
     # Get command line arguments
     parser = argparse.ArgumentParser(

--- a/skll/utils/logging.py
+++ b/skll/utils/logging.py
@@ -45,14 +45,12 @@ def get_skll_logger(
     ----------
     name : str
         The name to be used for the logger.
-    filepath : str, optional
+    filepath : Optional[str], default=None
         The file to be used for the logger via a FileHandler.
         Default: None in which case no file is attached to the
         logger.
-        Defaults to ``None``.
-    log_level : str, optional
+    log_level : int, default=logging.INFO
         The level for logging messages
-        Defaults to ``logging.INFO``.
 
     Returns
     -------
@@ -85,7 +83,7 @@ def get_skll_logger(
     return logger
 
 
-def close_and_remove_logger_handlers(logger):
+def close_and_remove_logger_handlers(logger: logging.Logger) -> None:
     """
     Close and remove any handlers attached to a logger instance.
 
@@ -93,10 +91,6 @@ def close_and_remove_logger_handlers(logger):
     ----------
     logger : logging.Logger
         Logger instance
-
-    Returns
-    -------
-    NoneType
     """
     for handler in logger.handlers[:]:
         handler.close()


### PR DESCRIPTION
- chore: ignore E501 errors in various files. 
- chore: fix docstrings and types in `skll.experiments` and `skll.learner` modules. 

To review this, please look at the [built documentation](https://skll.readthedocs.io/en/647-improve-docstrings-typehints-4/index.html) and check that under "API documentation",  look at the sections "`metrics` Package" and "`utils` Package" and confirm that:

- All parameters have a docstring.
- All type hints have clickable types or type hints.
- The default values are all specified as default = blah.
- All other changes look okay.

This is the final PR for #647. Closes #647. 