### PR TITLE
Allow None value in feature_scaling

### DIFF
--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -720,8 +720,8 @@ def parse_config_file(
 
     # ensure that feature_scaling is specified only as one of the
     # four available choices
-    feature_scaling = config.get("Input", "feature_scaling")
-    if feature_scaling.lower() not in VALID_FEATURE_SCALING_OPTIONS:
+    feature_scaling = config.get("Input", "feature_scaling").lower()
+    if feature_scaling not in VALID_FEATURE_SCALING_OPTIONS:
         raise ValueError(f"Invalid value for feature_scaling parameter: {feature_scaling}")
 
     suffix = config.get("Input", "suffix")

--- a/skll/config/__init__.py
+++ b/skll/config/__init__.py
@@ -721,8 +721,8 @@ def parse_config_file(
     # ensure that feature_scaling is specified only as one of the
     # four available choices
     feature_scaling = config.get("Input", "feature_scaling")
-    if feature_scaling not in VALID_FEATURE_SCALING_OPTIONS:
-        raise ValueError("Invalid value for feature_scaling parameter: " f"{feature_scaling}")
+    if feature_scaling.lower() not in VALID_FEATURE_SCALING_OPTIONS:
+        raise ValueError(f"Invalid value for feature_scaling parameter: {feature_scaling}")
 
     suffix = config.get("Input", "suffix")
     label_col = config.get("Input", "label_col")

--- a/tests/configs/test_feature_scaling_none.template.cfg
+++ b/tests/configs/test_feature_scaling_none.template.cfg
@@ -1,0 +1,19 @@
+[General]
+experiment_name=test_class_map
+task=evaluate
+
+[Input]
+feature_hasher = true
+hasher_features = 100
+featuresets=[["test_class_map"]]
+learners=["LogisticRegression"]
+suffix=.jsonlines
+class_map={'dog': ['beagle', 'dachsund']}
+feature_scaling=None
+
+[Tuning]
+grid_search=False
+objectives=['accuracy']
+
+[Output]
+probability=false

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1848,6 +1848,31 @@ class TestInput(unittest.TestCase):
         self.assertEqual(wandb_credentials["wandb_entity"], "wandb_entity")
         self.assertEqual(wandb_credentials["wandb_project"], "wandb_project")
 
+    def test_config_parsing_feature_scaling_none(self):
+        """Test that feature scaling value of None is acceptable and converted to a string"""
+        values_to_fill_dict = {
+            "experiment_name": "config_parsing",
+            "task": "evaluate",
+            "train_directory": train_dir,
+            "test_directory": test_dir,
+            "featuresets": "[['f1', 'f2', 'f3']]",
+            "fixed_parameters": '[{"estimator_names": ["SVC", "LogisticRegression", "MultinomialNB"]}]',
+            "learners": "['VotingClassifier']",
+            "objectives": "['accuracy']",
+            "logs": output_dir,
+            "results": output_dir,
+        }
+
+        config_template_path = config_dir / "test_feature_scaling_none.template.cfg"
+
+        config_path = fill_in_config_options(
+            config_template_path, values_to_fill_dict, "default_value_save_votes"
+        )
+
+        configuration = parse_config_file(config_path)
+        feature_scaling = configuration[20]
+
+        self.assertEqual("none", feature_scaling)
     def test_config_parsing_set_wandb_missing_value(self):
         """Test that config parsing works as expected for when values are missing `wandb_credentials`."""
         values_to_fill_dict = {


### PR DESCRIPTION
If `None` is given in the configuration file, it is passed as the string "None". This change converts it to "none" which is the default value.
I didn't change anything in the documentation - @desilinguist  do you `None` this should be explicitly mentioned as an acceptable option?