### PR TITLE
Release v4.0.1

### DIFF
--- a/conda-recipe/skll/meta.yaml
+++ b/conda-recipe/skll/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: skll
-  version: 4.0
+  version: 4.0.1
 
 source:
   path: ../../../skll

--- a/skll/version.py
+++ b/skll/version.py
@@ -10,5 +10,5 @@ in one place. Based on the suggestion `here. <http://bit.ly/16LbuJF>`_
 :organization: ETS
 """
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 VERSION = tuple(int(x) for x in __version__.split("."))


### PR DESCRIPTION
Update version number and conda recipe.

v4.0.1 conda and TestPyPI packages have been built, deployed, and tested.

skll-conda-tester: https://github.com/EducationalTestingService/skll-conda-tester/pull/9
skll-pip-tester: https://github.com/EducationalTestingService/skll-pip-tester/pull/9