### PR TITLE
Release v4.0.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE.txt
 include requirements.txt
+prune tests

--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: skll
-  version: 3.2
+  version: 4.0
 
 source:
   path: ../../../skll
@@ -12,15 +12,6 @@ build:
     - cd $SRC_DIR
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
-    - compute_eval_from_predictions = skll.utils.commandline.compute_eval_from_predictions:main
-    - filter_features = skll.utils.commandline.filter_features:main
-    - generate_predictions = skll.utils.commandline.generate_predictions:main
-    - join_features = skll.utils.commandline.join_features:main
-    - plot_learning_curves = skll.utils.commandline.plot_learning_curves:main
-    - print_model_weights = skll.utils.commandline.print_model_weights:main
-    - run_experiment = skll.utils.commandline.run_experiment:main
-    - skll_convert = skll.utils.commandline.skll_convert:main
-    - summarize_results = skll.utils.commandline.summarize_results:main
     - compute_eval_from_predictions = skll.utils.commandline.compute_eval_from_predictions:main
     - filter_features = skll.utils.commandline.filter_features:main
     - generate_predictions = skll.utils.commandline.generate_predictions:main
@@ -43,10 +34,11 @@ requirements:
     - numpy
     - pandas
     - ruamel.yaml
-    - scikit-learn >=1.2.0,<1.3.0
+    - scikit-learn >=1.3.0,<1.4.0
     - scipy
     - seaborn
     - tabulate
+    - typing_extensions
 
 test:
   # Python imports

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -23,15 +23,13 @@ Organization
 
 The main Python code for the SKLL package lives inside the ``skll`` sub-directory of the repository. It contains the following files and sub-directories:
 
--  `__init__.py <https://github.com/EducationalTestingService/skll/blob/main/skll/__init__.py>`__ : Code used to initialize the ``skll`` Python package.
-
 -  `config/ <https://github.com/EducationalTestingService/skll/tree/main/skll/config>`__ : Code to parse SKLL experiment configuration files.
 
 -  `experiments/ <https://github.com/EducationalTestingService/skll/tree/main/skll/experiments>`__ : Code that is related to creating and running SKLL experiments. It also contains code that collects the various evaluation metrics and predictions for each SKLL experiment and writes them out to disk.
 
 -  `learner/ <https://github.com/EducationalTestingService/skll/tree/main/skll/learner>`__ : Code for the `Learner <https://github.com/EducationalTestingService/skll/blob/main/skll/learner/__init__.py>`__ and `VotingLearner <https://github.com/EducationalTestingService/skll/blob/main/skll/learner/voting.py>`__ classes. The former is instantiated for all learner names specified in the experiment configuration file *except* ``VotingClassifier`` and ``VotingRegressor`` for which the latter is instantiated instead.
 
--  `metrics.py <https://github.com/EducationalTestingService/skll/blob/main/skll/metrics.py>`__ : Code for any custom metrics that are not in ``sklearn.metrics``, e.g., ``kappa``, ``kendall_tau``, ``spearman``, etc.
+-  `metrics.py <https://github.com/EducationalTestingService/skll/blob/main/skll/metrics.py>`__ : Code for any custom metrics that are not in ``sklearn.metrics``, e.g., ``kappa``, ``kendall_tau``, ``spearman``, etc. This module also contains the code that powers :ref:`user-defined custom metrics <custom_metrics>`.
 
 -  `data/ <https://github.com/EducationalTestingService/skll/tree/main/skll/data>`__
 
@@ -80,12 +78,12 @@ There are three main entry points into the SKLL codebase:
    `run_experiment <https://skll.readthedocs.io/en/latest/run_experiment.html#using-run-experiment>`__ script. When you run the command
    ``run_experiment <config_file>``, the following happens (at a high level):
 
-   -  the configuration file is handed off to the `run_configuration() <https://github.com/EducationalTestingService/skll/blob/main/skll/experiments/__init__.py#L482>`__ function in ``experiments.py``.
+   -  the configuration file is handed off to the `run_configuration() <https://github.com/EducationalTestingService/skll/blob/main/skll/experiments/__init__.py#L609>`__ function in ``experiments.py``.
 
-   -  a `SKLLConfigParser <https://github.com/EducationalTestingService/skll/blob/main/skll/config/__init__.py#L41>`__ object is instantiated from ``config.py`` that parses all of the relevant fields out of the given configuration file.
+   -  a `SKLLConfigParser <https://github.com/EducationalTestingService/skll/blob/main/skll/config/__init__.py#L44>`__ object is instantiated from ``config.py`` that parses all of the relevant fields out of the given configuration file.
 
-   -  the configuration fields are then passed to the `_classify_featureset() <https://github.com/EducationalTestingService/skll/blob/main/skll/experiments/__init__.py#L56>`__ function in ``experiments.py`` which instantiates the learners (using code from ``learner.py``), the featuresets (using code from ``reader.py`` & ``featureset.py``), and runs the experiments, collects the results, and writes them out to disk.
+   -  the configuration fields are then passed to the `_classify_featureset() <https://github.com/EducationalTestingService/skll/blob/main/skll/experiments/__init__.py#L64>`__ function in ``experiments.py`` which instantiates the learners (using code from ``learner.py``), the featuresets (using code from ``reader.py`` & ``featureset.py``), and runs the experiments, collects the results, and writes them out to disk.
 
-2. **SKLL API**. Another way to interact with SKLL is via the SKLL API directly in your Python code rather than using configuration files. For example, you could use the `Learner.from_file() <https://github.com/EducationalTestingService/skll/blob/main/skll/learner/__init__.py#L324>`__ or `VotingLearner.from_file() <https://github.com/EducationalTestingService/skll/blob/main/skll/learner/voting.py#L254>`__ methods to load saved models of those types from disk and make predictions on new data. The documentation for the SKLL API can be found `here <https://skll.readthedocs.io/en/latest/api.html>`__.
+2. **SKLL API**. Another way to interact with SKLL is via the SKLL API directly in your Python code rather than using configuration files. For example, you could use the `Learner.from_file() <https://github.com/EducationalTestingService/skll/blob/main/skll/learner/__init__.py#L384>`__ or `VotingLearner.from_file() <https://github.com/EducationalTestingService/skll/blob/main/skll/learner/voting.py#L243>`__ methods to load saved models of those types from disk and make predictions on new data. The documentation for the SKLL API can be found `here <https://skll.readthedocs.io/en/latest/api.html>`__.
 
 3. **Utility scripts**. The scripts listed in the section above under ``utils`` are also entry points into the SKLL code. These scripts are convenient wrappers that use the SKLL API for commonly used tasks, e.g., generating predictions on new data from an already trained model.

--- a/skll/utils/testing.py
+++ b/skll/utils/testing.py
@@ -1,6 +1,7 @@
 """Utility functions to make SKLL testing simpler."""
 
 
+import os
 import re
 from collections import OrderedDict
 from math import floor, log10
@@ -23,7 +24,10 @@ from skll.config import _setup_config_parser, fix_json
 from skll.data import FeatureSet, NDJWriter
 from skll.types import PathOrStr
 
-tests_dir = Path(__file__).resolve().parent.parent.parent / "tests"
+if env_test_dir := os.getenv("TESTDIR"):
+    tests_dir = Path(env_test_dir) / "tests"
+else:
+    tests_dir = Path(__file__).resolve().parent.parent.parent / "tests"
 config_dir = tests_dir / "configs"
 backward_compatibility_dir = tests_dir / "backward_compatibility"
 examples_dir = tests_dir.parent / "examples"

--- a/skll/version.py
+++ b/skll/version.py
@@ -1,6 +1,8 @@
 # License: BSD 3 clause
 """
-This module exists solely for version information so I only have to change it
+Define version number.
+
+This module exists solely for version information so we only have to change it
 in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 
 :author: Dan Blanchard (dblanchard@ets.org)
@@ -8,5 +10,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :organization: ETS
 """
 
-__version__ = "3.2.0"
+__version__ = "4.0.0"
 VERSION = tuple(int(x) for x in __version__.split("."))

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -85,26 +85,27 @@ class TestInput(unittest.TestCase):
         """Test that `config.locate_file` works with absolute paths."""
         config_abs_path = config_dir / "test_config_parsing_relative_path1.cfg"
         open(config_abs_path, "w").close()
-        self.assertEqual(
-            locate_file(config_abs_path, tests_dir),
-            str(config_dir / "test_config_parsing_relative_path1.cfg"),
-        )
+        computed_path = locate_file(config_abs_path, tests_dir)
+        expected_path = str(config_dir / "test_config_parsing_relative_path1.cfg")
+        self.assertEqual(Path(computed_path).resolve(), Path(expected_path).resolve())
 
     def test_locate_file_valid_paths2(self):
         """Test that `config.locate_file` works with relative paths."""
         config_abs_path = config_dir / "test_config_parsing_relative_path2.cfg"
         config_rel_path = "configs/test_config_parsing_relative_path2.cfg"
         open(config_abs_path, "w").close()
-        self.assertEqual(locate_file(config_rel_path, tests_dir), str(config_abs_path))
+        computed_path = locate_file(config_rel_path, tests_dir)
+        expected_path = str(config_abs_path)
+        self.assertEqual(Path(computed_path).resolve(), Path(expected_path).resolve())
 
     def test_locate_file_valid_paths3(self):
         """Test that `config.locate_file` works with relative/absolute paths."""
         config_abs_path = config_dir / "test_config_parsing_relative_path3.cfg"
         config_rel_path = "configs/test_config_parsing_relative_path3.cfg"
         open(config_abs_path, "w").close()
-        self.assertEqual(
-            locate_file(config_abs_path, tests_dir), locate_file(config_rel_path, tests_dir)
-        )
+        computed_path = locate_file(config_abs_path, tests_dir)
+        expected_path = locate_file(config_rel_path, tests_dir)
+        self.assertEqual(Path(computed_path).resolve(), Path(expected_path).resolve())
 
     def test_locate_file_invalid_path(self):
         """Test that `config.locate_file` raises error for paths that do not exist."""

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -85,27 +85,27 @@ class TestInput(unittest.TestCase):
         """Test that `config.locate_file` works with absolute paths."""
         config_abs_path = config_dir / "test_config_parsing_relative_path1.cfg"
         open(config_abs_path, "w").close()
-        computed_path = locate_file(config_abs_path, tests_dir)
-        expected_path = str(config_dir / "test_config_parsing_relative_path1.cfg")
-        self.assertEqual(Path(computed_path).resolve(), Path(expected_path).resolve())
+        computed_path = Path(locate_file(config_abs_path, tests_dir))
+        expected_path = config_dir / "test_config_parsing_relative_path1.cfg"
+        self.assertEqual(computed_path.resolve(), expected_path.resolve())
 
     def test_locate_file_valid_paths2(self):
         """Test that `config.locate_file` works with relative paths."""
         config_abs_path = config_dir / "test_config_parsing_relative_path2.cfg"
         config_rel_path = "configs/test_config_parsing_relative_path2.cfg"
         open(config_abs_path, "w").close()
-        computed_path = locate_file(config_rel_path, tests_dir)
-        expected_path = str(config_abs_path)
-        self.assertEqual(Path(computed_path).resolve(), Path(expected_path).resolve())
+        computed_path = Path(locate_file(config_rel_path, tests_dir))
+        expected_path = config_abs_path
+        self.assertEqual(computed_path.resolve(), expected_path.resolve())
 
     def test_locate_file_valid_paths3(self):
         """Test that `config.locate_file` works with relative/absolute paths."""
         config_abs_path = config_dir / "test_config_parsing_relative_path3.cfg"
         config_rel_path = "configs/test_config_parsing_relative_path3.cfg"
         open(config_abs_path, "w").close()
-        computed_path = locate_file(config_abs_path, tests_dir)
-        expected_path = locate_file(config_rel_path, tests_dir)
-        self.assertEqual(Path(computed_path).resolve(), Path(expected_path).resolve())
+        computed_path = Path(locate_file(config_abs_path, tests_dir))
+        expected_path = Path(locate_file(config_rel_path, tests_dir))
+        self.assertEqual(computed_path.resolve(), expected_path.resolve())
 
     def test_locate_file_invalid_path(self):
         """Test that `config.locate_file` raises error for paths that do not exist."""


### PR DESCRIPTION
- Update version number.
- Update conda recipe.
- Fix minor issue in testing setup that prevented SKLL Conda Tester and SKLL PyPI tester from working with `nose2`. 
- Update `MANIFEST.in` from including `tests` directory into packages.
- Update `doc/contributing.rst`
  - Remove entry for `skll/__init__.py` since it's now blank.
  - Update entry for `skll/metrics.py` since it now does more.
  - Fix all of the link anchors to point to the correct line numbers.
  
v4.0 conda and TestPyPI packages have been built, deployed, and tested. 
  
skll-conda-tester: [passing](https://github.com/EducationalTestingService/skll-conda-tester/pull/8)
skll-pip-tester: [passing](https://github.com/EducationalTestingService/skll-pip-tester/pull/8)

