### PR TITLE
Stop using sklearn's private `_scorer` API for custom metrics in SKLL. 

### DIFF
--- a/doc/custom_metrics.rst
+++ b/doc/custom_metrics.rst
@@ -23,12 +23,12 @@ Note that these keyword arguments are identical to the keyword arguments for the
 In short, custom metric functions take two required positional arguments (order matters) and three optional keyword arguments. Here's a simple example of a custom metric function: F\ :sub:`β` with β=0.75 defined in a file called ``custom.py``.
 
 .. code-block:: python
-   :caption: custom.py
+  :caption: custom.py
 
-    from sklearn.metrics import fbeta_score
+  from sklearn.metrics import fbeta_score
 
-    def f075(y_true, y_pred):
-        return fbeta_score(y_true, y_pred, beta=0.75)
+  def f075(y_true, y_pred):
+      return fbeta_score(y_true, y_pred, beta=0.75)
 
 
 Obviously, you may write much more complex functions that aren't directly
@@ -73,7 +73,7 @@ assumes that the file ``custom.py`` above is located in the same directory.
    [Output]
    metrics = ['roc_auc']
    probability = true
-   log = output
+   logs = output
    results = output
    predictions = output
    models = output

--- a/doc/custom_metrics.rst
+++ b/doc/custom_metrics.rst
@@ -115,7 +115,7 @@ is located in the current directory.
 As with configuration files, custom metric functions can be used for
 both training as well as evaluation with the API.
 
-.. note::
+.. important::
 
     1. When using the API, if you have multiple metric functions defined in a
        Python source file, you must register each one individually using
@@ -124,13 +124,14 @@ both training as well as evaluation with the API.
        same Python session, it will raise a ``NameError``. Therefore, if you
        edit your custom metric, you must start a new Python session to be able
        to see the changes.
-
-.. warning::
-
-    1. When using a configuration file or the API, if the names of any of your
+    3. When using the API, if the names of any of your
        custom metric functions conflict with names of :ref:`metrics <objectives>`
        that already exist in either SKLL or scikit-learn, it will raise a
        ``NameError``. You should rename the metric function in that case.
-    2. Unlike for the built-in metrics, SKLL does not check whether your custom
+    4. When using a configuration file, if your custom metric name conflicts
+       with names of :ref:`metrics <objectives>` that already exist in either
+       SKLL or scikit-learn, it will be silently ignored in favor of the
+       already existing metric.
+    5. Unlike for the built-in metrics, SKLL does not check whether your custom
        metric function is appropriate for classification or regression. You
        must make that decision for yourself.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
 ruamel.yaml
-scikit-learn>=1.2.0,<1.3.0
+scikit-learn>=1.3.0,<1.4.0
 seaborn
 sphinx>=5.0,<6.0
 sphinx_rtd_theme==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy
 pandas
 pre-commit
 ruamel.yaml
-scikit-learn>=1.2.0,<1.3.0
+scikit-learn>=1.3.0,<1.4.0
 scipy
 seaborn
 tabulate

--- a/skll/__init__.py
+++ b/skll/__init__.py
@@ -1,39 +1,9 @@
 # License: BSD 3 clause
 """
-This package provides a number of utilities to make it simpler to run
-common scikit-learn experiments with pre-generated features.
+Easily run common common scikit-learn experiments with pre-generated features.
 
 :author: Nitin Madnani (nmadnani@ets.org)
 :author: Dan Blanchard (dblanchard@ets.org)
 :author: Michael Heilman (mheilman@ets.org)
 :organization: ETS
 """
-
-from sklearn.metrics import f1_score, fbeta_score, make_scorer
-from sklearn.metrics._scorer import _SCORERS
-
-from .metrics import correlation, f1_score_least_frequent, kappa
-
-# Add our scorers to the sklearn dictionary here so that they will always be
-# available if you import anything from skll
-_scorers = {
-    "f1_score_micro": make_scorer(f1_score, average="micro"),
-    "f1_score_macro": make_scorer(f1_score, average="macro"),
-    "f1_score_weighted": make_scorer(f1_score, average="weighted"),
-    "f1_score_least_frequent": make_scorer(f1_score_least_frequent),
-    "f05": make_scorer(fbeta_score, beta=0.5, average="binary"),
-    "f05_score_micro": make_scorer(fbeta_score, beta=0.5, average="micro"),
-    "f05_score_macro": make_scorer(fbeta_score, beta=0.5, average="macro"),
-    "f05_score_weighted": make_scorer(fbeta_score, beta=0.5, average="weighted"),
-    "pearson": make_scorer(correlation, corr_type="pearson"),
-    "spearman": make_scorer(correlation, corr_type="spearman"),
-    "kendall_tau": make_scorer(correlation, corr_type="kendall_tau"),
-    "unweighted_kappa": make_scorer(kappa),
-    "quadratic_weighted_kappa": make_scorer(kappa, weights="quadratic"),
-    "linear_weighted_kappa": make_scorer(kappa, weights="linear"),
-    "qwk_off_by_one": make_scorer(kappa, weights="quadratic", allow_off_by_one=True),
-    "lwk_off_by_one": make_scorer(kappa, weights="linear", allow_off_by_one=True),
-    "uwk_off_by_one": make_scorer(kappa, allow_off_by_one=True),
-}
-
-_SCORERS.update(_scorers)

--- a/skll/__init__.py
+++ b/skll/__init__.py
@@ -1,6 +1,6 @@
 # License: BSD 3 clause
 """
-Easily run common common scikit-learn experiments with pre-generated features.
+Easily run common scikit-learn experiments with pre-generated features.
 
 :author: Nitin Madnani (nmadnani@ets.org)
 :author: Dan Blanchard (dblanchard@ets.org)

--- a/skll/data/writers.py
+++ b/skll/data/writers.py
@@ -251,7 +251,6 @@ class Writer(object):
         ------
         NotImplementedError
         """
-        __import__("ipdb").sset_trace()
         raise NotImplementedError
 
     def _write_data(self, feature_set, output_file, filter_features):
@@ -273,7 +272,6 @@ class Writer(object):
         ------
         NotImplementedError
         """
-        __import__("ipdb").sset_trace()
         raise NotImplementedError
 
     def _get_column_names_and_indexes(

--- a/skll/experiments/__init__.py
+++ b/skll/experiments/__init__.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional, Union
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn import __version__ as SCIKIT_VERSION
-from sklearn.metrics._scorer import _SCORERS
+from sklearn.metrics import get_scorer_names
 
 from skll.config import parse_config_file
 from skll.config.utils import _munge_featureset_name
@@ -154,12 +154,12 @@ def _classify_featureset(args: Dict[str, Any]) -> List[Dict[str, Any]]:
             # metrics that are not in `SCORERS` or `None` are candidates
             # (the `None` is a by-product of how jobs with single tuning
             # objectives are created)
-            if metric_name not in _SCORERS and metric_name is not None:
+            if (
+                metric_name not in get_scorer_names()
+                and metric_name not in _CUSTOM_METRICS
+                and metric_name is not None
+            ):
                 possible_custom_metric_names.append(metric_name)
-            # if the metric is already in `SCORERS`, is it a custom one
-            # that we already registered? if so, log that
-            elif metric_name in _CUSTOM_METRICS:
-                logger.info(f"custom metric '{metric_name}' is already registered")
 
         # initialize list that will hold any invalid metrics
         # that we could not register as custom metrics

--- a/skll/learner/utils.py
+++ b/skll/learner/utils.py
@@ -50,7 +50,7 @@ from sklearn.model_selection import (
 )
 
 from skll.data import FeatureSet
-from skll.metrics import _CUSTOM_METRICS, use_score_func
+from skll.metrics import _CUSTOM_METRICS, _PREDEFINED_CUSTOM_METRICS, use_score_func
 from skll.types import (
     ComputeEvalMetricsResults,
     ConfusionMatrix,
@@ -619,9 +619,10 @@ def get_acceptable_classification_metrics(label_array: np.ndarray) -> Set[str]:
         if contiguous_ints_or_floats(label_array):
             acceptable_metrics.update(WEIGHTED_KAPPA_METRICS)
 
-    # if there are any custom metrics registered, include them too
-    if len(_CUSTOM_METRICS) > 0:
-        acceptable_metrics.update(_CUSTOM_METRICS)
+    # if there are any user-defined custom metrics registered, include them too
+    user_defined_metrics = set(_CUSTOM_METRICS) - set(_PREDEFINED_CUSTOM_METRICS)
+    if len(user_defined_metrics) > 0:
+        acceptable_metrics.update(user_defined_metrics)
 
     return acceptable_metrics
 
@@ -637,9 +638,10 @@ def get_acceptable_regression_metrics() -> Set[str]:
         | CORRELATION_METRICS
     )
 
-    # if there are any custom metrics registered, include them too
-    if len(_CUSTOM_METRICS) > 0:
-        acceptable_metrics.update(_CUSTOM_METRICS)
+    # if there are any user-defined custom metrics registered, include them too
+    user_defined_metrics = set(_CUSTOM_METRICS) - set(_PREDEFINED_CUSTOM_METRICS)
+    if len(user_defined_metrics) > 0:
+        acceptable_metrics.update(user_defined_metrics)
 
     return acceptable_metrics
 

--- a/skll/utils/testing.py
+++ b/skll/utils/testing.py
@@ -1148,7 +1148,7 @@ def make_california_housing_data(num_examples=None, test_size=0.2):
     """
     # load the housing data
     housing = fetch_california_housing(
-        data_home=other_dir, download_if_missing=False, as_frame=True
+        data_home=str(other_dir), download_if_missing=False, as_frame=True
     )
     df_housing = housing.frame
 


### PR DESCRIPTION
- Update scikit-learn to v1.3.0.
- Move all custom pre-defined metrics to `_PREDEFINED_CUSTOM_METRICS` dictionary in `metrics.py`.
- Make a copy of the above dictionary as `CUSTOM _METRICS`. This dictionary will be the source of all custom metrics: pre-defined and user-defined.
- We need two dictionaries because at some points in the code, we need to be able to differentiate between pre-defined custom metrics and user-defined custom metrics.
- Remove any use of `sklearn.metrics._scorer` private API and use `sklearn.metrics.get_scorer()` and `sklearn.metrics.get_scorer_names()` instead.
- Use the actual metric function when using custom metrics instead of its name. This is the core change that makes everything work since sklearn validates callables but does not validate custom metric name strings.
- Update tests to not use `_SCORERS` and fix a minor bug in another test related to scikit-learn v1.3.0. 

This PR closes #748 and closes #750. 

To review this PR, please try to create some [custom metrics](https://skll.readthedocs.io/en/latest/custom_metrics.html) for both the titanic and California examples and try to use them via both the API and the configuration file. 