### PR TITLE
Add support for Python 3.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ How to contribute
 
 3. Create an isolated environment for SKLL development. We recommend using the [conda](https://conda.io/en/latest/) package manager. To create a `conda` environment, run the following command in the root of the working directory:
 
-         $ conda create -n sklldev -c conda-forge --file requirements.txt python=3.10
+         $ conda create -n sklldev -c conda-forge --file requirements.txt python=3.11
 
 4. Activate the conda environment
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ You can install using either ``pip`` or ``conda``. See details `here <https://sk
 Requirements
 ~~~~~~~~~~~~
 
--  Python 3.8, 3.9, or 3.10
+-  Python 3.8, 3.9, 3.10, or 3.11
 -  `beautifulsoup4 <http://www.crummy.com/software/BeautifulSoup/>`__
 -  `gridmap <https://pypi.org/project/gridmap/>`__ (only required if you plan
    to run things in parallel on a DRMAA-compatible cluster)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@
 
 variables:
   MPLBACKEND: Agg
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.11
 
 trigger:
   branches:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     zip_safe=False,
 )

--- a/skll/learner/utils.py
+++ b/skll/learner/utils.py
@@ -876,14 +876,14 @@ def rescaled(cls):
         """
         Get kwargs for superclass and add new kwargs.
 
-        This is adapted from scikit-learns's ``BaseEstimator`` class.
+        This is adapted from scikit-learn's ``BaseEstimator`` class.
         It gets the kwargs for the superclass's init method and adds the
         kwargs for newly added ``__init__()`` method.
 
         Parameters
         ----------
         class_x
-            The the superclass from which to retrieve param names.
+            The superclass from which to retrieve param names.
 
         Returns
         -------
@@ -926,10 +926,10 @@ def rescaled(cls):
             pass
 
         # now get the additional rescaling arguments
-        rescale_args = inspect.getargspec(class_x.__init__)[0]
+        rescale_args = list(inspect.signature(class_x.__init__).parameters.keys())
 
         # Remove 'self'
-        rescale_args.pop(0)
+        rescale_args.remove("self")
 
         # add the rescaling arguments to the original arguments and sort
         args += rescale_args


### PR DESCRIPTION
- Replace deprecated `inspect.getargspec()` in `rescaled` decorator. 
- Switch Azure Pipeline to Python 3.11.
- Add Python 3.11 to `README.rst`, `setup.py`, and `CONTRIBUTING.md`. 

Closes #744. 